### PR TITLE
feat: ZAI /app — spec scorer page with client-side rubric

### DIFF
--- a/e2e/app-scorer.spec.ts
+++ b/e2e/app-scorer.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+
+const SAMPLE_SPEC = `# sample
+
+## Intent
+A short intent paragraph.
+
+## Decision Tree
+| Option | Decision |
+|---|---|
+| A | ✅ |
+
+Trigger for change: condition flips.
+
+## Draft-of-thoughts
+Reasoning.
+
+## Final Spec
+Details.
+
+## Acceptance Criteria
+- [ ] one
+- [ ] two
+- [ ] three
+
+## Game Theory Review
+Who benefits: users.
+Abuse vector: gaming.
+Mitigation: rate limits.
+
+## Subject Migration Summary
+| | |
+|---|---|
+| Open questions | confirm name |
+
+## Files
+\`\`\`
+src/foo.ts
+\`\`\`
+`;
+
+test.describe("/app spec scorer", () => {
+  test("renders header and upload zone, hides score panel initially", async ({
+    page,
+  }) => {
+    await page.goto("/app");
+    await expect(
+      page.getByRole("heading", { name: /Score your spec before it ships/i })
+    ).toBeVisible();
+    await expect(page.getByTestId("upload-zone")).toBeVisible();
+    await expect(page.getByTestId("score-panel-placeholder")).toBeVisible();
+    await expect(page.getByTestId("score-panel")).toHaveCount(0);
+    await expect(page.getByText(/Coming soon/i)).toHaveCount(0);
+  });
+
+  test("uploads a compliant spec and shows 7/7 score panel", async ({
+    page,
+  }) => {
+    await page.goto("/app");
+
+    const input = page.getByTestId("upload-input");
+    await input.setInputFiles({
+      name: "sample-spec.md",
+      mimeType: "text/markdown",
+      buffer: Buffer.from(SAMPLE_SPEC),
+    });
+
+    const panel = page.getByTestId("score-panel");
+    await expect(panel).toBeVisible();
+
+    const counter = page.getByTestId("score-counter");
+    await expect(counter).toContainText("7/7", { timeout: 5000 });
+
+    await expect(panel.getByText(/cleared to ship/i)).toBeVisible();
+    await expect(panel.getByRole("button", { name: /Run impl/i })).toBeVisible();
+  });
+
+  test("pipeline explainer renders three steps", async ({ page }) => {
+    await page.goto("/app");
+    await expect(
+      page.getByRole("heading", { name: /From spec to shipped code/i })
+    ).toBeVisible();
+    await expect(page.getByTestId("pipeline-step-01")).toBeVisible();
+    await expect(page.getByTestId("pipeline-step-02")).toBeVisible();
+    await expect(page.getByTestId("pipeline-step-03")).toBeVisible();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ZAI — Zero Ambiguity Intelligence</title>
     <meta name="description" content="The engine of Spec Driven Development. By High Tech United." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Sora:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/issues/2026-04-12__feat__zai-app-spec-scorer-page.md
+++ b/issues/2026-04-12__feat__zai-app-spec-scorer-page.md
@@ -1,0 +1,298 @@
+# 2026-04-12__feat__zai-app-spec-scorer-page
+
+**Repo:** `zai` (zi007lin/zai)
+**Label:** `feat`
+**Branch:** `zai/app-spec-scorer-page`
+**Reviewer:** daniel-silvers
+**Route:** `/app`
+
+---
+
+## Spec Validation Score
+
+| Section | Status |
+|---|---|
+| Intent | ✅ PASS |
+| Decision Tree | ✅ PASS |
+| Draft-of-thoughts | ✅ PASS |
+| Final Spec | ✅ PASS |
+| Game Theory Review | ✅ PASS |
+| Subject Migration Summary | ✅ PASS |
+| Files list | ✅ PASS |
+
+**Score: 7 / 7 — cleared to ship**
+
+---
+
+## Intent
+
+Replace the "Coming soon" placeholder on `/app` with a fully functional spec scoring page. Users upload a `.md` spec file, get a deterministic 7-section score rendered with animated breakdown bars, see pre-deploy gates extracted from the spec, and can download the scored spec or proceed to impl. The page also includes a worked example, a downloadable template, and a pipeline explainer. No backend required for v1 — all scoring runs client-side via the rubric logic ported to TypeScript.
+
+---
+
+## Decision Tree
+
+**Question:** Where does the scoring run in v1?
+
+| Option | Runtime | Backend needed | Latency | Decision |
+|---|---|---|---|---|
+| Client-side TS rubric parser | Browser | ❌ None | Instant | ✅ Chosen — ships fast, zero infra |
+| API call to ZiLin-BS on Contabo | Server | ✅ Yes | 200–600ms | ❌ Defer to v2 — blocked on BS deploy |
+| Cloudflare Worker | Edge | ✅ Yes | ~50ms | ❌ Defer to v2 |
+
+**Decision:** Client-side for v1. Port `classify-spec.ts` rubric checks to a browser-safe `scoreSpec(markdown: string)` function in `src/lib/scoreSpec.ts`. When ZiLin-BS API ships, swap the scoring call — UI does not change.
+
+**Trigger for change:** ZiLin-BS classify API ships → replace `scoreSpec()` call with `fetch('/api/classify')`. UI layer unchanged.
+
+---
+
+## Draft-of-thoughts
+
+The upload flow is the first impression. It must feel like a real tool, not a demo. Key detail: the score bars animate sequentially section by section (200ms stagger), mimicking a real evaluation running. The big score counter increments as each section passes — creates a sense of the tool actually working through the file.
+
+Client-side parsing is completely sufficient. The rubric checks are structural (heading presence, table presence, string matching, checkbox count). A ~200-line TS function covers all 7 sections. The result is indistinguishable from a server call.
+
+Download template: generate a pre-filled `.md` template blob in the browser — no CDN needed. This is the primary growth hook for new users who don't have a spec yet.
+
+Dark theme: the page inherits the existing ZAI dark bg (`#0a0a0a`). All components use CSS custom properties already in the ZAI design system. No new color tokens needed.
+
+Font pairing: `DM Mono` for scores/metrics/code, `Sora` for headings/body. Both available on Google Fonts. The mono accent on section names and the score number is the visual anchor.
+
+---
+
+## Final Spec
+
+### 1. Route
+
+`/app` — replaces `AppPage.tsx` content entirely. Keep the existing page shell (navbar, footer).
+
+> **Amendment (research PR #14 · edf1174):** ZAI uses a hand-rolled state router in `src/App.tsx` — not React Router or TanStack. The `/app` route is already registered. No `<Route>` changes needed. Modify `AppPage.tsx` only.
+
+### 2. Page sections (top to bottom)
+
+#### A. Header
+```
+[eyebrow] ZAI · spec scorer
+[h1] Score your spec before it ships
+[subtitle] Upload a spec file to get a deterministic 7-section score.
+           No LLM judgment — pure structural analysis.
+```
+
+#### B. Main action area (two-column grid, collapses to single on mobile)
+
+**Left — Upload zone:**
+- Dashed border box, full height
+- Drag-and-drop target (`dragover`, `drop` events)
+- Click to open file picker (accept `.md` only)
+- States: empty | dragging | loaded
+- Two CTAs: "Score a spec" (primary) | "Download template ↓" (outline)
+- After upload: shows filename + "Scored · {ISO timestamp} · rubric v1.0.0"
+
+**Right — Score panel** (hidden until file loaded, animates in):
+- Large score counter `N/7` in DM Mono, teal color
+- Sub-label: "evaluating…" → "cleared to ship" or "N sections failed"
+- Status badge: "RUNNING" → "7/7 PASS" (green) or "N/7 FAIL" (red)
+- 7 section rows: name | animated bar | PASS/SKIP/FAIL pill
+  - Bars fill sequentially, 200ms stagger per section
+  - Score counter increments as each PASS lands
+- Pre-deploy gates section (if `gates[]` non-empty): amber dot list
+- Action buttons: "Download scored spec ↓" | "Run impl →" (sendPrompt equivalent — copies impl command to clipboard)
+
+#### C. Example section
+
+Two-column: spec file preview (monospace, syntax-highlighted with color classes) | score result card.
+
+The example uses the real `2026-04-12__feat__zai-hero-tagline-governance.md` scored output as data — hardcoded, not dynamic.
+
+#### D. Pipeline explainer
+
+Three-step horizontal flow (responsive → vertical on mobile):
+```
+[01 Write spec] → [02 classify spec] → [03 impl runs]
+```
+Each step: number | name | 2-line description. Middle step accented with teal border.
+
+#### E. Footer stamp
+```
+ZAI · Zero Ambiguity Intelligence · HTU Foundation · zzv.io
+```
+DM Mono, small, muted. Consistent with existing footer.
+
+### 3. `src/lib/scoreSpec.ts` — client-side rubric
+
+```typescript
+export type SectionStatus = 'PASS' | 'FAIL' | 'SKIP';
+
+export interface ScoreResult {
+  rubric_version: string;
+  score: string;
+  passed: boolean;
+  evaluated_at: string;
+  sections: Record<string, SectionStatus>;
+  gates: string[];
+}
+
+export function scoreSpec(markdown: string): ScoreResult {
+  const checks = {
+    intent: checkIntent(markdown),
+    decision_tree: checkDecisionTree(markdown),
+    draft_of_thoughts: checkDraftOfThoughts(markdown),
+    final_spec: checkFinalSpec(markdown),
+    game_theory: checkGameTheory(markdown),
+    migration_summary: checkMigrationSummary(markdown),
+    files_list: checkFilesList(markdown),
+  };
+  const gates = extractGates(markdown);
+  const passCount = Object.values(checks).filter(s => s === 'PASS').length;
+  const skipCount = Object.values(checks).filter(s => s === 'SKIP').length;
+  const required = 7 - skipCount;
+  const passed = Object.values(checks).every(s => s !== 'FAIL');
+  return {
+    rubric_version: '1.0.0',
+    score: `${passCount + skipCount}/7`,
+    passed,
+    evaluated_at: new Date().toISOString(),
+    sections: checks,
+    gates,
+  };
+}
+```
+
+Each `checkX()` function uses regex against the markdown string. No external dependencies.
+
+**Section check rules (implement exactly):**
+
+| Section | Check | Method |
+|---|---|---|
+| intent | `## Intent` heading exists + word count ≤ 150 below it | regex + split |
+| decision_tree | heading exists + markdown table present + "Trigger for change" string exists | regex |
+| draft_of_thoughts | heading exists → PASS; absent → SKIP (never FAIL) | regex |
+| final_spec | heading exists + `## Acceptance Criteria` exists + ≥ 3 `- [ ]` lines below it | regex + count |
+| game_theory | heading exists + "Who benefits", "Abuse vector", "Mitigation" all present | string search |
+| migration_summary | heading exists + table with "Open questions" row + value not empty | regex |
+| files_list | heading exists + ``` code block present after it | regex |
+
+**Gate extraction:**
+```
+Find lines matching: /- \[ \] \*\*Pre-deploy gate/i
+Extract the text after the pattern
+Return as string[]
+```
+
+### 4. Fonts
+
+> **Amendment (research PR #14 · edf1174):** No `_headers` file exists → no CSP. Google Fonts loadable via plain `<link>`. `DM Mono` and `Sora` not yet loaded — add the following.
+
+Add to `index.html` `<head>` (before existing `<link>` tags):
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Sora:wght@300;400;600;700&display=swap" rel="stylesheet">
+```
+
+Add to `src/styles.css` (or global CSS file — confirm path with `find src -name "*.css" | head -5`):
+```css
+:root {
+  --font-mono-zai: 'DM Mono', 'Courier New', monospace;
+  --font-sans-zai: 'Sora', system-ui, -apple-system, sans-serif;
+}
+```
+
+### 5. Color tokens (add to ZAI design system)
+
+```css
+--zai-teal: #1D9E75;
+--zai-purple: #7F77DD;
+--zai-amber: #EF9F27;
+--zai-muted: #666;
+--zai-border: #222;
+--zai-card: #111;
+```
+
+### 6. Template download
+
+Blob-based client download (no CDN, no API):
+```typescript
+const template = `# YYYY-MM-DD__feat__title\n\n## Intent\n\n...\n`;
+const blob = new Blob([template], { type: 'text/markdown' });
+const url = URL.createObjectURL(blob);
+// trigger anchor click, revoke after
+```
+
+Template content: the full 7-section skeleton from `spec-rubric.yaml`, pre-filled with inline guidance comments.
+
+### 7. Animation spec
+
+- Score panel: `opacity: 0 → 1`, `transform: translateY(8px) → 0`, duration 300ms, easing `cubic-bezier(0.4, 0, 0.2, 1)`
+- Bar fills: each bar `width: 0 → 100%`, 600ms, stagger 200ms per section
+- Score counter: increments integer by integer as each PASS section's bar completes
+- All animations: respect `prefers-reduced-motion` — skip transitions, show final state instantly
+
+---
+
+## Game Theory Review
+
+**Who benefits:** ZAI users get immediate, trustworthy spec quality feedback before wasting an impl run. The page demonstrates ZAI's core value prop (Zero Ambiguity) in the product itself — the tool eats its own dog food.
+
+**Abuse vector:** User edits spec to pass structural checks without meaningful content ("Who benefits: yes"). Client-side scoring cannot catch semantic emptiness. Mitigation: scoring is a floor, not a ceiling. The page copy should make this explicit: "Structural checks. Human review still required."
+
+**Abuse vector 2:** User submits a non-spec `.md` file (e.g., README). The rubric will likely score 0–2/7. This is correct behavior — no special handling needed.
+
+**Adoption incentive:** The "Download template" button is the primary growth hook. A user who downloads the template is primed to return with a spec. The template includes inline guidance that reinforces the ZiLin Command methodology.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `/app` route renders the spec scorer page with all 4 sections
+- [ ] Drag-and-drop file upload works, accepts `.md` only
+- [ ] Click-to-upload via file picker works
+- [ ] Score panel is hidden on load, animates in after file is selected
+- [ ] Bars animate sequentially with 200ms stagger
+- [ ] Score counter increments as each PASS lands
+- [ ] Pre-deploy gates appear as amber dot list when present in spec
+- [ ] "Download template" generates and downloads `spec-template.md`
+- [ ] "Download scored spec" downloads the original markdown + appended score block
+- [ ] "Run impl →" copies `impl i <filename>` to clipboard, shows "Copied!" toast
+- [ ] Example section renders with hardcoded `zai-hero` spec data
+- [ ] Pipeline explainer renders 3 steps, collapses to vertical on mobile ≤ 560px
+- [ ] DM Mono + Sora fonts load correctly
+- [ ] All colors match ZAI dark theme (`#0a0a0a` bg)
+- [ ] `prefers-reduced-motion` respected — no animation
+- [ ] `src/lib/scoreSpec.ts` has unit tests for all 7 section checks
+- [ ] 15/15 e2e tests pass (existing suite + new upload flow tests)
+- [ ] "Coming soon" text is gone from `/app`
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | ZAI `/app` — full spec scorer page replacing "Coming soon" |
+| State | Spec complete 7/7; **2 amendments applied** (research PR #14 · edf1174); cleared to impl |
+| Open questions | (1) Does ZAI use React Router or file-based routing? Confirm before modifying `AppPage.tsx`. (2) Existing e2e selector `locator("main h1").first()` — update after h1 copy changes. |
+| Next action | `impl i 2026-04-12__feat__zai-app-spec-scorer-page.md` |
+| Repo | `zi007lin/zai` |
+
+---
+
+## Files
+
+```
+src/pages/AppPage.tsx              ← replace content entirely
+src/lib/scoreSpec.ts               ← new (client-side rubric parser)
+src/lib/scoreSpec.test.ts          ← new (unit tests, 7 section checks)
+src/components/UploadZone.tsx      ← new
+src/components/ScorePanel.tsx      ← new
+src/components/ScoreExample.tsx    ← new
+src/components/PipelineSteps.tsx   ← new
+index.html                         ← add Google Fonts import
+src/styles/zai-tokens.css          ← add font + color tokens (or globals.css)
+e2e/app-scorer.spec.ts             ← new e2e tests
+```
+
+Confirm component file locations:
+```bash
+find src -name "AppPage*" -o -name "pages" -type d 2>/dev/null
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,64 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.2",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
+        "vitest": "^4.1.4",
         "wrangler": "^3.80.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -317,6 +367,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
@@ -455,10 +518,173 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -779,6 +1005,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -796,6 +1040,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -811,6 +1073,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -879,6 +1159,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fastify/busboy": {
@@ -1321,6 +1619,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -1335,6 +1662,263 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1694,6 +2278,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1966,6 +2557,101 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2010,6 +2696,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2067,6 +2771,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2090,6 +2880,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/as-table": {
       "version": "1.0.55",
       "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
@@ -2098,6 +2923,16 @@
       "license": "MIT",
       "dependencies": {
         "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2111,6 +2946,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/blake3-wasm": {
@@ -2174,6 +3019,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -2241,6 +3096,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2254,6 +3130,20 @@
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2273,12 +3163,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2289,6 +3196,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
@@ -2310,6 +3225,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2393,12 +3328,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2459,6 +3422,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -2491,6 +3467,16 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
@@ -2498,6 +3484,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2514,6 +3507,67 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2824,6 +3878,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2833,6 +3898,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -2845,6 +3917,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/miniflare": {
@@ -2916,12 +3998,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2943,6 +4049,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -3020,12 +4139,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -3078,6 +4223,14 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3087,6 +4240,71 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -3176,6 +4394,19 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3250,6 +4481,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -3289,6 +4527,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
@@ -3300,6 +4545,13 @@
         "get-source": "^2.0.12"
       }
     },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -3310,6 +4562,26 @@
         "node": ">=4",
         "npm": ">=6"
       }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
@@ -3330,6 +4602,96 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -3479,6 +4841,669 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -3486,6 +5511,71 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {
@@ -3980,6 +6070,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "deploy:dev": "npm run build && npx wrangler pages deploy dist/ --project-name zai --branch dev",
     "deploy:demo": "npm run build && npx wrangler pages deploy dist/ --project-name zai --branch demo",
@@ -23,12 +25,16 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
+    "vitest": "^4.1.4",
     "wrangler": "^3.80.0"
   }
 }

--- a/src/components/PipelineSteps.tsx
+++ b/src/components/PipelineSteps.tsx
@@ -1,0 +1,76 @@
+interface Step {
+  num: string;
+  name: string;
+  body: string;
+  accent?: boolean;
+}
+
+const STEPS: Step[] = [
+  {
+    num: "01",
+    name: "Write spec",
+    body: "Seven sections, one markdown file. Intent through files list.",
+  },
+  {
+    num: "02",
+    name: "classify spec",
+    body: "Rubric runs. PASS / SKIP / FAIL per section. Pre-deploy gates surfaced.",
+    accent: true,
+  },
+  {
+    num: "03",
+    name: "impl runs",
+    body: "Branch, implement, test, PR. Every hop is recorded.",
+  },
+];
+
+export default function PipelineSteps() {
+  return (
+    <section className="max-w-6xl mx-auto px-6 py-20 border-t border-[var(--zai-border)]">
+      <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+        Pipeline
+      </div>
+      <h2
+        className="mt-2 text-3xl sm:text-4xl"
+        style={{ fontFamily: "var(--font-sans-zai)", fontWeight: 700 }}
+      >
+        From spec to shipped code
+      </h2>
+
+      <div className="mt-10 grid grid-cols-1 min-[560px]:grid-cols-3 gap-5">
+        {STEPS.map((step) => (
+          <div
+            key={step.num}
+            data-testid={`pipeline-step-${step.num}`}
+            className="rounded-xl bg-[var(--zai-card)] p-6"
+            style={{
+              border: step.accent
+                ? "1px solid var(--zai-teal)"
+                : "1px solid var(--zai-border)",
+            }}
+          >
+            <div
+              className="text-[11px] text-[var(--zai-muted)]"
+              style={{ fontFamily: "var(--font-mono-zai)" }}
+            >
+              {step.num}
+            </div>
+            <div
+              className="mt-1 text-xl"
+              style={{
+                fontFamily: "var(--font-sans-zai)",
+                fontWeight: 600,
+                color: step.accent ? "var(--zai-teal)" : undefined,
+              }}
+            >
+              {step.name}
+            </div>
+            <p className="mt-3 text-sm text-[var(--zai-muted)] leading-relaxed">
+              {step.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ScoreExample.tsx
+++ b/src/components/ScoreExample.tsx
@@ -1,0 +1,148 @@
+import { SECTION_LABELS, SECTION_ORDER } from "../lib/scoreSpec";
+
+const EXAMPLE = {
+  filename: "2026-04-12__feat__zai-hero-tagline-governance.md",
+  snippet: [
+    "# 2026-04-12__feat__zai-hero-tagline-governance",
+    "",
+    "## Intent",
+    "Replace the placeholder title on the ZAI hero section",
+    "with the governance positioning tagline…",
+    "",
+    "## Decision Tree",
+    "| Option | Claim scope | Decision |",
+    "|---|---|---|",
+    "| Keep placeholder | No claim | ❌ Reject |",
+    "| K's full tagline verbatim | End-to-end | ⚠️ Conditional |",
+    "",
+    "Trigger for change: When ZZV Chain anchoring goes live in prod…",
+    "",
+    "## Game Theory Review",
+    "Who benefits: enterprise/infra buyers.",
+    "Abuse vector: 'complete' is aspirational without chain.",
+    "Mitigation: scope claim to spec→PR layer only.",
+  ],
+  sections: {
+    intent: "PASS",
+    decision_tree: "PASS",
+    draft_of_thoughts: "PASS",
+    final_spec: "PASS",
+    game_theory: "PASS",
+    migration_summary: "PASS",
+    files_list: "PASS",
+  } as const,
+  score: "7/7",
+  gates: ["ZZV Chain anchoring status before merge"],
+};
+
+export default function ScoreExample() {
+  return (
+    <section className="max-w-6xl mx-auto px-6 py-20">
+      <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+        Example
+      </div>
+      <h2
+        className="mt-2 text-3xl sm:text-4xl"
+        style={{ fontFamily: "var(--font-sans-zai)", fontWeight: 700 }}
+      >
+        What a scored spec looks like
+      </h2>
+      <p className="mt-3 text-[var(--zai-muted)] max-w-2xl">
+        The real governance-tagline spec that shipped as PR&nbsp;#13, run through
+        the same rubric you'll run.
+      </p>
+
+      <div className="mt-8 grid md:grid-cols-2 gap-6">
+        <div className="rounded-xl border border-[var(--zai-border)] bg-[var(--zai-card)] overflow-hidden">
+          <div className="px-4 py-2 border-b border-[var(--zai-border)] text-[11px] text-[var(--zai-muted)]">
+            <span style={{ fontFamily: "var(--font-mono-zai)" }}>
+              {EXAMPLE.filename}
+            </span>
+          </div>
+          <pre
+            className="px-4 py-4 text-[12px] leading-relaxed overflow-x-auto"
+            style={{ fontFamily: "var(--font-mono-zai)" }}
+          >
+            {EXAMPLE.snippet.map((line, i) => {
+              let color = "var(--zai-muted)";
+              if (line.startsWith("#")) color = "var(--zai-teal)";
+              else if (line.startsWith("|")) color = "var(--zai-purple)";
+              else if (line.startsWith("Trigger")) color = "var(--zai-amber)";
+              else if (line.trim().length > 0) color = "#d4d4d4";
+              return (
+                <div key={i} style={{ color }}>
+                  {line || "\u00a0"}
+                </div>
+              );
+            })}
+          </pre>
+        </div>
+
+        <div className="rounded-xl border border-[var(--zai-border)] bg-[var(--zai-card)] p-6">
+          <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+            Score
+          </div>
+          <div
+            className="mt-1 text-5xl"
+            style={{
+              fontFamily: "var(--font-mono-zai)",
+              color: "var(--zai-teal)",
+              fontWeight: 500,
+            }}
+          >
+            {EXAMPLE.score}
+          </div>
+          <div className="mt-1 text-sm text-[var(--zai-muted)]">
+            cleared to ship
+          </div>
+
+          <div className="mt-5 space-y-2">
+            {SECTION_ORDER.map((key) => (
+              <div
+                key={key}
+                className="flex items-center justify-between text-xs"
+              >
+                <span
+                  className="text-neutral-300"
+                  style={{ fontFamily: "var(--font-mono-zai)" }}
+                >
+                  {SECTION_LABELS[key]}
+                </span>
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                  style={{
+                    fontFamily: "var(--font-mono-zai)",
+                    color: "var(--zai-teal)",
+                    border: "1px solid var(--zai-teal)",
+                  }}
+                >
+                  {EXAMPLE.sections[key]}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 pt-4 border-t border-[var(--zai-border)]">
+            <div className="text-[11px] uppercase tracking-[0.2em] text-[var(--zai-amber)] mb-2">
+              Pre-deploy gates
+            </div>
+            <ul className="space-y-1.5">
+              {EXAMPLE.gates.map((g, i) => (
+                <li
+                  key={i}
+                  className="flex items-start gap-2 text-xs text-neutral-300"
+                >
+                  <span
+                    className="inline-block w-2 h-2 rounded-full mt-1.5 shrink-0"
+                    style={{ background: "var(--zai-amber)" }}
+                  />
+                  {g}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ScorePanel.tsx
+++ b/src/components/ScorePanel.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  type ScoreResult,
+  SECTION_LABELS,
+  SECTION_ORDER,
+  type SectionStatus,
+} from "../lib/scoreSpec";
+
+interface Props {
+  result: ScoreResult;
+  filename: string;
+  onDownloadScored: () => void;
+  onCopyImplCommand: () => void;
+  justCopied: boolean;
+}
+
+const STAGGER_MS = 200;
+
+function statusColor(status: SectionStatus): string {
+  if (status === "PASS") return "var(--zai-teal)";
+  if (status === "SKIP") return "var(--zai-purple)";
+  return "#E15B5B";
+}
+
+function statusLabel(status: SectionStatus): string {
+  return status;
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export default function ScorePanel({
+  result,
+  filename,
+  onDownloadScored,
+  onCopyImplCommand,
+  justCopied,
+}: Props) {
+  const reducedMotion = useMemo(() => prefersReducedMotion(), []);
+  const totalSections = SECTION_ORDER.length;
+  const [revealed, setRevealed] = useState(reducedMotion ? totalSections : 0);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setRevealed(totalSections);
+      return;
+    }
+    setRevealed(0);
+    const timers: number[] = [];
+    for (let i = 1; i <= totalSections; i++) {
+      timers.push(
+        window.setTimeout(() => setRevealed(i), i * STAGGER_MS)
+      );
+    }
+    return () => timers.forEach((t) => window.clearTimeout(t));
+  }, [result.evaluated_at, reducedMotion, totalSections]);
+
+  const running = revealed < totalSections;
+  const passCountSoFar = SECTION_ORDER.slice(0, revealed).filter(
+    (k) => result.sections[k] === "PASS" || result.sections[k] === "SKIP"
+  ).length;
+
+  const statusText = running
+    ? "evaluating…"
+    : result.passed
+    ? "cleared to ship"
+    : `${SECTION_ORDER.filter((k) => result.sections[k] === "FAIL").length} sections failed`;
+
+  const badge = running
+    ? { text: "RUNNING", color: "var(--zai-amber)" }
+    : result.passed
+    ? { text: `${passCountSoFar}/7 PASS`, color: "var(--zai-teal)" }
+    : {
+        text: `${SECTION_ORDER.filter((k) => result.sections[k] === "FAIL").length}/7 FAIL`,
+        color: "#E15B5B",
+      };
+
+  return (
+    <div
+      className="rounded-xl border border-[var(--zai-border)] bg-[var(--zai-card)] p-6 sm:p-8"
+      style={{
+        animation: reducedMotion
+          ? undefined
+          : "zai-fade-in 300ms cubic-bezier(0.4, 0, 0.2, 1) both",
+      }}
+      data-testid="score-panel"
+    >
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+            Spec score
+          </div>
+          <div
+            className="mt-1 text-6xl sm:text-7xl"
+            style={{
+              fontFamily: "var(--font-mono-zai)",
+              color: "var(--zai-teal)",
+              fontWeight: 500,
+              lineHeight: 1,
+            }}
+            data-testid="score-counter"
+          >
+            {passCountSoFar}/7
+          </div>
+          <div className="mt-2 text-sm text-[var(--zai-muted)]">{statusText}</div>
+        </div>
+        <span
+          className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold"
+          style={{
+            fontFamily: "var(--font-mono-zai)",
+            color: badge.color,
+            border: `1px solid ${badge.color}`,
+            background: `${badge.color}1a`,
+          }}
+        >
+          <span
+            className="inline-block w-2 h-2 rounded-full"
+            style={{ background: badge.color }}
+          />
+          {badge.text}
+        </span>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        {SECTION_ORDER.map((key, i) => {
+          const status = result.sections[key];
+          const isRevealed = i < revealed;
+          const fill = isRevealed ? 100 : 0;
+          return (
+            <div
+              key={key}
+              className="grid grid-cols-[1fr_auto] sm:grid-cols-[140px_1fr_auto] gap-3 items-center"
+              data-testid={`section-${key}`}
+            >
+              <div
+                className="text-xs sm:text-sm text-neutral-300"
+                style={{ fontFamily: "var(--font-mono-zai)" }}
+              >
+                {SECTION_LABELS[key]}
+              </div>
+              <div className="hidden sm:block h-2 rounded-full bg-[var(--zai-border)] overflow-hidden">
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${fill}%`,
+                    background: statusColor(status),
+                    transition: reducedMotion
+                      ? undefined
+                      : "width 600ms cubic-bezier(0.4, 0, 0.2, 1)",
+                  }}
+                />
+              </div>
+              <span
+                className="justify-self-end text-[10px] px-2 py-0.5 rounded-full font-semibold"
+                style={{
+                  fontFamily: "var(--font-mono-zai)",
+                  color: statusColor(status),
+                  border: `1px solid ${statusColor(status)}`,
+                  opacity: isRevealed ? 1 : 0.25,
+                  transition: "opacity 200ms",
+                }}
+              >
+                {statusLabel(status)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {result.gates.length > 0 && (
+        <div className="mt-6 pt-5 border-t border-[var(--zai-border)]">
+          <div className="text-[11px] uppercase tracking-[0.2em] text-[var(--zai-amber)] mb-2">
+            Pre-deploy gates
+          </div>
+          <ul className="space-y-1.5">
+            {result.gates.map((gate, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-neutral-300">
+                <span
+                  className="inline-block w-2 h-2 rounded-full mt-1.5 shrink-0"
+                  style={{ background: "var(--zai-amber)" }}
+                />
+                {gate}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-6 pt-5 border-t border-[var(--zai-border)] text-[11px] text-[var(--zai-muted)]">
+        <span style={{ fontFamily: "var(--font-mono-zai)" }}>
+          {filename} · Scored · {result.evaluated_at} · rubric v{result.rubric_version}
+        </span>
+      </div>
+
+      <div className="mt-5 flex flex-col sm:flex-row gap-3">
+        <button
+          type="button"
+          onClick={onDownloadScored}
+          className="flex-1 px-4 py-2.5 rounded-md border border-[var(--zai-border)] text-neutral-200 hover:bg-[var(--zai-border)]/40 transition-colors"
+          style={{ fontFamily: "var(--font-sans-zai)" }}
+        >
+          Download scored spec ↓
+        </button>
+        <button
+          type="button"
+          onClick={onCopyImplCommand}
+          className="flex-1 px-4 py-2.5 rounded-md bg-[var(--zai-teal)] text-white font-medium hover:opacity-90 transition-opacity"
+          style={{ fontFamily: "var(--font-sans-zai)" }}
+        >
+          {justCopied ? "Copied!" : "Run impl →"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UploadZone.tsx
+++ b/src/components/UploadZone.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useRef, useState } from "react";
+
+interface Props {
+  onFile: (name: string, contents: string) => void;
+  onDownloadTemplate: () => void;
+  loadedFilename: string | null;
+}
+
+type DragState = "idle" | "dragging";
+
+export default function UploadZone({
+  onFile,
+  onDownloadTemplate,
+  loadedFilename,
+}: Props) {
+  const [dragState, setDragState] = useState<DragState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    async (files: FileList | null) => {
+      setError(null);
+      const file = files?.[0];
+      if (!file) return;
+      if (!/\.md$/i.test(file.name)) {
+        setError("Only .md files are accepted.");
+        return;
+      }
+      const text = await file.text();
+      onFile(file.name, text);
+    },
+    [onFile]
+  );
+
+  const borderClass =
+    dragState === "dragging"
+      ? "border-[var(--zai-teal)]"
+      : loadedFilename
+      ? "border-[var(--zai-teal)]/60"
+      : "border-[var(--zai-border)]";
+
+  return (
+    <div
+      className={`relative flex flex-col rounded-xl border-2 border-dashed ${borderClass} bg-[var(--zai-card)] p-8 transition-colors`}
+      onDragEnter={(e) => {
+        e.preventDefault();
+        setDragState("dragging");
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragState("dragging");
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        setDragState("idle");
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragState("idle");
+        handleFiles(e.dataTransfer.files);
+      }}
+      data-testid="upload-zone"
+    >
+      <div className="flex-1 flex flex-col items-center justify-center text-center py-8">
+        <div
+          className="w-14 h-14 rounded-full bg-[var(--zai-teal)]/10 flex items-center justify-center mb-5"
+          aria-hidden
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--zai-teal)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </div>
+        <h3
+          className="text-xl"
+          style={{ fontFamily: "var(--font-sans-zai)", fontWeight: 600 }}
+        >
+          {loadedFilename ? "Spec loaded" : "Drop a spec file"}
+        </h3>
+        <p className="mt-2 text-sm text-[var(--zai-muted)]">
+          {loadedFilename ? (
+            <span style={{ fontFamily: "var(--font-mono-zai)" }}>
+              {loadedFilename}
+            </span>
+          ) : (
+            <>or click to pick a <span style={{ fontFamily: "var(--font-mono-zai)" }}>.md</span> file</>
+          )}
+        </p>
+        {error && (
+          <p className="mt-3 text-sm text-red-400" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mt-4">
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="flex-1 px-4 py-2.5 rounded-md bg-[var(--zai-teal)] text-white font-medium hover:opacity-90 transition-opacity"
+          style={{ fontFamily: "var(--font-sans-zai)" }}
+        >
+          Score a spec
+        </button>
+        <button
+          type="button"
+          onClick={onDownloadTemplate}
+          className="flex-1 px-4 py-2.5 rounded-md border border-[var(--zai-border)] text-neutral-200 hover:bg-[var(--zai-border)]/40 transition-colors"
+          style={{ fontFamily: "var(--font-sans-zai)" }}
+        >
+          Download template ↓
+        </button>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".md,text/markdown"
+        className="sr-only"
+        onChange={(e) => handleFiles(e.target.files)}
+        data-testid="upload-input"
+      />
+    </div>
+  );
+}

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { scoreSpec } from "./scoreSpec";
+
+const fullSpec = `# title
+
+## Intent
+A tight paragraph describing the goal. About twenty words should be plenty.
+
+## Decision Tree
+| Option | Risk | Decision |
+|---|---|---|
+| A | low | ✅ |
+
+Trigger for change: when condition X flips.
+
+## Draft-of-thoughts
+Reasoning notes live here.
+
+## Final Spec
+Details.
+
+## Acceptance Criteria
+- [ ] one
+- [ ] two
+- [ ] three
+
+## Game Theory Review
+Who benefits: users.
+Abuse vector: gaming the system.
+Mitigation: rate limits.
+
+## Subject Migration Summary
+| | |
+|---|---|
+| What | A thing |
+| Open questions | confirm name |
+
+## Files
+\`\`\`
+src/foo.ts
+\`\`\`
+`;
+
+describe("scoreSpec", () => {
+  it("scores a fully compliant spec 7/7 passed", () => {
+    const r = scoreSpec(fullSpec);
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe("7/7");
+    expect(r.sections.intent).toBe("PASS");
+    expect(r.sections.decision_tree).toBe("PASS");
+    expect(r.sections.draft_of_thoughts).toBe("PASS");
+    expect(r.sections.final_spec).toBe("PASS");
+    expect(r.sections.game_theory).toBe("PASS");
+    expect(r.sections.migration_summary).toBe("PASS");
+    expect(r.sections.files_list).toBe("PASS");
+    expect(r.rubric_version).toBe("1.0.0");
+  });
+
+  it("intent FAILs when body is empty", () => {
+    const md = fullSpec.replace(
+      /## Intent\nA tight paragraph[^\n]*\n/,
+      "## Intent\n\n"
+    );
+    expect(scoreSpec(md).sections.intent).toBe("FAIL");
+  });
+
+  it("intent FAILs when body exceeds 150 words", () => {
+    const long = "word ".repeat(200);
+    const md = `## Intent\n${long}\n\n## Next\n`;
+    expect(scoreSpec(md).sections.intent).toBe("FAIL");
+  });
+
+  it("decision_tree FAILs without a table", () => {
+    const md = fullSpec.replace(
+      /\| Option \| Risk \| Decision \|\n\|---\|---\|---\|\n\| A \| low \| ✅ \|\n/,
+      ""
+    );
+    expect(scoreSpec(md).sections.decision_tree).toBe("FAIL");
+  });
+
+  it("decision_tree FAILs without 'Trigger for change'", () => {
+    const md = fullSpec.replace(/Trigger for change[^\n]*\n/, "");
+    expect(scoreSpec(md).sections.decision_tree).toBe("FAIL");
+  });
+
+  it("draft_of_thoughts SKIPs when heading absent (never FAIL)", () => {
+    const md = fullSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
+    const r = scoreSpec(md);
+    expect(r.sections.draft_of_thoughts).toBe("SKIP");
+    expect(r.passed).toBe(true);
+  });
+
+  it("final_spec FAILs when acceptance criteria has fewer than 3 checkboxes", () => {
+    const md = fullSpec.replace(
+      /## Acceptance Criteria\n- \[ \] one\n- \[ \] two\n- \[ \] three\n/,
+      "## Acceptance Criteria\n- [ ] one\n- [ ] two\n"
+    );
+    expect(scoreSpec(md).sections.final_spec).toBe("FAIL");
+  });
+
+  it("game_theory FAILs when any required phrase missing", () => {
+    const md = fullSpec.replace(/Mitigation:[^\n]*\n/, "");
+    expect(scoreSpec(md).sections.game_theory).toBe("FAIL");
+  });
+
+  it("migration_summary FAILs when Open questions value is empty", () => {
+    const md = fullSpec.replace(
+      /\| Open questions \| confirm name \|/,
+      "| Open questions |  |"
+    );
+    expect(scoreSpec(md).sections.migration_summary).toBe("FAIL");
+  });
+
+  it("files_list FAILs without a fenced code block", () => {
+    const md = fullSpec.replace(/## Files[\s\S]*$/, "## Files\nsrc/foo.ts\n");
+    expect(scoreSpec(md).sections.files_list).toBe("FAIL");
+  });
+
+  it("extracts Pre-deploy gates from checkboxes", () => {
+    const md = `${fullSpec}\n- [ ] **Pre-deploy gate:** confirm chain status\n- [ ] **Pre-deploy gate** accent color confirmed`;
+    const r = scoreSpec(md);
+    expect(r.gates.length).toBe(2);
+    expect(r.gates[0]).toMatch(/chain/i);
+  });
+
+  it("score string reflects PASS + SKIP count (never penalizes SKIP)", () => {
+    const md = fullSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
+    expect(scoreSpec(md).score).toBe("7/7");
+  });
+
+  it("non-spec markdown scores near zero without crashing", () => {
+    const r = scoreSpec("# README\n\nJust a readme, no sections.\n");
+    expect(r.passed).toBe(false);
+    expect(r.sections.intent).toBe("FAIL");
+    expect(r.sections.decision_tree).toBe("FAIL");
+  });
+});

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -1,0 +1,152 @@
+export type SectionStatus = "PASS" | "FAIL" | "SKIP";
+
+export type SectionKey =
+  | "intent"
+  | "decision_tree"
+  | "draft_of_thoughts"
+  | "final_spec"
+  | "game_theory"
+  | "migration_summary"
+  | "files_list";
+
+export interface ScoreResult {
+  rubric_version: string;
+  score: string;
+  passed: boolean;
+  evaluated_at: string;
+  sections: Record<SectionKey, SectionStatus>;
+  gates: string[];
+}
+
+const RUBRIC_VERSION = "1.0.0";
+
+const HEADING_PATTERNS: Record<SectionKey, RegExp> = {
+  intent: /^##\s+Intent\b/mi,
+  decision_tree: /^##\s+Decision\s+Tree\b/mi,
+  draft_of_thoughts: /^##\s+Draft[-\s]of[-\s]thoughts\b/mi,
+  final_spec: /^##\s+Final\s+Spec\b/mi,
+  game_theory: /^##\s+Game\s+Theory(\s+Review)?\b/mi,
+  migration_summary: /^##\s+Subject\s+Migration\s+Summary\b/mi,
+  files_list: /^##\s+Files\b/mi,
+};
+
+function sectionBody(markdown: string, key: SectionKey): string {
+  const start = markdown.search(HEADING_PATTERNS[key]);
+  if (start === -1) return "";
+  const afterHeading = markdown.slice(start).replace(HEADING_PATTERNS[key], "");
+  const nextHeading = afterHeading.search(/^##\s+/m);
+  return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+}
+
+function checkIntent(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "intent");
+  if (!body.trim()) return "FAIL";
+  const words = body.trim().split(/\s+/).filter(Boolean).length;
+  return words > 0 && words <= 150 ? "PASS" : "FAIL";
+}
+
+function checkDecisionTree(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "decision_tree");
+  if (!body.trim()) return "FAIL";
+  const hasTable = /\|.*\|.*\n\|[\s-:|]+\|/.test(body);
+  const hasTrigger = /trigger\s+for\s+change/i.test(body);
+  return hasTable && hasTrigger ? "PASS" : "FAIL";
+}
+
+function checkDraftOfThoughts(markdown: string): SectionStatus {
+  return HEADING_PATTERNS.draft_of_thoughts.test(markdown) ? "PASS" : "SKIP";
+}
+
+function checkFinalSpec(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "final_spec");
+  if (!body.trim()) return "FAIL";
+  const hasAC = /^##\s+Acceptance\s+Criteria\b/mi.test(markdown);
+  if (!hasAC) return "FAIL";
+  const acStart = markdown.search(/^##\s+Acceptance\s+Criteria\b/mi);
+  const acBody = markdown.slice(acStart).replace(/^##\s+Acceptance\s+Criteria\b/mi, "");
+  const nextHeading = acBody.search(/^##\s+/m);
+  const acSlice = nextHeading === -1 ? acBody : acBody.slice(0, nextHeading);
+  const checkboxes = (acSlice.match(/^- \[[ xX]\]/gm) || []).length;
+  return checkboxes >= 3 ? "PASS" : "FAIL";
+}
+
+function checkGameTheory(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "game_theory");
+  if (!body.trim()) return "FAIL";
+  const hasBenefits = /who\s+benefits/i.test(body);
+  const hasAbuse = /abuse\s+vector/i.test(body);
+  const hasMitigation = /mitigation/i.test(body);
+  return hasBenefits && hasAbuse && hasMitigation ? "PASS" : "FAIL";
+}
+
+function checkMigrationSummary(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "migration_summary");
+  if (!body.trim()) return "FAIL";
+  const openRow = body.match(/\|\s*Open\s+questions\s*\|([^|\n]*)\|/i);
+  if (!openRow) return "FAIL";
+  const value = openRow[1].trim();
+  return value.length > 0 ? "PASS" : "FAIL";
+}
+
+function checkFilesList(markdown: string): SectionStatus {
+  const body = sectionBody(markdown, "files_list");
+  if (!body.trim()) return "FAIL";
+  return /```[\s\S]*?```/.test(body) ? "PASS" : "FAIL";
+}
+
+function extractGates(markdown: string): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const gates: string[] = [];
+  const re = /- \[[ xX]\]\s+\*\*Pre-deploy gate[:\s*]*\*?\s*(.+)$/i;
+  for (const line of lines) {
+    const m = line.match(re);
+    if (m) {
+      gates.push(m[1].trim().replace(/\*+$/, "").trim());
+    }
+  }
+  return gates;
+}
+
+export function scoreSpec(markdown: string): ScoreResult {
+  const sections: Record<SectionKey, SectionStatus> = {
+    intent: checkIntent(markdown),
+    decision_tree: checkDecisionTree(markdown),
+    draft_of_thoughts: checkDraftOfThoughts(markdown),
+    final_spec: checkFinalSpec(markdown),
+    game_theory: checkGameTheory(markdown),
+    migration_summary: checkMigrationSummary(markdown),
+    files_list: checkFilesList(markdown),
+  };
+  const gates = extractGates(markdown);
+  const passCount = Object.values(sections).filter((s) => s === "PASS").length;
+  const skipCount = Object.values(sections).filter((s) => s === "SKIP").length;
+  const passed = Object.values(sections).every((s) => s !== "FAIL");
+  return {
+    rubric_version: RUBRIC_VERSION,
+    score: `${passCount + skipCount}/7`,
+    passed,
+    evaluated_at: new Date().toISOString(),
+    sections,
+    gates,
+  };
+}
+
+export const SECTION_LABELS: Record<SectionKey, string> = {
+  intent: "Intent",
+  decision_tree: "Decision Tree",
+  draft_of_thoughts: "Draft-of-thoughts",
+  final_spec: "Final Spec",
+  game_theory: "Game Theory Review",
+  migration_summary: "Subject Migration Summary",
+  files_list: "Files list",
+};
+
+export const SECTION_ORDER: SectionKey[] = [
+  "intent",
+  "decision_tree",
+  "draft_of_thoughts",
+  "final_spec",
+  "game_theory",
+  "migration_summary",
+  "files_list",
+];

--- a/src/lib/specTemplate.ts
+++ b/src/lib/specTemplate.ts
@@ -1,0 +1,69 @@
+export const SPEC_TEMPLATE = `# YYYY-MM-DD__feat__short-title
+
+## Intent
+
+<!-- One paragraph, ≤ 150 words. State the change and the motivation. -->
+
+---
+
+## Decision Tree
+
+<!-- The question you considered, options in a table, and the trigger for change. -->
+
+**Question:** <!-- the decision you made -->
+
+| Option | Risk | Decision |
+|---|---|---|
+| Option A | low | ✅ Chosen |
+| Option B | high | ❌ Rejected |
+
+**Trigger for change:** <!-- what new info would flip this decision -->
+
+---
+
+## Draft-of-thoughts
+
+<!-- Reasoning scratch. Waivable on trivial copy changes. -->
+
+---
+
+## Final Spec
+
+<!-- Concrete rendering rules, target elements, what is and isn't in scope. -->
+
+## Acceptance Criteria
+
+- [ ] First concrete outcome
+- [ ] Second concrete outcome
+- [ ] Third concrete outcome
+
+---
+
+## Game Theory Review
+
+**Who benefits:** <!-- who wins from this change -->
+
+**Abuse vector:** <!-- how a bad actor or lazy user could break or game it -->
+
+**Mitigation:** <!-- what prevents the abuse or caps the damage -->
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | <!-- one-line description --> |
+| State | Spec complete; not yet implemented |
+| Open questions | <!-- list anything to confirm before impl --> |
+| Next action | \`impl i YYYY-MM-DD__feat__short-title.md\` |
+
+---
+
+## Files
+
+\`\`\`
+path/to/file-to-change.ts
+path/to/new-file.ts
+\`\`\`
+`;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,8 +18,7 @@
     "spec_coverage": "Spec coverage"
   },
   "app": {
-    "title": "ZAI App",
-    "coming_soon": "Coming soon. The ZAI spec generator and translation round-trip are in active development."
+    "scorer_title": "Score your spec before it ships"
   },
   "pricing": {
     "title": "Editions",

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -1,11 +1,163 @@
-import { useTranslation } from "react-i18next";
+import { useCallback, useMemo, useState } from "react";
+import UploadZone from "../components/UploadZone";
+import ScorePanel from "../components/ScorePanel";
+import ScoreExample from "../components/ScoreExample";
+import PipelineSteps from "../components/PipelineSteps";
+import { scoreSpec, type ScoreResult } from "../lib/scoreSpec";
+import { SPEC_TEMPLATE } from "../lib/specTemplate";
+
+function downloadBlob(filename: string, contents: string) {
+  const blob = new Blob([contents], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function buildScoredSpec(
+  originalFilename: string,
+  originalMarkdown: string,
+  result: ScoreResult
+): string {
+  const lines: string[] = [];
+  lines.push(originalMarkdown.replace(/\s+$/, ""));
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push("## ZAI Spec Score");
+  lines.push("");
+  lines.push(`- **Rubric version:** ${result.rubric_version}`);
+  lines.push(`- **Evaluated at:** ${result.evaluated_at}`);
+  lines.push(`- **Score:** ${result.score}`);
+  lines.push(`- **Passed:** ${result.passed ? "YES" : "NO"}`);
+  lines.push("");
+  lines.push("| Section | Status |");
+  lines.push("|---|---|");
+  for (const [key, status] of Object.entries(result.sections)) {
+    lines.push(`| ${key} | ${status} |`);
+  }
+  if (result.gates.length > 0) {
+    lines.push("");
+    lines.push("### Pre-deploy gates");
+    for (const g of result.gates) lines.push(`- [ ] ${g}`);
+  }
+  lines.push("");
+  lines.push(`_Source: ${originalFilename}_`);
+  lines.push("");
+  return lines.join("\n");
+}
 
 export default function AppPage() {
-  const { t } = useTranslation();
+  const [filename, setFilename] = useState<string | null>(null);
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [result, setResult] = useState<ScoreResult | null>(null);
+  const [justCopied, setJustCopied] = useState(false);
+
+  const handleFile = useCallback((name: string, contents: string) => {
+    setFilename(name);
+    setMarkdown(contents);
+    setResult(scoreSpec(contents));
+  }, []);
+
+  const handleDownloadTemplate = useCallback(() => {
+    downloadBlob("spec-template.md", SPEC_TEMPLATE);
+  }, []);
+
+  const handleDownloadScored = useCallback(() => {
+    if (!filename || !markdown || !result) return;
+    const out = buildScoredSpec(filename, markdown, result);
+    const scoredName = filename.replace(/\.md$/i, "") + ".scored.md";
+    downloadBlob(scoredName, out);
+  }, [filename, markdown, result]);
+
+  const handleCopyImplCommand = useCallback(async () => {
+    if (!filename) return;
+    const cmd = `impl i ${filename}`;
+    try {
+      await navigator.clipboard.writeText(cmd);
+    } catch {
+      // silently ignore — toast still fires
+    }
+    setJustCopied(true);
+    window.setTimeout(() => setJustCopied(false), 1600);
+  }, [filename]);
+
+  const header = useMemo(
+    () => (
+      <section className="max-w-6xl mx-auto px-6 pt-16 pb-10">
+        <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+          <span style={{ fontFamily: "var(--font-mono-zai)" }}>
+            ZAI · spec scorer
+          </span>
+        </div>
+        <h1
+          className="mt-3 font-bold tracking-tight"
+          style={{
+            fontFamily: "var(--font-sans-zai)",
+            fontSize: "clamp(2rem, 5vw, 3.25rem)",
+            lineHeight: 1.1,
+          }}
+        >
+          Score your spec before it ships
+        </h1>
+        <p
+          className="mt-4 text-[var(--zai-muted)] max-w-2xl"
+          style={{ fontSize: "1.0625rem", lineHeight: 1.7 }}
+        >
+          Upload a spec file to get a deterministic 7-section score. No LLM
+          judgment — pure structural analysis. Structural checks. Human review
+          still required.
+        </p>
+      </section>
+    ),
+    []
+  );
+
   return (
-    <div className="max-w-3xl mx-auto px-6 py-24 text-center">
-      <h1 className="text-4xl font-bold">{t("app.title")}</h1>
-      <p className="mt-4 text-neutral-400">{t("app.coming_soon")}</p>
+    <div className="bg-[#0a0a0a]">
+      {header}
+
+      <section className="max-w-6xl mx-auto px-6 pb-12">
+        <div className="grid md:grid-cols-2 gap-6 items-stretch">
+          <UploadZone
+            onFile={handleFile}
+            onDownloadTemplate={handleDownloadTemplate}
+            loadedFilename={filename}
+          />
+          {result && filename ? (
+            <ScorePanel
+              result={result}
+              filename={filename}
+              onDownloadScored={handleDownloadScored}
+              onCopyImplCommand={handleCopyImplCommand}
+              justCopied={justCopied}
+            />
+          ) : (
+            <div
+              className="rounded-xl border border-dashed border-[var(--zai-border)] bg-[var(--zai-card)]/40 p-8 flex items-center justify-center text-sm text-[var(--zai-muted)]"
+              data-testid="score-panel-placeholder"
+            >
+              Score panel appears here after a spec is loaded.
+            </div>
+          )}
+        </div>
+      </section>
+
+      <ScoreExample />
+      <PipelineSteps />
+
+      <section className="max-w-6xl mx-auto px-6 py-10 border-t border-[var(--zai-border)]">
+        <div
+          className="text-[11px] text-[var(--zai-muted)]"
+          style={{ fontFamily: "var(--font-mono-zai)" }}
+        >
+          ZAI · Zero Ambiguity Intelligence · HTU Foundation · zzv.io
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,28 @@
 
 :root {
   color-scheme: dark;
+
+  --font-mono-zai: "DM Mono", "JetBrains Mono", "Courier New", monospace;
+  --font-sans-zai: "Sora", system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
+
+  --zai-teal: #1d9e75;
+  --zai-purple: #7f77dd;
+  --zai-amber: #ef9f27;
+  --zai-muted: #666;
+  --zai-border: #222;
+  --zai-card: #111;
+}
+
+@keyframes zai-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 html,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the "Coming soon" placeholder on \`/app\` with a full spec scorer page. Drop a \`.md\` spec, get a deterministic 7-section score with animated breakdown bars, see pre-deploy gates, download the scored spec or copy the impl command.

Everything runs client-side. When the ZiLin-BS classify API ships, \`scoreSpec()\` becomes \`fetch('/api/classify')\` and the UI does not change.

Spec: \`issues/2026-04-12__feat__zai-app-spec-scorer-page.md\`
Blocking research: #14 (merged), report at \`issues/reports/2026-04-12__research__zai-app-scorer-prereqs.md\`

## Amendments from research PR #14 (applied)

- **Routing**: hand-rolled state router in \`src/App.tsx\`, \`/app\` already wired. \`AppPage.tsx\` replaced in place, no router changes.
- **Fonts/CSP**: no \`_headers\` file, no CSP. DM Mono + Sora added via plain \`<link>\` tags in \`index.html\`. Tokens declared in \`src/styles.css\`.

## New files

| Path | What |
|---|---|
| \`src/lib/scoreSpec.ts\` | Rubric parser — regex/string checks per section, no deps |
| \`src/lib/scoreSpec.test.ts\` | 13 vitest tests covering every rubric branch + gate extraction + non-spec fallback |
| \`src/lib/specTemplate.ts\` | 7-section spec skeleton for the Download template action |
| \`src/components/UploadZone.tsx\` | Drag/drop + file picker, .md-only, primary/secondary CTAs |
| \`src/components/ScorePanel.tsx\` | Big DM Mono \`N/7\` counter, staggered bar fills, gate list, actions |
| \`src/components/ScoreExample.tsx\` | Hardcoded example using the governance-tagline spec result |
| \`src/components/PipelineSteps.tsx\` | 01 / 02 / 03 steps, middle step teal-accented |
| \`src/pages/AppPage.tsx\` | Wires it all together |
| \`e2e/app-scorer.spec.ts\` | 3 new Playwright tests |
| \`vitest.config.ts\` | Scopes vitest to \`src/**/*.test.ts\` so it doesn't suck in \`e2e/\` |

Modified: \`index.html\` (Google Fonts \`<link>\`), \`src/styles.css\` (fonts + ZAI palette + \`zai-fade-in\` keyframes), \`src/locales/en.json\` (drop \`app.title\` / \`app.coming_soon\`), \`package.json\` (\`test\` + \`test:watch\` scripts, vitest + testing-library + jsdom devDeps).

## Rubric rules (implemented exactly per spec)

| Section | Rule |
|---|---|
| intent | heading present, 1–150 words |
| decision_tree | heading + markdown table + "Trigger for change" |
| draft_of_thoughts | present → PASS, absent → SKIP (never FAIL) |
| final_spec | heading + \`## Acceptance Criteria\` with ≥ 3 \`- [ ]\` lines |
| game_theory | heading + "Who benefits" + "Abuse vector" + "Mitigation" |
| migration_summary | heading + table row "Open questions" with non-empty value |
| files_list | heading + fenced code block |
| gates | \`- [ ] **Pre-deploy gate**\` lines extracted as \`string[]\` |

Score string counts PASS + SKIP out of 7. \`passed\` is \`true\` iff no FAIL.

## Animations

- Score panel fades + slides in (300ms, \`cubic-bezier(0.4, 0, 0.2, 1)\`)
- Bars fill sequentially at 200ms stagger (600ms each)
- Counter increments as each bar lands
- \`prefers-reduced-motion\` → skips every transition, final state renders instantly

## Tests

- \`npm run test\` — **13/13** unit tests (scoreSpec rubric branches + gates + non-spec)
- \`npm run test:e2e\` — **18/18** Playwright tests (15 existing responsive + 3 new scorer)
- \`npm run build\` — tsc + vite, 222 kB JS / 22 kB CSS

## Acceptance criteria

- [x] \`/app\` renders spec scorer with all 4 sections (A–E)
- [x] Drag-and-drop file upload, \`.md\` only
- [x] Click-to-upload via file picker
- [x] Score panel hidden on load, animates in after file selection
- [x] Bars animate sequentially with 200ms stagger
- [x] Score counter increments as each PASS lands
- [x] Pre-deploy gates rendered as amber dot list when present
- [x] "Download template" generates \`spec-template.md\`
- [x] "Download scored spec" writes original + appended score block
- [x] "Run impl →" copies \`impl i <filename>\` to clipboard, shows "Copied!"
- [x] Example section renders with hardcoded governance-tagline data
- [x] Pipeline explainer: 3 steps, collapses to vertical under 560px
- [x] DM Mono + Sora fonts loaded
- [x] ZAI dark theme (\`#0a0a0a\` bg) applied
- [x] \`prefers-reduced-motion\` respected
- [x] \`scoreSpec.ts\` has unit tests for all 7 section checks
- [x] 18/18 e2e tests pass
- [x] "Coming soon" text gone from \`/app\`

## Spec deviations (small)

1. The spec referenced \`src/styles/zai-tokens.css\`. Repo uses \`src/styles.css\` (confirmed in research report). Tokens landed there.
2. Abuse-vector copy from the Game Theory review ("Structural checks. Human review still required.") is included in the header subtitle to satisfy the spec's mitigation requirement.

Reviewer: daniel-silvers