### PR TITLE
docs: ZAI governance layer section in README (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ The controller decides: *which agent, which model, which repo, which gate.* Suba
 
 ---
 
+## ZAI vs "Guardrails"
+
+Most AI teams are building guardrails. ZAI is building governance.
+
+| Guardrails Thinking | ZAI Governance |
+|---------------------|----------------|
+| Zapier workflows | Kafka + Cloudflare event streams |
+| Manual approvals | Programmatic governance (SDD) |
+| Monitoring | Observability + event logs + replay |
+| Prototype-first | Production-grade architecture from day 1 |
+| Safety | Anti-fragile system design |
+
+**Guardrails treat AI like a tool that needs limits.**
+**ZAI treats AI like a system that needs governance + incentives + auditability.**
+
+### The governance stack
+
+```
+Event sourcing    — every spec, every decision, every deploy is logged
+CQRS              — read and write paths are separated
+Identity          — every action is tied to a verified actor
+ZZV Chain         — immutable audit trail, append-only
+SDD               — the spec is the contract, not the chat
+```
+
+Simple interface. Production-grade architecture underneath.
+
+---
+
 ## RGB Color System
 
 ZAI uses a three-channel signal convention across logs, dashboards, and PR checks:

--- a/issues/2026-04-12__docs__zai-readme-governance.md
+++ b/issues/2026-04-12__docs__zai-readme-governance.md
@@ -1,0 +1,50 @@
+Add "AI Governance Layer" section to ZAI README — differentiate from guardrails/Zapier thinking.
+
+## Add this section to README.md after "ZAI Architecture"
+
+Insert between "ZAI Architecture" and "How it works":
+
+---
+
+## ZAI vs "Guardrails"
+
+Most AI teams are building guardrails. ZAI is building governance.
+
+| Guardrails Thinking | ZAI Governance |
+|---------------------|----------------|
+| Zapier workflows | Kafka + Cloudflare event streams |
+| Manual approvals | Programmatic governance (SDD) |
+| Monitoring | Observability + event logs + replay |
+| Prototype-first | Production-grade architecture from day 1 |
+| Safety | Anti-fragile system design |
+
+**Guardrails treat AI like a tool that needs limits.**
+**ZAI treats AI like a system that needs governance + incentives + auditability.**
+
+### The governance stack
+
+```
+Event sourcing    — every spec, every decision, every deploy is logged
+CQRS              — read and write paths are separated
+Identity          — every action is tied to a verified actor
+ZZV Chain         — immutable audit trail, append-only
+SDD               — the spec is the contract, not the chat
+```
+
+Simple interface. Production-grade architecture underneath.
+
+---
+
+## Tasks
+
+1. Read current README.md
+2. Insert the section above between "ZAI Architecture" and "How it works"
+3. Commit: `docs: Add ZAI governance layer section — differentiate from guardrails`
+4. Push to main
+
+## Acceptance Criteria
+
+- [ ] "ZAI vs Guardrails" comparison table in README
+- [ ] Governance stack listed
+- [ ] "Simple interface. Production-grade architecture underneath." tagline present
+- [ ] Committed and pushed to main


### PR DESCRIPTION
## Summary

Adds the "ZAI vs Guardrails" comparison table and governance stack to \`README.md\`, between the existing **ZAI Architecture — Agentic Traffic Controller** section and the **RGB Color System** section.

## Note on placement

The spec asked for insertion "between ZAI Architecture and How it works". The current README has no "How it works" heading — the section immediately after Architecture is "RGB Color System". I placed the new section right after Architecture, which is the closest match to the spec's intent.

## Content added

- "ZAI vs 'Guardrails'" comparison table (5 rows: Zapier vs Kafka+CF, manual approvals vs programmatic, monitoring vs observability+replay, prototype-first vs production-grade, safety vs anti-fragile)
- Bold summary lines contrasting guardrails-as-limits vs ZAI-as-governance
- "The governance stack" code block (event sourcing, CQRS, identity, ZZV Chain, SDD)
- Closing tagline: "Simple interface. Production-grade architecture underneath."

## Note on process

The spec ended with "Push to main", but zai's CLAUDE.md says "zi007lin authors PRs; never merges own PRs." Following the governance rule — this is a PR for daniel-silvers, not a direct push.

Closes #10