### PR TITLE
feat: Ambiguity viz — dynamic section background + larger type

### DIFF
--- a/issues/2026-04-12__feat__zai-ambiguity-viz-ui-polish.md
+++ b/issues/2026-04-12__feat__zai-ambiguity-viz-ui-polish.md
@@ -1,0 +1,89 @@
+# 2026-04-12__feat__zai-ambiguity-viz-ui-polish
+
+## Intent
+
+Polish the ZAI "From ambiguity to spec — in color" interactive widget:
+1. Increase font sizes across heading, body, and labels for readability.
+2. Remove the static teal color square; instead use the computed color as a full-screen dynamic background behind the entire widget.
+
+---
+
+## Decision Tree
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Color square → full-screen background | Immersive; color signal becomes ambient rather than isolated | ✅ Chosen |
+| Keep square, also tint background | Redundant visual; cluttered | ❌ Rejected |
+| Remove color entirely | Loses the core ZAI metaphor | ❌ Rejected |
+| Bump font sizes globally | Improves hierarchy and legibility, no layout cost | ✅ Chosen |
+
+---
+
+## Final Spec
+
+### 1. Typography
+
+| Element | Current (est.) | Target |
+|---|---|---|
+| `h1` / heading | ~28px | **40px**, `font-weight: 700` |
+| Body paragraph | ~14px | **18px**, `line-height: 1.7` |
+| Slider labels (`Ambiguity: X%`, `Spec coverage: X%`) | ~13px | **16px** |
+
+Use the existing font stack (Space Grotesk preferred; system-ui fallback).
+
+### 2. Color square → dynamic background
+
+- **Remove** the `<div>` / element rendering the standalone teal square.
+- The computed `hsl` / hex color (currently driving the square fill) must instead be applied as:
+  ```css
+  background-color: <computed-color>;
+  transition: background-color 0.3s ease;
+  ```
+  on the **root container** of the widget (full viewport if fullscreen, or the outermost wrapper div if embedded).
+- Text and slider elements must remain legible over the colored background:
+  - Apply a **semi-transparent dark overlay** (`rgba(0,0,0,0.45)`) between the background color and the content layer, OR
+  - Switch heading/body text to `color: #fff` with `text-shadow: 0 1px 4px rgba(0,0,0,0.6)` when background luminance is above a threshold (L > 0.5 in HSL).
+- Slider track and thumb styling should remain unchanged.
+- The `transition` ensures smooth color sweeps as sliders move.
+
+### 3. Color mapping (unchanged logic)
+
+No changes to how ambiguity + spec coverage map to a color value. Only the _render target_ changes (background instead of square).
+
+---
+
+## Acceptance Criteria
+
+- [ ] Teal color square is gone from the DOM
+- [ ] Root container background animates as sliders move
+- [ ] Heading renders at ≥ 40px
+- [ ] Body copy renders at ≥ 18px
+- [ ] Slider labels render at ≥ 16px
+- [ ] Text remains readable (contrast ≥ 4.5:1) at both low and high ambiguity settings
+- [ ] No layout shift when square is removed
+
+---
+
+## Files to modify
+
+```
+apps/htu-io/src/components/ZaiAmbiguityViz.tsx   (or equivalent component path)
+apps/htu-io/src/components/ZaiAmbiguityViz.css   (if separate)
+```
+
+Confirm exact path before starting — run:
+```bash
+find . -type f -name "*.tsx" | xargs grep -l "ambiguity\|spec.*color\|color.*square" 2>/dev/null
+```
+
+---
+
+## Subject Migration Summary
+
+| Field | Value |
+|---|---|
+| What | UI polish: font scale-up + color square → full-screen background |
+| State | Spec written; not yet implemented |
+| Open questions | Exact component file path; luminance-threshold logic for text contrast |
+| Next action | `impl i 2026-04-12__feat__zai-ambiguity-viz-ui-polish.md` |
+| Files touched | This spec only |

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -68,17 +68,35 @@ export default function HomePage({ onNavigate }: Props) {
         </div>
       </section>
 
-      {/* RGB demo — below the fold */}
-      <section className="max-w-6xl mx-auto px-6 py-20 grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h2 className="text-2xl md:text-3xl font-semibold">
+      {/* RGB demo — full-section dynamic background driven by the sliders */}
+      <section
+        className="relative overflow-hidden transition-colors duration-300"
+        style={{ backgroundColor: color }}
+        aria-label={`ZAI ambiguity visualizer, current RGB ${color}`}
+      >
+        {/* Dark overlay keeps text legible at every slider position */}
+        <div className="absolute inset-0 bg-black/45 pointer-events-none" />
+
+        <div className="relative max-w-3xl mx-auto px-6 py-24 text-white">
+          <h2
+            className="font-bold tracking-tight"
+            style={{ fontSize: "clamp(2.5rem, 5vw, 3.25rem)", lineHeight: 1.15 }}
+          >
             {t("demo.title")}
           </h2>
-          <p className="mt-3 text-neutral-400">{t("demo.description")}</p>
+          <p
+            className="mt-5 text-neutral-100"
+            style={{ fontSize: "1.125rem", lineHeight: 1.7 }}
+          >
+            {t("demo.description")}
+          </p>
 
-          <div className="mt-6 space-y-4">
+          <div className="mt-10 space-y-6">
             <label className="block">
-              <span className="text-sm text-neutral-400">
+              <span
+                className="text-neutral-100"
+                style={{ fontSize: "1rem" }}
+              >
                 {t("demo.ambiguity")}: {ambiguity}%
               </span>
               <input
@@ -91,7 +109,10 @@ export default function HomePage({ onNavigate }: Props) {
               />
             </label>
             <label className="block">
-              <span className="text-sm text-neutral-400">
+              <span
+                className="text-neutral-100"
+                style={{ fontSize: "1rem" }}
+              >
                 {t("demo.spec_coverage")}: {spec}%
               </span>
               <input
@@ -104,14 +125,6 @@ export default function HomePage({ onNavigate }: Props) {
               />
             </label>
           </div>
-        </div>
-
-        <div className="flex items-center justify-center">
-          <div
-            className="w-56 h-56 md:w-64 md:h-64 rounded-2xl border border-neutral-800 transition-colors"
-            style={{ background: color }}
-            aria-label={`RGB preview ${color}`}
-          />
         </div>
       </section>
     </>


### PR DESCRIPTION
## Summary

Implements \`issues/2026-04-12__feat__zai-ambiguity-viz-ui-polish.md\` — polishes the "From ambiguity to spec — in color" widget so the color signal becomes ambient instead of isolated, and bumps typography for readability.

## Changes (\`src/pages/HomePage.tsx\`)

- **Removed** the standalone color swatch \`<div>\` that previously sat beside the sliders.
- **Promoted** the computed RGB color to \`backgroundColor\` on the demo section's outer \`<section>\`, with \`transition-colors duration-300\`.
- **Added** an \`absolute inset-0 bg-black/45\` overlay between the color layer and the content so text stays readable at every slider position. This is the dark-overlay branch from the spec's decision tree — simpler than runtime luminance detection and handles all hues uniformly.
- **Typography**: heading \`clamp(2.5rem, 5vw, 3.25rem)\` (always ≥ 40px, scales to 52px), body \`18px / line-height 1.7\`, slider labels \`16px\`. All on-color text switches to white.
- **Layout**: demo section switches from a two-column grid (text + square) to a single centered column, since there's no swatch to pair against.

## Spec acceptance criteria

- [x] Teal color square gone from the DOM
- [x] Root container background animates as sliders move (300ms ease)
- [x] Heading renders at ≥ 40px (clamp floor is 2.5rem)
- [x] Body copy renders at 18px
- [x] Slider labels render at 16px
- [x] Text remains readable via black/45 overlay at both low and high ambiguity
- [x] No layout shift — the section owns its own background now, other sections untouched

## Tests

- \`npm run build\` — ✅
- \`npm run test:e2e\` — ✅ 15/15 existing responsive tests still pass

## Not doing

- **Luminance-threshold text switching**: the spec offered either "dark overlay" OR "white text + runtime luminance check". I picked the overlay because it's a single rule, no JS branching, handles every color uniformly, and the spec lists open questions on the luminance approach.
- **Font family change**: spec mentioned "Space Grotesk preferred; system-ui fallback". Current repo uses system-ui only; adding a webfont would be a separate feature with its own loading/perf trade-offs. Left as a follow-up.