### PR TITLE
research: ZAI app scorer prereqs — cleared to impl with two amendments

### DIFF
--- a/issues/2026-04-12__research__zai-app-scorer-prereqs.md
+++ b/issues/2026-04-12__research__zai-app-scorer-prereqs.md
@@ -1,0 +1,207 @@
+# 2026-04-12__research__zai-app-scorer-prereqs
+
+**Repo:** `zi007lin/zai`
+**Label:** `research`
+**Branch:** `zai/research-app-scorer-prereqs`
+**Reviewer:** daniel-silvers
+**Blocks:** `2026-04-12__feat__zai-app-spec-scorer-page.md`
+
+---
+
+## Intent
+
+Audit the ZAI repo to answer the two open questions that block impl of the spec scorer page. Produce a report saved to `issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md` with exact answers and the recommended one-line fixes where applicable. ZiLin-Dev must not start the feat impl until this report is merged.
+
+---
+
+## Research Questions
+
+### Q1 — Routing mechanism
+
+**Question:** Does ZAI use React Router (`<Route path="/app">`) or file-based routing (Vite plugin, TanStack Router, or similar)?
+
+**Why it matters:** The feat impl modifies `AppPage.tsx`. If routing is file-based, the file path IS the route — no additional registration needed. If React Router, a `<Route>` entry must be confirmed present or added. Getting this wrong means the page renders but the route 404s, or vice versa.
+
+**Commands to run:**
+```bash
+# Find routing entrypoint
+find src -name "AppPage*" 2>/dev/null
+find src -name "router*" -o -name "routes*" 2>/dev/null
+find src -name "main.tsx" -o -name "App.tsx" 2>/dev/null
+
+# Check for React Router
+grep -r "react-router" package.json 2>/dev/null
+grep -r "BrowserRouter\|createBrowserRouter\|Route path" src/ 2>/dev/null | head -20
+
+# Check for TanStack Router
+grep -r "tanstack/router\|createFileRoute\|createRootRoute" src/ 2>/dev/null | head -10
+
+# Check for Vite file-based routing plugins
+grep -r "vite-plugin-pages\|vite-plugin-file-based\|generouted" package.json vite.config* 2>/dev/null
+```
+
+**Expected answer format:**
+```
+Routing: React Router v6
+Route registration: src/App.tsx line 42
+AppPage.tsx path: src/pages/AppPage.tsx
+Action required: none — route already registered
+```
+
+---
+
+### Q2 — Google Fonts CSP + font availability
+
+**Question:** Are `DM Mono` and `Sora` loadable from Google Fonts on `zai.htu.io`, or is the CSP too restrictive?
+
+**Why it matters:** The design spec requires `DM Mono` (monospace metrics/scores) and `Sora` (sans headings). If `fonts.googleapis.com` and `fonts.gstatic.com` are blocked by CSP, the impl must use fallback fonts defined in `zai-tokens.css` instead. Using the wrong fonts either breaks the visual design or triggers CSP errors in the browser console.
+
+**Commands to run:**
+```bash
+# Check existing font imports
+grep -r "googleapis\|gstatic\|font-face\|@import.*font" index.html src/ public/ 2>/dev/null | head -20
+
+# Check CSP headers (wrangler config or _headers file)
+find . -name "_headers" -o -name "wrangler*.toml" -o -name "wrangler*.jsonc" 2>/dev/null | xargs grep -l "Content-Security-Policy\|font-src" 2>/dev/null
+cat _headers 2>/dev/null || echo "no _headers file"
+
+# Check if any Google Fonts already load successfully in the project
+grep -r "DM Mono\|Sora\|font-family" src/ public/ index.html 2>/dev/null | head -20
+
+# Check Cloudflare Pages config for CSP
+find . -name "*.toml" | xargs grep -l "header\|csp" 2>/dev/null
+```
+
+**Expected answer format:**
+```
+Google Fonts: ALLOWED — fonts.googleapis.com in font-src
+DM Mono: not yet loaded — needs import added to index.html
+Sora: not yet loaded — needs import added to index.html
+Action required: add <link> to index.html (safe, no CSP changes needed)
+```
+OR:
+```
+Google Fonts: BLOCKED — font-src 'self' only in _headers
+DM Mono fallback: 'Courier New', monospace
+Sora fallback: system-ui, -apple-system, sans-serif
+Action required: use fallback stack in zai-tokens.css, no index.html change
+```
+
+---
+
+### Q3 — Existing test selectors that will break
+
+**Question:** Do any existing e2e tests select against the `/app` route content (e.g., "Coming soon", "ZAI App" h1, or `AppPage` text)? If so, list the exact files and line numbers.
+
+**Why it matters:** The feat impl replaces all `/app` content. Any hardcoded text selector on the old copy will fail. These must be updated in the same PR — not discovered post-merge.
+
+**Commands to run:**
+```bash
+# Find all e2e tests referencing /app route
+grep -rn "\/app\|AppPage\|Coming soon\|ZAI App\|spec generator" e2e/ 2>/dev/null
+
+# Find component tests referencing AppPage
+grep -rn "AppPage\|Coming soon" src/ 2>/dev/null
+```
+
+**Expected answer format:**
+```
+Affected files:
+  e2e/responsive.spec.ts:34 — getByText('Coming soon')  → UPDATE to new h1
+  e2e/navigation.spec.ts:18 — expect(page).toHaveTitle('ZAI App') → VERIFY still valid
+No component tests affected.
+```
+
+---
+
+### Q4 — Tailwind version and arbitrary value support
+
+**Question:** Is ZAI using Tailwind v3 or v4? Does it support arbitrary CSS values (`text-[#1D9E75]`, `bg-[#111]`)?
+
+**Why it matters:** The design uses specific hex values for the ZAI dark theme. If Tailwind v4 is in use (known issues with some arbitrary value syntaxes) or if the project uses a strict content config, the impl may need to use CSS custom properties via `zai-tokens.css` instead of Tailwind arbitrary values.
+
+**Commands to run:**
+```bash
+# Tailwind version
+grep "tailwindcss" package.json
+
+# Config file
+cat tailwind.config.* 2>/dev/null | head -40
+
+# Check if arbitrary values are already used in codebase
+grep -r "\[#" src/ 2>/dev/null | head -5
+```
+
+**Expected answer format:**
+```
+Tailwind: v4.0.14
+Arbitrary values: supported — already used in src/
+Action required: none
+```
+
+---
+
+## Report Format
+
+Claude Code must save the completed report to:
+```
+issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md
+```
+
+Report structure:
+```markdown
+# Research Report: ZAI App Scorer Prereqs
+**Date:** YYYY-MM-DD
+**Repo:** zi007lin/zai
+**Commit:** {HEAD SHA}
+
+## Q1 — Routing
+{exact answer + action required}
+
+## Q2 — Fonts / CSP  
+{exact answer + action required}
+
+## Q3 — Broken test selectors
+{exact answer — list file:line for each affected selector}
+
+## Q4 — Tailwind
+{exact answer + action required}
+
+## Impl Amendment Required
+{YES/NO}
+{If YES: list exact changes needed in 2026-04-12__feat__zai-app-spec-scorer-page.md before impl runs}
+
+## Cleared to impl
+{YES/NO}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 4 questions answered with exact file paths and line numbers where relevant
+- [ ] Report saved to `issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md`
+- [ ] "Cleared to impl: YES/NO" stated explicitly at end of report
+- [ ] If any amendment is required to the feat spec, the exact amendment is stated
+- [ ] PR opened for daniel-silvers review
+- [ ] No implementation code written — research only
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | Pre-impl audit for ZAI app scorer page — routing, fonts, tests, Tailwind |
+| Blocks | `2026-04-12__feat__zai-app-spec-scorer-page.md` |
+| State | Spec complete; not yet executed |
+| Next action | `impl i 2026-04-12__research__zai-app-scorer-prereqs.md` → read report → run feat impl |
+| Repo | `zi007lin/zai` |
+
+---
+
+## Files
+
+```
+issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md  ← created by this research
+```

--- a/issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md
+++ b/issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md
@@ -1,0 +1,147 @@
+# Research Report: ZAI App Scorer Prereqs
+**Date:** 2026-04-12
+**Repo:** zi007lin/zai
+**Commit:** 1ffdeb2e15d9d5065ba7c4eaec4f0fd2f0b01dc6 (main at time of research)
+**Research branch:** zai/research-app-scorer-prereqs
+
+---
+
+## Q1 — Routing
+
+**Answer:**
+
+```
+Routing: Custom hand-rolled state router (no library)
+Route registration: src/App.tsx lines 5, 11, 32 + src/components/TopBar.tsx lines 53, 140
+AppPage.tsx path: src/pages/AppPage.tsx
+Action required: none — /app already registered and linked from nav
+```
+
+**Evidence:**
+
+- `package.json` has **no** router dependency — `react-router`, `@tanstack/router`, `vite-plugin-pages`, `generouted` all absent.
+- `src/App.tsx` implements routing by hand:
+  - Line 5: `import AppPage from "./pages/AppPage";`
+  - Lines 9–13: `routeFromPath()` maps `pathname.startsWith("/app")` → `"app"`
+  - Line 17: `useState<Route>` seeded from `window.location.pathname`
+  - Line 22: `navigate()` uses `window.history.pushState`
+  - Line 32: `{route === "app" && <AppPage />}`
+- `src/components/TopBar.tsx:53,140`: desktop + mobile nav links to `/app`, wired to `onNavigate("app")`.
+
+**Implication for feat impl:** Replacing content inside `src/pages/AppPage.tsx` is sufficient. The file has no route-table registration to update. If the feat impl needs sub-routes under `/app` (e.g., `/app/scorer`, `/app/history`), it must extend `routeFromPath()` and the router switch in `App.tsx:31-35` — there is **no dynamic route matcher**, only literal prefix checks.
+
+---
+
+## Q2 — Fonts / CSP
+
+**Answer:**
+
+```
+Google Fonts: ALLOWED — no CSP configured at all
+_headers file: ABSENT (only public/_redirects exists)
+Wrangler CSP: NONE — wrangler.dev.toml / wrangler.demo.toml / wrangler.jsonc carry only [vars], no headers block
+DM Mono: not loaded — needs import added to index.html
+Sora: not loaded — needs import added to index.html
+Existing font stack: src/styles.css:13 — ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif
+Action required: add <link rel="preconnect"> + Google Fonts <link> to index.html (safe, no CSP change)
+```
+
+**Evidence:**
+
+- `public/` contains only `_redirects`. No `_headers` file anywhere in the repo (verified via `ls public/` and `find . -name _headers`).
+- Cloudflare Pages serves no CSP by default when there's no `_headers` file — `font-src` is effectively unrestricted.
+- `index.html` has zero `<link>` tags (just the Vite module entry).
+- `src/styles.css:13` is the only font-family declaration in the repo.
+- Grep for `googleapis|gstatic|@font-face|DM Mono|Sora` across `src/`, `public/`, `index.html` → **no hits** (all spec file hits excluded).
+
+**Implication for feat impl:** The impl can add DM Mono + Sora via standard Google Fonts `<link>` tags in `index.html` without any CSP work. Recommended snippet for the impl:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Sora:wght@400;600;700&display=swap" rel="stylesheet" />
+```
+
+Then extend `src/styles.css` `@theme` (Tailwind v4) or raw CSS with `--font-sans: "Sora", ...;` / `--font-mono: "DM Mono", ...;`.
+
+---
+
+## Q3 — Broken test selectors
+
+**Answer:**
+
+```
+Affected files: none
+```
+
+**Evidence:**
+
+- Grep for `AppPage|Coming soon|ZAI App|spec generator|/app` across `e2e/`:
+  - `e2e/responsive.spec.ts` does **not** reference any `/app` content. It only hits `/` and selects `main h1` (generic), plus `ZAI` logo link and `htu.io` link.
+- Grep across `src/` for `AppPage|Coming soon`: only the source files themselves:
+  - `src/App.tsx` — router import/switch (structural, not copy)
+  - `src/pages/AppPage.tsx` — the page being replaced
+  - `src/components/TopBar.tsx` — `href="/app"` link (structural)
+  - `src/locales/en.json:21-22` — `app.title` / `app.coming_soon` keys used only by `AppPage.tsx`
+
+**Implication for feat impl:** No e2e test needs updating. The impl should delete or repurpose the `app.title` / `app.coming_soon` i18n keys if they're no longer referenced, and add new keys for the scorer UI. TopBar's `/app` link continues to work unchanged.
+
+---
+
+## Q4 — Tailwind
+
+**Answer:**
+
+```
+Tailwind: v4.2.2 (installed) via @tailwindcss/vite plugin
+Config file: none — Tailwind v4 uses CSS-based @theme (not currently declared)
+Arbitrary values: supported (core Tailwind v4 feature)
+Existing usage of arbitrary hex in src/: none yet
+Action required: none — arbitrary hex classes like text-[#1D9E75] and bg-[#111] work out of the box
+```
+
+**Evidence:**
+
+- `package.json` declares `"tailwindcss": "^4.0.0"` and `"@tailwindcss/vite": "^4.0.0"`.
+- `node -p "require('./node_modules/tailwindcss/package.json').version"` → `4.2.2`.
+- `ls tailwind.config.*` → no config file exists. Tailwind v4 defaults apply.
+- `vite.config.ts` registers `tailwindcss()` plugin; `src/styles.css` starts with `@import "tailwindcss";`.
+- Grep for `\[#` in `src/` → zero hits; feat impl will be the first to introduce arbitrary hex classes.
+
+**Implication for feat impl:** Arbitrary values are safe to use. Optionally the impl can centralize palette via a Tailwind v4 `@theme` block in `src/styles.css`:
+
+```css
+@theme {
+  --color-zai-green: #1D9E75;
+  --color-zai-bg:    #111;
+}
+```
+
+…then use `text-zai-green` / `bg-zai-bg` instead of arbitrary brackets. Either approach works; `@theme` is cleaner if the palette is reused across ≥3 components.
+
+---
+
+## Impl Amendment Required
+
+**YES** — two small amendments to `2026-04-12__feat__zai-app-spec-scorer-page.md` before it runs:
+
+1. **Routing note**: Replace any language assuming React Router or file-based routing with:
+   > "Routing is a hand-rolled state router in `src/App.tsx`. The `/app` route is already wired (line 32). Replacing `src/pages/AppPage.tsx` content is sufficient. If sub-routes are needed, extend `routeFromPath()` and the switch in `App.tsx`."
+
+2. **Font loading instruction**: Add a concrete step to the feat spec:
+   > "Add to `index.html` inside `<head>`:
+   > ```html
+   > <link rel="preconnect" href="https://fonts.googleapis.com" />
+   > <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+   > <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Sora:wght@400;600;700&display=swap" rel="stylesheet" />
+   > ```
+   > Then declare `--font-sans` and `--font-mono` in `src/styles.css`. No CSP change needed — `_headers` does not exist and CF Pages serves no default CSP."
+
+No test-selector amendment is needed (Q3 is clear).
+No Tailwind amendment is needed (Q4 is clear); feat impl is free to use arbitrary brackets or add a `@theme` palette block — reviewer discretion.
+
+---
+
+## Cleared to impl
+
+**YES** — once the two amendments above are applied to `2026-04-12__feat__zai-app-spec-scorer-page.md`, the feat impl can run. No blocking unknowns remain.


### PR DESCRIPTION
## Summary

Answers the four pre-impl questions from \`issues/2026-04-12__research__zai-app-scorer-prereqs.md\`, which blocks \`2026-04-12__feat__zai-app-spec-scorer-page.md\`. No implementation code written — research only, per the spec.

Full report: \`issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md\`

## Findings (one-liners)

| # | Question | Answer |
|---|---|---|
| Q1 | Routing | Hand-rolled state router in \`src/App.tsx\` (no library). \`/app\` already registered. No action. |
| Q2 | Fonts / CSP | No \`_headers\`, no CSP anywhere. Google Fonts loadable via plain \`<link>\`. DM Mono + Sora not yet loaded. |
| Q3 | Broken test selectors | **None.** \`e2e/responsive.spec.ts\` doesn't touch \`/app\` content. |
| Q4 | Tailwind | v4.2.2 via \`@tailwindcss/vite\`, no config file, arbitrary brackets work out of the box. |

## Amendments required to feat spec

**YES** — two small edits before the feat impl runs:

1. **Routing note**: replace any language assuming React Router / file-based routing with "Hand-rolled state router in \`src/App.tsx\`; \`/app\` already wired; replacing \`AppPage.tsx\` is sufficient."
2. **Font loading snippet**: add explicit \`<link rel="preconnect">\` + Google Fonts URL for DM Mono and Sora to \`index.html\`, plus \`--font-sans\` / \`--font-mono\` declarations in \`src/styles.css\`. No CSP change.

Exact snippets and file:line references in the report.

## Cleared to impl

**YES** — after the two amendments above are applied to \`2026-04-12__feat__zai-app-spec-scorer-page.md\`, the feat impl can run with no blocking unknowns.

## Labels

This PR should carry \`research\` per the workflow. The parent repo's issue label routing (from streettt's CLAUDE.md) says research → report → impl — the report is complete, the impl issue needs to be created from this report as a follow-up.

Reviewer: daniel-silvers