### PR TITLE
fix: ZAI responsive layout + Playwright device tests (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist-ssr
 .DS_Store
 *.log
 *.tsbuildinfo
+test-results
+playwright-report
+.playwright

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+const devices = [
+  { name: "iPhone SE", width: 375, height: 667 },
+  { name: "iPhone 14", width: 390, height: 844 },
+  { name: "iPad", width: 768, height: 1024 },
+  { name: "Desktop HD", width: 1280, height: 800 },
+  { name: "Desktop 4K", width: 1920, height: 1080 },
+];
+
+for (const device of devices) {
+  test(`Hero fits viewport on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height });
+    await page.goto("/");
+
+    const headline = page.getByRole("heading", { name: /Zero Ambiguity/i });
+    await expect(headline).toBeVisible();
+    const headlineBox = await headline.boundingBox();
+    expect(headlineBox).not.toBeNull();
+    expect(headlineBox!.y + headlineBox!.height).toBeLessThan(device.height);
+
+    const tryZAI = page.getByRole("button", { name: /Try ZAI/i });
+    await expect(tryZAI).toBeVisible();
+    const ctaBox = await tryZAI.boundingBox();
+    expect(ctaBox).not.toBeNull();
+    expect(ctaBox!.y + ctaBox!.height).toBeLessThan(device.height);
+  });
+
+  test(`No horizontal scroll on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height });
+    await page.goto("/");
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(device.width + 2);
+  });
+
+  test(`Nav visible on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height });
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: "ZAI" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /htu\.io/i }).first()).toBeVisible();
+  });
+}

--- a/issues/2026-04-12__fix__zai-responsive-layout.md
+++ b/issues/2026-04-12__fix__zai-responsive-layout.md
@@ -1,0 +1,177 @@
+Fix ZAI landing page layout — fit hero on one screen, responsive across all devices, Playwright E2E tests.
+
+## Problem
+
+The hero section ("Zero Ambiguity Intelligence" + tagline + CTAs) does not fit
+on a single viewport. Users must scroll to see the full hero. The RGB demo
+section is partially visible at the bottom, drawing the eye away.
+
+## Target layouts
+
+### Desktop (1280px+)
+- Full hero visible above the fold: headline + tagline + by HTU + two CTAs
+- RGB demo section visible on scroll
+- Nav: Home / App / Pricing / htu.io ↗
+
+### Tablet (768px–1279px)
+- Hero fits in viewport
+- Slightly smaller headline
+
+### Mobile (375px–767px)
+- Hero fits in viewport
+- Headline wraps to 2 lines max
+- CTAs stack vertically
+- Nav collapses to hamburger
+
+## Tasks
+
+### Step 1 — Audit current layout issues
+
+```bash
+grep -r 'fontSize\|font-size\|h1\|hero\|vh\|vw\|padding\|margin' \
+  ~/dev/zai/src --include='*.tsx' --include='*.css' | head -30
+```
+
+### Step 2 — Fix hero to fit viewport
+
+Key changes:
+- `min-height: 100dvh` on hero container (dynamic viewport height for mobile)
+- Headline: `clamp(2.5rem, 6vw, 5rem)` — scales with viewport
+- Tagline: `clamp(1rem, 2.5vw, 1.5rem)`
+- Vertical padding: reduce to ensure everything fits
+- CTAs: flex-wrap on mobile
+
+### Step 3 — Fix nav
+
+```tsx
+// Mobile: hamburger menu
+// Desktop: inline links
+// Always show: ZAI logo + htu.io link
+```
+
+### Step 4 — Playwright E2E tests
+
+Create `e2e/responsive.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const devices = [
+  { name: 'iPhone SE', width: 375, height: 667 },
+  { name: 'iPhone 14', width: 390, height: 844 },
+  { name: 'iPad', width: 768, height: 1024 },
+  { name: 'Desktop HD', width: 1280, height: 800 },
+  { name: 'Desktop 4K', width: 1920, height: 1080 },
+]
+
+for (const device of devices) {
+  test(`Hero fits viewport on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height })
+    await page.goto('/')
+
+    // Hero headline visible without scrolling
+    const headline = page.getByRole('heading', { name: /Zero Ambiguity/i })
+    await expect(headline).toBeVisible()
+    const box = await headline.boundingBox()
+    expect(box!.y + box!.height).toBeLessThan(device.height)
+
+    // CTAs visible without scrolling
+    const tryZAI = page.getByRole('button', { name: /Try ZAI/i })
+    await expect(tryZAI).toBeVisible()
+    const ctaBox = await tryZAI.boundingBox()
+    expect(ctaBox!.y + ctaBox!.height).toBeLessThan(device.height)
+  })
+
+  test(`No horizontal scroll on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height })
+    await page.goto('/')
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth)
+    expect(scrollWidth).toBeLessThanOrEqual(device.width + 2)
+  })
+
+  test(`Nav visible on ${device.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: device.width, height: device.height })
+    await page.goto('/')
+    await expect(page.getByText('ZAI')).toBeVisible()
+    await expect(page.getByText(/htu\.io/i)).toBeVisible()
+  })
+}
+```
+
+### Step 5 — Playwright config
+
+Create `playwright.config.ts`:
+
+```ts
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+})
+```
+
+Install Playwright:
+```bash
+cd ~/dev/zai
+npm install -D @playwright/test
+npx playwright install chromium
+```
+
+### Step 6 — Run tests locally
+
+```bash
+npm run dev &
+npx playwright test e2e/responsive.spec.ts --reporter=list
+```
+
+All 15 tests (5 devices × 3 tests) must pass.
+
+### Step 7 — Deploy dev
+
+```bash
+npm run deploy:dev
+```
+
+### Step 8 — Commit and PR
+
+```bash
+git add src/ e2e/ playwright.config.ts
+git commit -m "fix: Responsive layout — hero fits viewport on all devices + Playwright E2E tests"
+```
+
+PR title: `fix: ZAI responsive layout + Playwright device tests`
+Reviewer: daniel-silvers
+
+## Acceptance Criteria
+
+- [ ] Hero (headline + tagline + CTAs) fits above the fold on all 5 device sizes
+- [ ] No horizontal scroll on any device
+- [ ] Nav visible on all devices
+- [ ] Mobile: CTAs stack vertically
+- [ ] Mobile: headline ≤ 2 lines
+- [ ] All 15 Playwright tests pass
+- [ ] deploy:dev succeeds
+- [ ] PR opened for daniel-silvers
+
+## Run Instruction
+
+```bash
+cp /mnt/c/Users/zilin/Downloads/2026-04-12__fix__zai-responsive-layout.md \
+   ~/dev/zai/issues/
+
+gh issue create \
+  --title "fix: ZAI responsive layout + Playwright device tests" \
+  --body-file ~/dev/zai/issues/2026-04-12__fix__zai-responsive-layout.md \
+  --repo zi007lin/zai
+
+cd ~/dev/streettt && claude
+# implw zi007lin/zai#<number>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-i18next": "^15.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.0.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
@@ -1318,6 +1319,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2926,6 +2943,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.9",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
+    "test:e2e": "playwright test",
     "deploy:dev": "npm run build && npx wrangler pages deploy dist/ --project-name zai --branch dev",
     "deploy:demo": "npm run build && npx wrangler pages deploy dist/ --project-name zai --branch demo",
     "deploy:full": "npm run build && npx wrangler pages deploy dist/ --project-name zai --branch main"
@@ -20,6 +21,7 @@
     "react-i18next": "^15.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:5173",
+  },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 type Route = "home" | "app" | "pricing";
@@ -9,32 +10,40 @@ interface Props {
 
 export default function TopBar({ current, onNavigate }: Props) {
   const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const linkClass = (r: Route) =>
     `px-3 py-2 text-sm transition-colors ${
       current === r ? "text-white" : "text-neutral-400 hover:text-white"
     }`;
 
+  const go = (r: Route) => {
+    setMenuOpen(false);
+    onNavigate(r);
+  };
+
   return (
     <header className="border-b border-neutral-800 bg-neutral-950/80 backdrop-blur sticky top-0 z-10">
-      <div className="max-w-6xl mx-auto flex items-center justify-between px-6 h-14">
+      <div className="max-w-6xl mx-auto flex items-center justify-between px-4 sm:px-6 h-14">
         <a
           href="/"
           onClick={(e) => {
             e.preventDefault();
-            onNavigate("home");
+            go("home");
           }}
           className="flex items-center gap-2 text-white font-semibold tracking-wide"
         >
           <span className="inline-block w-7 h-7 rounded-md bg-gradient-to-br from-fuchsia-500 via-indigo-500 to-cyan-400" />
           ZAI
         </a>
-        <nav className="flex items-center gap-1">
+
+        {/* Desktop nav */}
+        <nav className="hidden md:flex items-center gap-1">
           <a
             href="/"
             onClick={(e) => {
               e.preventDefault();
-              onNavigate("home");
+              go("home");
             }}
             className={linkClass("home")}
           >
@@ -44,7 +53,7 @@ export default function TopBar({ current, onNavigate }: Props) {
             href="/app"
             onClick={(e) => {
               e.preventDefault();
-              onNavigate("app");
+              go("app");
             }}
             className={linkClass("app")}
           >
@@ -54,7 +63,7 @@ export default function TopBar({ current, onNavigate }: Props) {
             href="/pricing"
             onClick={(e) => {
               e.preventDefault();
-              onNavigate("pricing");
+              go("pricing");
             }}
             className={linkClass("pricing")}
           >
@@ -69,7 +78,87 @@ export default function TopBar({ current, onNavigate }: Props) {
             htu.io ↗
           </a>
         </nav>
+
+        {/* Mobile: htu.io link always visible + hamburger */}
+        <div className="flex md:hidden items-center gap-2">
+          <a
+            href="https://htu.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-2 py-2 text-sm text-neutral-400 hover:text-white"
+          >
+            htu.io ↗
+          </a>
+          <button
+            type="button"
+            aria-label="Open menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((v) => !v)}
+            className="p-2 text-neutral-300 hover:text-white"
+          >
+            <svg
+              width="22"
+              height="22"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              {menuOpen ? (
+                <>
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </>
+              ) : (
+                <>
+                  <line x1="3" y1="7" x2="21" y2="7" />
+                  <line x1="3" y1="12" x2="21" y2="12" />
+                  <line x1="3" y1="17" x2="21" y2="17" />
+                </>
+              )}
+            </svg>
+          </button>
+        </div>
       </div>
+
+      {/* Mobile dropdown panel */}
+      {menuOpen && (
+        <nav className="md:hidden border-t border-neutral-800 bg-neutral-950">
+          <div className="flex flex-col px-4 py-2">
+            <a
+              href="/"
+              onClick={(e) => {
+                e.preventDefault();
+                go("home");
+              }}
+              className={linkClass("home")}
+            >
+              {t("nav.home")}
+            </a>
+            <a
+              href="/app"
+              onClick={(e) => {
+                e.preventDefault();
+                go("app");
+              }}
+              className={linkClass("app")}
+            >
+              {t("nav.app")}
+            </a>
+            <a
+              href="/pricing"
+              onClick={(e) => {
+                e.preventDefault();
+                go("pricing");
+              }}
+              className={linkClass("pricing")}
+            >
+              {t("nav.pricing")}
+            </a>
+          </div>
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,12 +20,24 @@ export default function HomePage({ onNavigate }: Props) {
   }, [ambiguity, spec]);
 
   return (
-    <div className="max-w-6xl mx-auto px-6 py-20">
-      <section className="text-center">
-        <h1 className="text-5xl md:text-6xl font-bold tracking-tight">
+    <>
+      {/* Hero — fills the viewport below the 56px TopBar */}
+      <section
+        className="flex flex-col items-center justify-center text-center px-6"
+        style={{ minHeight: "calc(100dvh - 56px)" }}
+      >
+        <h1
+          className="font-bold tracking-tight leading-[1.05] max-w-[18ch]"
+          style={{ fontSize: "clamp(2.25rem, 6vw, 5rem)" }}
+        >
           {t("hero.title")}
         </h1>
-        <p className="mt-5 text-xl text-neutral-400">{t("hero.tagline")}</p>
+        <p
+          className="mt-4 text-neutral-400 max-w-[32ch]"
+          style={{ fontSize: "clamp(1rem, 2.2vw, 1.5rem)" }}
+        >
+          {t("hero.tagline")}
+        </p>
         <p className="mt-3 text-sm text-neutral-500">
           {t("hero.by")}{" "}
           <a
@@ -38,14 +50,16 @@ export default function HomePage({ onNavigate }: Props) {
           </a>
         </p>
 
-        <div className="mt-10 flex justify-center gap-3">
+        <div className="mt-8 flex flex-col sm:flex-row gap-3 w-full max-w-xs sm:max-w-none sm:w-auto">
           <button
+            type="button"
             onClick={() => onNavigate("app")}
             className="px-5 py-2.5 rounded-md bg-white text-neutral-900 font-medium hover:bg-neutral-200 transition-colors"
           >
             {t("hero.cta_try")}
           </button>
           <button
+            type="button"
             onClick={() => onNavigate("pricing")}
             className="px-5 py-2.5 rounded-md border border-neutral-700 text-white hover:bg-neutral-900 transition-colors"
           >
@@ -54,9 +68,12 @@ export default function HomePage({ onNavigate }: Props) {
         </div>
       </section>
 
-      <section className="mt-24 grid md:grid-cols-2 gap-8 items-center">
+      {/* RGB demo — below the fold */}
+      <section className="max-w-6xl mx-auto px-6 py-20 grid md:grid-cols-2 gap-10 items-center">
         <div>
-          <h2 className="text-2xl font-semibold">{t("demo.title")}</h2>
+          <h2 className="text-2xl md:text-3xl font-semibold">
+            {t("demo.title")}
+          </h2>
           <p className="mt-3 text-neutral-400">{t("demo.description")}</p>
 
           <div className="mt-6 space-y-4">
@@ -91,12 +108,12 @@ export default function HomePage({ onNavigate }: Props) {
 
         <div className="flex items-center justify-center">
           <div
-            className="w-64 h-64 rounded-2xl border border-neutral-800 transition-colors"
+            className="w-56 h-56 md:w-64 md:h-64 rounded-2xl border border-neutral-800 transition-colors"
             style={{ background: color }}
             aria-label={`RGB preview ${color}`}
           />
         </div>
       </section>
-    </div>
+    </>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,3 +13,8 @@ body,
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 }
+
+html,
+body {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
## Summary

Fixes the hero section not fitting the viewport on any device and adds a Playwright E2E suite to keep it that way.

## Layout changes (\`HomePage.tsx\`, \`TopBar.tsx\`, \`styles.css\`)

- **Hero**: centered in \`min-height: calc(100dvh - 56px)\` so headline, tagline, HTU attribution, and both CTAs always sit above the fold. The 56px offset matches the sticky TopBar.
- **Fluid typography**: headline \`clamp(2.25rem, 6vw, 5rem)\`, tagline \`clamp(1rem, 2.2vw, 1.5rem)\`. One rule covers every breakpoint, no separate mobile/desktop typography.
- **CTAs**: stack vertically below \`sm\`, row from \`sm\` up.
- **RGB demo**: moved into its own section below the hero — scroll to reveal.
- **TopBar**: inline Home/App/Pricing links hide below \`md\`, replaced with a hamburger that toggles a dropdown panel. ZAI logo and \`htu.io ↗\` link stay visible on every width so the \`Nav visible\` test passes everywhere.
- **Overflow**: \`html, body { overflow-x: hidden }\` to eliminate 1px horizontal scroll from rounding on 375px.

## Tests (\`e2e/responsive.spec.ts\`, \`playwright.config.ts\`)

- 5 devices × 3 assertions = **15 tests, all passing**:
  - iPhone SE 375×667, iPhone 14 390×844, iPad 768×1024, Desktop HD 1280×800, Desktop 4K 1920×1080
  - \`Hero fits viewport\` — headline bottom + \`Try ZAI\` CTA bottom both \`< viewport.height\`
  - \`No horizontal scroll\` — \`document.body.scrollWidth <= viewport.width + 2\`
  - \`Nav visible\` — ZAI logo + htu.io link both visible
- Config auto-starts \`npm run dev\` on 5173 and reuses an existing server when not in CI.
- Script added: \`npm run test:e2e\`.

## Verification

- [x] \`npm run build\` — tsc + vite, 204 kB JS / 15 kB CSS
- [x] \`npm run test:e2e\` — 15/15 passing (4.2s)
- [ ] \`npm run deploy:dev\` — will run after merge

Closes #8