### PR TITLE
feat: rubric v1.1.0 — type-aware section sets on ZAI /app scorer

### DIFF
--- a/issues/2026-04-13__feat__zilin-bs-rubric-spec-types.md
+++ b/issues/2026-04-13__feat__zilin-bs-rubric-spec-types.md
@@ -1,0 +1,387 @@
+# 2026-04-13__feat__zilin-bs-rubric-spec-types
+
+**Repo:** `htu-foundation`
+**Label:** `feat`
+**Branch:** `htu/zilin-bs-rubric-spec-types`
+**Reviewer:** daniel-silvers
+**Depends on:** `2026-04-12__feat__zilin-bs-classify-command.md` (rubric v1.0.0)
+
+---
+
+## Spec Validation Score
+
+| Section | Status |
+|---|---|
+| Intent | ✅ PASS |
+| Decision Tree | ✅ PASS |
+| Draft-of-thoughts | ✅ PASS |
+| Final Spec | ✅ PASS |
+| Game Theory Review | ✅ PASS |
+| Subject Migration Summary | ✅ PASS |
+| Files list | ✅ PASS |
+
+**Score: 7 / 7 — cleared to ship**
+
+---
+
+## Intent
+
+Extend `spec-rubric.yaml` from v1.0.0 to v1.1.0 to support multiple spec types (`feat`, `research`, `bug`, `chore`). Each type has a different required section set. The classifier reads the spec type from the filename prefix (`YYYY-MM-DD__TYPE__title.md`) and applies the correct section rules. This fixes false FAILs on research and chore specs that have a legitimately different structure from feat specs.
+
+---
+
+## Decision Tree
+
+**Question:** How should the rubric handle different spec types?
+
+| Option | Mechanism | Backward compatible | Decision |
+|---|---|---|---|
+| One rubric for all types | Current state — all types judged as feat | ❌ False FAILs on research/chore | ❌ Status quo broken |
+| Per-type rubric files | `rubric-feat.yaml`, `rubric-research.yaml` | ✅ | ❌ Fragmented — hard to maintain |
+| Single rubric with type-aware section sets | `spec_types` map inside `spec-rubric.yaml` | ✅ | ✅ Chosen |
+| Filename prefix ignored, manual override flag | `classify spec --type research` | ✅ | ❌ Requires human to remember flag |
+
+**Decision:** Single rubric file with a `spec_types` map. Classifier reads filename prefix to determine type automatically. No human flag needed.
+
+**Trigger for change:** New spec type added (e.g., `hotfix`, `refactor`) → add entry to `spec_types` map, bump to v1.2.0.
+
+---
+
+## Draft-of-thoughts
+
+The filename already encodes the type: `2026-04-13__research__title.md` → type = `research`. The classifier can extract this with a simple regex on the basename. If the filename doesn't match the pattern, default to `feat` (safe — most strict ruleset).
+
+Research specs legitimately don't need:
+- Decision Tree (they're discovering information, not deciding between options)
+- Final Spec (they produce a report, not a spec)
+- Game Theory Review (no incentive design in a research task)
+
+Research specs DO need:
+- Intent (why is this research being done)
+- Research Questions (structured queries — map to `decision_tree` slot with relaxed check)
+- Acceptance Criteria (what does "done" look like — must include "report saved to")
+- Migration Summary (state + next actions)
+- Files list (the report file path)
+
+Chore specs (dependency bumps, cleanup) need even less — Intent + Files list is sufficient.
+
+---
+
+## Final Spec
+
+### 1. Rubric v1.1.0 — updated `spec-rubric.yaml`
+
+Replace the current file entirely:
+
+```yaml
+version: "1.1.0"
+
+spec_types:
+  feat:
+    sections:
+      intent:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Intent"
+          - type: word_count_under
+            limit: 150
+      decision_tree:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Decision Tree"
+          - type: table_present
+          - type: column_present
+            columns: ["Option", "Decision"]
+          - type: string_present
+            value: "Trigger for change"
+      draft_of_thoughts:
+        required: false
+        waive_label: "SKIP"
+      final_spec:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Final Spec"
+          - type: heading_present
+            pattern: "^#+\\s+Acceptance Criteria"
+          - type: checkbox_count_gte
+            minimum: 3
+      game_theory:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Game Theory"
+          - type: string_present
+            value: "Who benefits"
+          - type: string_present
+            value: "Abuse vector"
+          - type: string_present
+            value: "Mitigation"
+      migration_summary:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Subject Migration Summary"
+          - type: table_row_present
+            label: "Open questions"
+          - type: open_questions_not_empty
+      files_list:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Files"
+          - type: code_block_present
+
+  research:
+    sections:
+      intent:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Intent"
+          - type: word_count_under
+            limit: 150
+      research_questions:
+        required: true
+        display_name: "Research Questions"
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Research Questions"
+          - type: subheading_count_gte
+            minimum: 1
+      draft_of_thoughts:
+        required: false
+        waive_label: "SKIP"
+      acceptance_criteria:
+        required: true
+        display_name: "Acceptance Criteria"
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Acceptance Criteria"
+          - type: checkbox_count_gte
+            minimum: 3
+          - type: string_present
+            value: "report saved"
+      report_format:
+        required: true
+        display_name: "Report Format"
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Report Format"
+      migration_summary:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Subject Migration Summary"
+          - type: table_row_present
+            label: "Open questions"
+          - type: open_questions_not_empty
+      files_list:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Files"
+          - type: code_block_present
+
+  bug:
+    sections:
+      intent:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Intent"
+      reproduction_steps:
+        required: true
+        display_name: "Reproduction Steps"
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Repro"
+      final_spec:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Fix"
+          - type: heading_present
+            pattern: "^#+\\s+Acceptance Criteria"
+          - type: checkbox_count_gte
+            minimum: 2
+      migration_summary:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Subject Migration Summary"
+          - type: open_questions_not_empty
+      files_list:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Files"
+          - type: code_block_present
+
+  chore:
+    sections:
+      intent:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Intent"
+      files_list:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Files"
+          - type: code_block_present
+
+  hotfix:
+    sections:
+      intent:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Intent"
+      final_spec:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Fix"
+          - type: heading_present
+            pattern: "^#+\\s+Acceptance Criteria"
+          - type: checkbox_count_gte
+            minimum: 2
+      files_list:
+        required: true
+        checks:
+          - type: heading_present
+            pattern: "^#+\\s+Files"
+          - type: code_block_present
+```
+
+### 2. Classifier changes (`classify-spec.ts`)
+
+**Type extraction (add before section evaluation):**
+```typescript
+function extractSpecType(filepath: string): string {
+  const basename = path.basename(filepath);
+  const match = basename.match(/^\d{4}-\d{2}-\d{2}__(\w+)__/);
+  const rawType = match?.[1]?.toLowerCase() ?? 'feat';
+  const knownTypes = ['feat', 'feature', 'research', 'bug', 'chore', 'hotfix', 'refactor'];
+  // normalize aliases
+  if (rawType === 'feature') return 'feat';
+  if (rawType === 'refactor') return 'chore';
+  return knownTypes.includes(rawType) ? rawType : 'feat';
+}
+```
+
+**Score block output additions:**
+```json
+{
+  "rubric_version": "1.1.0",
+  "spec_type": "research",
+  "score": "6/6",
+  "passed": true,
+  ...
+}
+```
+
+Note: score denominator is now dynamic — it equals the number of required sections for the detected type, not always 7.
+
+**Score display format:** `N / M` where M = required sections for this type. Example: research = `6/6`, chore = `2/2`.
+
+### 3. Score block `<!-- zilin-bs:score -->` addition
+
+Add `spec_type` field to the appended JSON block so the ZAI `/app` scorer page can display it.
+
+### 4. ZAI `/app` scorer page update (`src/lib/scoreSpec.ts`)
+
+The client-side scorer must also be updated to match rubric v1.1.0:
+
+```typescript
+// Add at top of scoreSpec.ts
+function detectSpecType(filename: string): SpecType {
+  const match = filename.match(/^\d{4}-\d{2}-\d{2}__(\w+)__/);
+  const raw = match?.[1]?.toLowerCase() ?? 'feat';
+  if (raw === 'feature') return 'feat';
+  if (raw === 'refactor') return 'chore';
+  const known: SpecType[] = ['feat', 'research', 'bug', 'chore', 'hotfix'];
+  return known.includes(raw as SpecType) ? (raw as SpecType) : 'feat';
+}
+
+export function scoreSpec(markdown: string, filename: string = ''): ScoreResult {
+  const specType = detectSpecType(filename);
+  // route to type-specific section checks
+  ...
+}
+```
+
+The upload handler in `AppPage.tsx` must pass `file.name` to `scoreSpec()`:
+```typescript
+const result = scoreSpec(text, file.name);
+```
+
+Score denominator on the UI shows the correct max for the type (not always `/7`).
+
+### 5. Score display on `/app`
+
+- Score panel header: add small type badge next to the score: `FEAT` / `RESEARCH` / `BUG` / `CHORE`
+- Score denominator: dynamic — `N / {requiredCount}` not hardcoded `/7`
+- Section names: use `display_name` from rubric when present (e.g., "Research Questions" not "decision_tree")
+
+---
+
+## Game Theory Review
+
+**Who benefits:** All spec types score correctly. Research specs no longer false-fail, which means BS/Dev pipelines don't get blocked on legitimate research issues. Developers using the ZAI `/app` scorer get accurate feedback regardless of what kind of spec they upload.
+
+**Abuse vector:** Author names a feat spec `research` to avoid Decision Tree and Game Theory requirements. Mitigation: the filename convention is enforced by the impl workflow — ZiLin Issuer generates the filename based on the issue type selected. Misclassification would be visible in PR review (a spec with implementation code labeled `research`).
+
+**Abuse vector 2:** Unknown type defaults to `feat` (most strict). This means a typo like `__freature__` gets the full feat rubric — failing loudly rather than silently passing with a lenient ruleset. This is the correct failure mode.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `spec-rubric.yaml` bumped to v1.1.0 with `spec_types` map for `feat`, `research`, `bug`, `chore`, `hotfix`
+- [ ] `classify-spec.ts` extracts type from filename, routes to correct section set
+- [ ] Unknown/aliased types normalize correctly (`feature` → `feat`, `refactor` → `chore`)
+- [ ] Research spec `2026-04-13__research__zai-app-readme-homepage-alignment.md` scores 6/6 PASS
+- [ ] Feat spec `2026-04-12__feat__zai-hero-tagline-governance.md` still scores 7/7 PASS
+- [ ] Chore spec scores 2/2 PASS
+- [ ] Score block JSON includes `spec_type` field
+- [ ] Score denominator is dynamic (not hardcoded 7)
+- [ ] `src/lib/scoreSpec.ts` updated to match v1.1.0 type routing
+- [ ] `AppPage.tsx` passes `file.name` to `scoreSpec()`
+- [ ] Score panel shows type badge (`FEAT` / `RESEARCH` / etc.)
+- [ ] Score panel denominator updates correctly per type
+- [ ] Unit tests updated — add research, bug, chore type test cases
+- [ ] 18/18 e2e tests still pass
+- [ ] `README.md` in `tools/zilin-bs/` updated with type table
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | Rubric v1.1.0 — type-aware section sets; fixes false FAILs on research/chore specs |
+| State | Spec complete 7/7; not yet implemented |
+| Open questions | None |
+| Next action | `impl i 2026-04-13__feat__zilin-bs-rubric-spec-types.md` |
+| Repos | `htu-foundation` (rubric + classifier) + `zi007lin/zai` (scoreSpec.ts + AppPage.tsx) |
+
+---
+
+## Files
+
+```
+htu-foundation/
+├── tools/zilin-bs/spec-rubric.yaml         ← v1.0.0 → v1.1.0
+├── tools/zilin-bs/classify-spec.ts         ← add type extraction + routing
+└── tools/zilin-bs/classify-spec.test.ts    ← add research/bug/chore test cases
+
+zi007lin/zai/
+├── src/lib/scoreSpec.ts                    ← add type detection + routing
+├── src/pages/AppPage.tsx                   ← pass file.name to scoreSpec()
+└── src/components/ScorePanel.tsx           ← dynamic denominator + type badge
+```

--- a/src/components/ScoreExample.tsx
+++ b/src/components/ScoreExample.tsx
@@ -1,4 +1,22 @@
-import { SECTION_LABELS, SECTION_ORDER } from "../lib/scoreSpec";
+const SECTION_LABELS: Record<string, string> = {
+  intent: "Intent",
+  decision_tree: "Decision Tree",
+  draft_of_thoughts: "Draft-of-thoughts",
+  final_spec: "Final Spec",
+  game_theory: "Game Theory Review",
+  migration_summary: "Subject Migration Summary",
+  files_list: "Files list",
+};
+
+const SECTION_ORDER: string[] = [
+  "intent",
+  "decision_tree",
+  "draft_of_thoughts",
+  "final_spec",
+  "game_theory",
+  "migration_summary",
+  "files_list",
+];
 
 const EXAMPLE = {
   filename: "2026-04-12__feat__zai-hero-tagline-governance.md",
@@ -30,7 +48,7 @@ const EXAMPLE = {
     game_theory: "PASS",
     migration_summary: "PASS",
     files_list: "PASS",
-  } as const,
+  } as Record<string, string>,
   score: "7/7",
   gates: ["ZZV Chain anchoring status before merge"],
 };

--- a/src/components/ScorePanel.tsx
+++ b/src/components/ScorePanel.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  type ScoreResult,
-  SECTION_LABELS,
-  SECTION_ORDER,
-  type SectionStatus,
-} from "../lib/scoreSpec";
+import { type ScoreResult, type SectionStatus } from "../lib/scoreSpec";
 
 interface Props {
   result: ScoreResult;
@@ -39,7 +34,8 @@ export default function ScorePanel({
   justCopied,
 }: Props) {
   const reducedMotion = useMemo(() => prefersReducedMotion(), []);
-  const totalSections = SECTION_ORDER.length;
+  const totalSections = result.section_order.length;
+  const denominator = result.required_count;
   const [revealed, setRevealed] = useState(reducedMotion ? totalSections : 0);
 
   useEffect(() => {
@@ -50,32 +46,40 @@ export default function ScorePanel({
     setRevealed(0);
     const timers: number[] = [];
     for (let i = 1; i <= totalSections; i++) {
-      timers.push(
-        window.setTimeout(() => setRevealed(i), i * STAGGER_MS)
-      );
+      timers.push(window.setTimeout(() => setRevealed(i), i * STAGGER_MS));
     }
     return () => timers.forEach((t) => window.clearTimeout(t));
   }, [result.evaluated_at, reducedMotion, totalSections]);
 
   const running = revealed < totalSections;
-  const passCountSoFar = SECTION_ORDER.slice(0, revealed).filter(
-    (k) => result.sections[k] === "PASS" || result.sections[k] === "SKIP"
+  const passCountSoFar = result.section_order
+    .slice(0, revealed)
+    .filter(
+      (k) => result.sections[k] === "PASS" || result.sections[k] === "SKIP"
+    ).length;
+  const failCount = result.section_order.filter(
+    (k) => result.sections[k] === "FAIL"
   ).length;
 
   const statusText = running
     ? "evaluating…"
     : result.passed
     ? "cleared to ship"
-    : `${SECTION_ORDER.filter((k) => result.sections[k] === "FAIL").length} sections failed`;
+    : `${failCount} sections failed`;
 
   const badge = running
     ? { text: "RUNNING", color: "var(--zai-amber)" }
     : result.passed
-    ? { text: `${passCountSoFar}/7 PASS`, color: "var(--zai-teal)" }
+    ? {
+        text: `${passCountSoFar}/${denominator} PASS`,
+        color: "var(--zai-teal)",
+      }
     : {
-        text: `${SECTION_ORDER.filter((k) => result.sections[k] === "FAIL").length}/7 FAIL`,
+        text: `${failCount}/${denominator} FAIL`,
         color: "#E15B5B",
       };
+
+  const typeLabel = result.spec_type.toUpperCase();
 
   return (
     <div
@@ -89,8 +93,20 @@ export default function ScorePanel({
     >
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <div className="text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
-            Spec score
+          <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-[var(--zai-muted)]">
+            <span>Spec score</span>
+            <span
+              className="px-2 py-0.5 rounded-full text-[10px]"
+              style={{
+                fontFamily: "var(--font-mono-zai)",
+                color: "var(--zai-purple)",
+                border: "1px solid var(--zai-purple)",
+                letterSpacing: "0.15em",
+              }}
+              data-testid="spec-type-badge"
+            >
+              {typeLabel}
+            </span>
           </div>
           <div
             className="mt-1 text-6xl sm:text-7xl"
@@ -102,7 +118,7 @@ export default function ScorePanel({
             }}
             data-testid="score-counter"
           >
-            {passCountSoFar}/7
+            {passCountSoFar}/{denominator}
           </div>
           <div className="mt-2 text-sm text-[var(--zai-muted)]">{statusText}</div>
         </div>
@@ -124,21 +140,22 @@ export default function ScorePanel({
       </div>
 
       <div className="mt-6 space-y-3">
-        {SECTION_ORDER.map((key, i) => {
+        {result.section_order.map((key, i) => {
           const status = result.sections[key];
           const isRevealed = i < revealed;
           const fill = isRevealed ? 100 : 0;
           return (
             <div
               key={key}
-              className="grid grid-cols-[1fr_auto] sm:grid-cols-[140px_1fr_auto] gap-3 items-center"
+              className="grid grid-cols-[1fr_auto] sm:grid-cols-[160px_1fr_auto] gap-3 items-center"
               data-testid={`section-${key}`}
             >
               <div
-                className="text-xs sm:text-sm text-neutral-300"
+                className="text-xs sm:text-sm text-neutral-300 truncate"
                 style={{ fontFamily: "var(--font-mono-zai)" }}
+                title={result.section_labels[key]}
               >
-                {SECTION_LABELS[key]}
+                {result.section_labels[key]}
               </div>
               <div className="hidden sm:block h-2 rounded-full bg-[var(--zai-border)] overflow-hidden">
                 <div

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { scoreSpec } from "./scoreSpec";
+import { scoreSpec, detectSpecType } from "./scoreSpec";
 
-const fullSpec = `# title
+// ─── feat fixture ─────────────────────────────────────────────────────────
+
+const featSpec = `# title
 
 ## Intent
 A tight paragraph describing the goal. About twenty words should be plenty.
@@ -41,97 +43,294 @@ src/foo.ts
 \`\`\`
 `;
 
-describe("scoreSpec", () => {
-  it("scores a fully compliant spec 7/7 passed", () => {
-    const r = scoreSpec(fullSpec);
-    expect(r.passed).toBe(true);
+// ─── research fixture ─────────────────────────────────────────────────────
+
+const researchSpec = `# research title
+
+## Intent
+Audit the thing to answer the open questions.
+
+## Research Questions
+
+### Q1 — one
+Details.
+
+### Q2 — two
+Details.
+
+## Acceptance Criteria
+- [ ] answered Q1
+- [ ] answered Q2
+- [ ] report saved to issues/reports/example.md
+
+## Report Format
+The report structure is documented here.
+
+## Subject Migration Summary
+| | |
+|---|---|
+| Open questions | list here |
+
+## Files
+\`\`\`
+issues/reports/example.md
+\`\`\`
+`;
+
+// ─── bug fixture ──────────────────────────────────────────────────────────
+
+const bugSpec = `# bug title
+
+## Intent
+Fix the thing that breaks.
+
+## Repro
+Steps to reproduce.
+
+## Fix
+Details.
+
+## Acceptance Criteria
+- [ ] one
+- [ ] two
+
+## Subject Migration Summary
+| | |
+|---|---|
+| Open questions | confirm regression |
+
+## Files
+\`\`\`
+src/foo.ts
+\`\`\`
+`;
+
+// ─── chore fixture ────────────────────────────────────────────────────────
+
+const choreSpec = `# chore title
+
+## Intent
+Bump dep.
+
+## Files
+\`\`\`
+package.json
+\`\`\`
+`;
+
+// ─── hotfix fixture ───────────────────────────────────────────────────────
+
+const hotfixSpec = `# hotfix title
+
+## Intent
+Urgent prod fix.
+
+## Fix
+Patch.
+
+## Acceptance Criteria
+- [ ] prod green
+- [ ] incident closed
+
+## Files
+\`\`\`
+src/foo.ts
+\`\`\`
+`;
+
+// ─── detectSpecType ───────────────────────────────────────────────────────
+
+describe("detectSpecType", () => {
+  it("extracts feat from filename prefix", () => {
+    expect(detectSpecType("2026-04-13__feat__title.md")).toBe("feat");
+  });
+  it("extracts research, bug, chore, hotfix", () => {
+    expect(detectSpecType("2026-04-13__research__x.md")).toBe("research");
+    expect(detectSpecType("2026-04-13__bug__x.md")).toBe("bug");
+    expect(detectSpecType("2026-04-13__chore__x.md")).toBe("chore");
+    expect(detectSpecType("2026-04-13__hotfix__x.md")).toBe("hotfix");
+  });
+  it("normalizes feature → feat and refactor → chore", () => {
+    expect(detectSpecType("2026-04-13__feature__x.md")).toBe("feat");
+    expect(detectSpecType("2026-04-13__refactor__x.md")).toBe("chore");
+  });
+  it("defaults unknown or missing type to feat", () => {
+    expect(detectSpecType("2026-04-13__wat__x.md")).toBe("feat");
+    expect(detectSpecType("random.md")).toBe("feat");
+    expect(detectSpecType("")).toBe("feat");
+  });
+  it("strips directory components from the path", () => {
+    expect(detectSpecType("issues/2026-04-13__research__x.md")).toBe("research");
+    expect(detectSpecType("/abs/path/2026-04-13__bug__x.md")).toBe("bug");
+  });
+});
+
+// ─── scoreSpec — feat ─────────────────────────────────────────────────────
+
+describe("scoreSpec — feat", () => {
+  it("scores a compliant feat spec 7/7 passed", () => {
+    const r = scoreSpec(featSpec, "2026-04-12__feat__example.md");
+    expect(r.spec_type).toBe("feat");
+    expect(r.required_count).toBe(7);
     expect(r.score).toBe("7/7");
-    expect(r.sections.intent).toBe("PASS");
-    expect(r.sections.decision_tree).toBe("PASS");
+    expect(r.passed).toBe(true);
     expect(r.sections.draft_of_thoughts).toBe("PASS");
-    expect(r.sections.final_spec).toBe("PASS");
-    expect(r.sections.game_theory).toBe("PASS");
-    expect(r.sections.migration_summary).toBe("PASS");
-    expect(r.sections.files_list).toBe("PASS");
-    expect(r.rubric_version).toBe("1.0.0");
   });
 
-  it("intent FAILs when body is empty", () => {
-    const md = fullSpec.replace(
+  it("intent FAILs on empty body", () => {
+    const md = featSpec.replace(
       /## Intent\nA tight paragraph[^\n]*\n/,
       "## Intent\n\n"
     );
-    expect(scoreSpec(md).sections.intent).toBe("FAIL");
+    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.intent).toBe("FAIL");
   });
 
   it("intent FAILs when body exceeds 150 words", () => {
     const long = "word ".repeat(200);
     const md = `## Intent\n${long}\n\n## Next\n`;
-    expect(scoreSpec(md).sections.intent).toBe("FAIL");
+    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.intent).toBe("FAIL");
   });
 
   it("decision_tree FAILs without a table", () => {
-    const md = fullSpec.replace(
+    const md = featSpec.replace(
       /\| Option \| Risk \| Decision \|\n\|---\|---\|---\|\n\| A \| low \| ✅ \|\n/,
       ""
     );
-    expect(scoreSpec(md).sections.decision_tree).toBe("FAIL");
+    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.decision_tree).toBe("FAIL");
   });
 
-  it("decision_tree FAILs without 'Trigger for change'", () => {
-    const md = fullSpec.replace(/Trigger for change[^\n]*\n/, "");
-    expect(scoreSpec(md).sections.decision_tree).toBe("FAIL");
-  });
-
-  it("draft_of_thoughts SKIPs when heading absent (never FAIL)", () => {
-    const md = fullSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
-    const r = scoreSpec(md);
+  it("draft_of_thoughts SKIPs when absent (never FAIL)", () => {
+    const md = featSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.draft_of_thoughts).toBe("SKIP");
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe("7/7");
+  });
+
+  it("final_spec FAILs with fewer than 3 acceptance checkboxes", () => {
+    const md = featSpec.replace(
+      /- \[ \] one\n- \[ \] two\n- \[ \] three\n/,
+      "- [ ] one\n- [ ] two\n"
+    );
+    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.final_spec).toBe("FAIL");
+  });
+
+  it("game_theory FAILs when Mitigation is missing", () => {
+    const md = featSpec.replace(/Mitigation:[^\n]*\n/, "");
+    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.game_theory).toBe("FAIL");
+  });
+});
+
+// ─── scoreSpec — research ─────────────────────────────────────────────────
+
+describe("scoreSpec — research", () => {
+  it("scores a compliant research spec 6/6 passed", () => {
+    const r = scoreSpec(researchSpec, "2026-04-13__research__example.md");
+    expect(r.spec_type).toBe("research");
+    expect(r.required_count).toBe(6);
+    expect(r.score).toBe("6/6");
+    expect(r.passed).toBe(true);
+    expect(r.sections.research_questions).toBe("PASS");
+    expect(r.sections.report_format).toBe("PASS");
+    expect("decision_tree" in r.sections).toBe(false);
+    expect("game_theory" in r.sections).toBe(false);
+  });
+
+  it("research_questions FAILs without at least one subheading", () => {
+    const md = researchSpec.replace(/### Q1[\s\S]*?### Q2[^\n]*\n/, "");
+    const r = scoreSpec(md, "2026-04-13__research__x.md");
+    expect(r.sections.research_questions).toBe("FAIL");
+  });
+
+  it("acceptance_criteria FAILs without 'report saved' phrase", () => {
+    const md = researchSpec.replace(
+      /- \[ \] report saved[^\n]*\n/,
+      "- [ ] something else\n"
+    );
+    const r = scoreSpec(md, "2026-04-13__research__x.md");
+    expect(r.sections.acceptance_criteria).toBe("FAIL");
+  });
+
+  it("report_format FAILs when heading absent", () => {
+    const md = researchSpec.replace(/## Report Format\n[\s\S]*?(?=## )/, "");
+    const r = scoreSpec(md, "2026-04-13__research__x.md");
+    expect(r.sections.report_format).toBe("FAIL");
+  });
+});
+
+// ─── scoreSpec — bug ──────────────────────────────────────────────────────
+
+describe("scoreSpec — bug", () => {
+  it("scores a compliant bug spec 5/5 passed", () => {
+    const r = scoreSpec(bugSpec, "2026-04-13__bug__example.md");
+    expect(r.spec_type).toBe("bug");
+    expect(r.required_count).toBe(5);
+    expect(r.score).toBe("5/5");
     expect(r.passed).toBe(true);
   });
 
-  it("final_spec FAILs when acceptance criteria has fewer than 3 checkboxes", () => {
-    const md = fullSpec.replace(
-      /## Acceptance Criteria\n- \[ \] one\n- \[ \] two\n- \[ \] three\n/,
-      "## Acceptance Criteria\n- [ ] one\n- [ ] two\n"
+  it("fix section FAILs with fewer than 2 acceptance checkboxes", () => {
+    const md = bugSpec.replace(/- \[ \] one\n- \[ \] two\n/, "- [ ] one\n");
+    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.fix).toBe("FAIL");
+  });
+
+  it("reproduction_steps FAILs without ## Repro heading", () => {
+    const md = bugSpec.replace(/## Repro[\s\S]*?(?=## )/, "");
+    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.reproduction_steps).toBe(
+      "FAIL"
     );
-    expect(scoreSpec(md).sections.final_spec).toBe("FAIL");
+  });
+});
+
+// ─── scoreSpec — chore ────────────────────────────────────────────────────
+
+describe("scoreSpec — chore", () => {
+  it("scores a compliant chore spec 2/2 passed", () => {
+    const r = scoreSpec(choreSpec, "2026-04-13__chore__example.md");
+    expect(r.spec_type).toBe("chore");
+    expect(r.required_count).toBe(2);
+    expect(r.score).toBe("2/2");
+    expect(r.passed).toBe(true);
+    expect("decision_tree" in r.sections).toBe(false);
   });
 
-  it("game_theory FAILs when any required phrase missing", () => {
-    const md = fullSpec.replace(/Mitigation:[^\n]*\n/, "");
-    expect(scoreSpec(md).sections.game_theory).toBe("FAIL");
+  it("refactor alias routes to chore", () => {
+    const r = scoreSpec(choreSpec, "2026-04-13__refactor__example.md");
+    expect(r.spec_type).toBe("chore");
+    expect(r.score).toBe("2/2");
   });
+});
 
-  it("migration_summary FAILs when Open questions value is empty", () => {
-    const md = fullSpec.replace(
-      /\| Open questions \| confirm name \|/,
-      "| Open questions |  |"
-    );
-    expect(scoreSpec(md).sections.migration_summary).toBe("FAIL");
+// ─── scoreSpec — hotfix ───────────────────────────────────────────────────
+
+describe("scoreSpec — hotfix", () => {
+  it("scores a compliant hotfix spec 3/3 passed", () => {
+    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
+    expect(r.spec_type).toBe("hotfix");
+    expect(r.required_count).toBe(3);
+    expect(r.score).toBe("3/3");
+    expect(r.passed).toBe(true);
   });
+});
 
-  it("files_list FAILs without a fenced code block", () => {
-    const md = fullSpec.replace(/## Files[\s\S]*$/, "## Files\nsrc/foo.ts\n");
-    expect(scoreSpec(md).sections.files_list).toBe("FAIL");
-  });
+// ─── gates + meta ─────────────────────────────────────────────────────────
 
-  it("extracts Pre-deploy gates from checkboxes", () => {
-    const md = `${fullSpec}\n- [ ] **Pre-deploy gate:** confirm chain status\n- [ ] **Pre-deploy gate** accent color confirmed`;
-    const r = scoreSpec(md);
+describe("scoreSpec — gates and meta", () => {
+  it("extracts multiple Pre-deploy gates from checkboxes", () => {
+    const md = `${featSpec}\n- [ ] **Pre-deploy gate:** confirm chain status\n- [ ] **Pre-deploy gate** accent color confirmed`;
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.gates.length).toBe(2);
     expect(r.gates[0]).toMatch(/chain/i);
   });
 
-  it("score string reflects PASS + SKIP count (never penalizes SKIP)", () => {
-    const md = fullSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
-    expect(scoreSpec(md).score).toBe("7/7");
+  it("rubric version is 1.1.0", () => {
+    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.1.0");
   });
 
-  it("non-spec markdown scores near zero without crashing", () => {
-    const r = scoreSpec("# README\n\nJust a readme, no sections.\n");
+  it("non-spec markdown falls back to feat and fails gracefully", () => {
+    const r = scoreSpec("# README\n\nJust a readme.\n", "README.md");
+    expect(r.spec_type).toBe("feat");
+    expect(r.required_count).toBe(7);
     expect(r.passed).toBe(false);
-    expect(r.sections.intent).toBe("FAIL");
-    expect(r.sections.decision_tree).toBe("FAIL");
   });
 });

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -1,98 +1,238 @@
 export type SectionStatus = "PASS" | "FAIL" | "SKIP";
 
-export type SectionKey =
-  | "intent"
-  | "decision_tree"
-  | "draft_of_thoughts"
-  | "final_spec"
-  | "game_theory"
-  | "migration_summary"
-  | "files_list";
+export type SpecType = "feat" | "research" | "bug" | "chore" | "hotfix";
 
 export interface ScoreResult {
   rubric_version: string;
+  spec_type: SpecType;
   score: string;
+  required_count: number;
   passed: boolean;
   evaluated_at: string;
-  sections: Record<SectionKey, SectionStatus>;
+  sections: Record<string, SectionStatus>;
+  section_order: string[];
+  section_labels: Record<string, string>;
   gates: string[];
 }
 
-const RUBRIC_VERSION = "1.0.0";
+const RUBRIC_VERSION = "1.1.0";
 
-const HEADING_PATTERNS: Record<SectionKey, RegExp> = {
-  intent: /^##\s+Intent\b/mi,
-  decision_tree: /^##\s+Decision\s+Tree\b/mi,
-  draft_of_thoughts: /^##\s+Draft[-\s]of[-\s]thoughts\b/mi,
-  final_spec: /^##\s+Final\s+Spec\b/mi,
-  game_theory: /^##\s+Game\s+Theory(\s+Review)?\b/mi,
-  migration_summary: /^##\s+Subject\s+Migration\s+Summary\b/mi,
-  files_list: /^##\s+Files\b/mi,
-};
+// ─── helpers ──────────────────────────────────────────────────────────────
 
-function sectionBody(markdown: string, key: SectionKey): string {
-  const start = markdown.search(HEADING_PATTERNS[key]);
+function sectionBody(markdown: string, headingPattern: RegExp): string {
+  const start = markdown.search(headingPattern);
   if (start === -1) return "";
-  const afterHeading = markdown.slice(start).replace(HEADING_PATTERNS[key], "");
+  const afterHeading = markdown.slice(start).replace(headingPattern, "");
   const nextHeading = afterHeading.search(/^##\s+/m);
   return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
 }
 
-function checkIntent(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "intent");
-  if (!body.trim()) return "FAIL";
-  const words = body.trim().split(/\s+/).filter(Boolean).length;
+function headingPresent(markdown: string, pattern: RegExp): boolean {
+  return pattern.test(markdown);
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function tablePresent(body: string): boolean {
+  return /\|.*\|.*\n\|[\s-:|]+\|/.test(body);
+}
+
+function codeBlockPresent(body: string): boolean {
+  return /```[\s\S]*?```/.test(body);
+}
+
+function checkboxCount(body: string): number {
+  return (body.match(/^- \[[ xX]\]/gm) || []).length;
+}
+
+function subheadingCount(body: string): number {
+  return (body.match(/^###\s+/gm) || []).length;
+}
+
+function openQuestionsNotEmpty(body: string): boolean {
+  const row = body.match(/\|\s*Open\s+questions\s*\|([^|\n]*)\|/i);
+  if (!row) return false;
+  return row[1].trim().length > 0;
+}
+
+function acceptanceCriteriaCheckboxes(markdown: string): number {
+  const heading = /^##\s+Acceptance\s+Criteria\b/mi;
+  const start = markdown.search(heading);
+  if (start === -1) return 0;
+  const body = markdown.slice(start).replace(heading, "");
+  const nextHeading = body.search(/^##\s+/m);
+  const slice = nextHeading === -1 ? body : body.slice(0, nextHeading);
+  return checkboxCount(slice);
+}
+
+// ─── section checks ───────────────────────────────────────────────────────
+
+const INTENT_HEADING = /^##\s+Intent\b/mi;
+const DECISION_TREE_HEADING = /^##\s+Decision\s+Tree\b/mi;
+const DRAFT_HEADING = /^##\s+Draft[-\s]of[-\s]thoughts\b/mi;
+const FINAL_SPEC_HEADING = /^##\s+Final\s+Spec\b/mi;
+const GAME_THEORY_HEADING = /^##\s+Game\s+Theory(\s+Review)?\b/mi;
+const MIGRATION_HEADING = /^##\s+Subject\s+Migration\s+Summary\b/mi;
+const FILES_HEADING = /^##\s+Files\b/mi;
+const RESEARCH_QUESTIONS_HEADING = /^##\s+Research\s+Questions\b/mi;
+const ACCEPTANCE_CRITERIA_HEADING = /^##\s+Acceptance\s+Criteria\b/mi;
+const REPORT_FORMAT_HEADING = /^##\s+Report\s+Format\b/mi;
+const REPRO_HEADING = /^##\s+Repro(duction)?(\s+Steps)?\b/mi;
+const FIX_HEADING = /^##\s+Fix\b/mi;
+
+function checkIntentStrict(md: string): SectionStatus {
+  if (!headingPresent(md, INTENT_HEADING)) return "FAIL";
+  const body = sectionBody(md, INTENT_HEADING);
+  const words = wordCount(body);
   return words > 0 && words <= 150 ? "PASS" : "FAIL";
 }
 
-function checkDecisionTree(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "decision_tree");
-  if (!body.trim()) return "FAIL";
-  const hasTable = /\|.*\|.*\n\|[\s-:|]+\|/.test(body);
+function checkIntentLoose(md: string): SectionStatus {
+  return headingPresent(md, INTENT_HEADING) ? "PASS" : "FAIL";
+}
+
+function checkDecisionTree(md: string): SectionStatus {
+  if (!headingPresent(md, DECISION_TREE_HEADING)) return "FAIL";
+  const body = sectionBody(md, DECISION_TREE_HEADING);
+  const hasTable = tablePresent(body);
   const hasTrigger = /trigger\s+for\s+change/i.test(body);
   return hasTable && hasTrigger ? "PASS" : "FAIL";
 }
 
-function checkDraftOfThoughts(markdown: string): SectionStatus {
-  return HEADING_PATTERNS.draft_of_thoughts.test(markdown) ? "PASS" : "SKIP";
+function checkDraftOfThoughts(md: string): SectionStatus {
+  return headingPresent(md, DRAFT_HEADING) ? "PASS" : "SKIP";
 }
 
-function checkFinalSpec(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "final_spec");
-  if (!body.trim()) return "FAIL";
-  const hasAC = /^##\s+Acceptance\s+Criteria\b/mi.test(markdown);
-  if (!hasAC) return "FAIL";
-  const acStart = markdown.search(/^##\s+Acceptance\s+Criteria\b/mi);
-  const acBody = markdown.slice(acStart).replace(/^##\s+Acceptance\s+Criteria\b/mi, "");
-  const nextHeading = acBody.search(/^##\s+/m);
-  const acSlice = nextHeading === -1 ? acBody : acBody.slice(0, nextHeading);
-  const checkboxes = (acSlice.match(/^- \[[ xX]\]/gm) || []).length;
-  return checkboxes >= 3 ? "PASS" : "FAIL";
+function checkFinalSpec(md: string): SectionStatus {
+  if (!headingPresent(md, FINAL_SPEC_HEADING)) return "FAIL";
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
+  return acceptanceCriteriaCheckboxes(md) >= 3 ? "PASS" : "FAIL";
 }
 
-function checkGameTheory(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "game_theory");
-  if (!body.trim()) return "FAIL";
-  const hasBenefits = /who\s+benefits/i.test(body);
-  const hasAbuse = /abuse\s+vector/i.test(body);
-  const hasMitigation = /mitigation/i.test(body);
-  return hasBenefits && hasAbuse && hasMitigation ? "PASS" : "FAIL";
+function checkGameTheory(md: string): SectionStatus {
+  if (!headingPresent(md, GAME_THEORY_HEADING)) return "FAIL";
+  const body = sectionBody(md, GAME_THEORY_HEADING);
+  const ok =
+    /who\s+benefits/i.test(body) &&
+    /abuse\s+vector/i.test(body) &&
+    /mitigation/i.test(body);
+  return ok ? "PASS" : "FAIL";
 }
 
-function checkMigrationSummary(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "migration_summary");
-  if (!body.trim()) return "FAIL";
-  const openRow = body.match(/\|\s*Open\s+questions\s*\|([^|\n]*)\|/i);
-  if (!openRow) return "FAIL";
-  const value = openRow[1].trim();
-  return value.length > 0 ? "PASS" : "FAIL";
+function checkMigrationSummary(md: string): SectionStatus {
+  if (!headingPresent(md, MIGRATION_HEADING)) return "FAIL";
+  const body = sectionBody(md, MIGRATION_HEADING);
+  return openQuestionsNotEmpty(body) ? "PASS" : "FAIL";
 }
 
-function checkFilesList(markdown: string): SectionStatus {
-  const body = sectionBody(markdown, "files_list");
-  if (!body.trim()) return "FAIL";
-  return /```[\s\S]*?```/.test(body) ? "PASS" : "FAIL";
+function checkFilesList(md: string): SectionStatus {
+  if (!headingPresent(md, FILES_HEADING)) return "FAIL";
+  return codeBlockPresent(sectionBody(md, FILES_HEADING)) ? "PASS" : "FAIL";
 }
+
+function checkResearchQuestions(md: string): SectionStatus {
+  if (!headingPresent(md, RESEARCH_QUESTIONS_HEADING)) return "FAIL";
+  return subheadingCount(sectionBody(md, RESEARCH_QUESTIONS_HEADING)) >= 1
+    ? "PASS"
+    : "FAIL";
+}
+
+function checkAcceptanceCriteriaResearch(md: string): SectionStatus {
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
+  if (acceptanceCriteriaCheckboxes(md) < 3) return "FAIL";
+  return /report\s+saved/i.test(md) ? "PASS" : "FAIL";
+}
+
+function checkReportFormat(md: string): SectionStatus {
+  return headingPresent(md, REPORT_FORMAT_HEADING) ? "PASS" : "FAIL";
+}
+
+function checkReproSteps(md: string): SectionStatus {
+  return headingPresent(md, REPRO_HEADING) ? "PASS" : "FAIL";
+}
+
+function checkBugFixSection(md: string): SectionStatus {
+  if (!headingPresent(md, FIX_HEADING)) return "FAIL";
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
+  return acceptanceCriteriaCheckboxes(md) >= 2 ? "PASS" : "FAIL";
+}
+
+function checkMigrationSummaryBug(md: string): SectionStatus {
+  if (!headingPresent(md, MIGRATION_HEADING)) return "FAIL";
+  const body = sectionBody(md, MIGRATION_HEADING);
+  return openQuestionsNotEmpty(body) ? "PASS" : "FAIL";
+}
+
+// ─── section definitions per spec type ────────────────────────────────────
+
+interface SectionDef {
+  key: string;
+  label: string;
+  check: (md: string) => SectionStatus;
+}
+
+const FEAT_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentStrict },
+  { key: "decision_tree", label: "Decision Tree", check: checkDecisionTree },
+  { key: "draft_of_thoughts", label: "Draft-of-thoughts", check: checkDraftOfThoughts },
+  { key: "final_spec", label: "Final Spec", check: checkFinalSpec },
+  { key: "game_theory", label: "Game Theory Review", check: checkGameTheory },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
+  { key: "files_list", label: "Files list", check: checkFilesList },
+];
+
+const RESEARCH_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentStrict },
+  { key: "research_questions", label: "Research Questions", check: checkResearchQuestions },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: checkAcceptanceCriteriaResearch },
+  { key: "report_format", label: "Report Format", check: checkReportFormat },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
+  { key: "files_list", label: "Files list", check: checkFilesList },
+];
+
+const BUG_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentLoose },
+  { key: "reproduction_steps", label: "Reproduction Steps", check: checkReproSteps },
+  { key: "fix", label: "Fix", check: checkBugFixSection },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummaryBug },
+  { key: "files_list", label: "Files list", check: checkFilesList },
+];
+
+const CHORE_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentLoose },
+  { key: "files_list", label: "Files list", check: checkFilesList },
+];
+
+const HOTFIX_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentLoose },
+  { key: "fix", label: "Fix", check: checkBugFixSection },
+  { key: "files_list", label: "Files list", check: checkFilesList },
+];
+
+const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {
+  feat: FEAT_SECTIONS,
+  research: RESEARCH_SECTIONS,
+  bug: BUG_SECTIONS,
+  chore: CHORE_SECTIONS,
+  hotfix: HOTFIX_SECTIONS,
+};
+
+// ─── type detection ───────────────────────────────────────────────────────
+
+const KNOWN_TYPES: SpecType[] = ["feat", "research", "bug", "chore", "hotfix"];
+
+export function detectSpecType(filename: string): SpecType {
+  const basename = filename.split(/[\\/]/).pop() || filename;
+  const match = basename.match(/^\d{4}-\d{2}-\d{2}__(\w+)__/);
+  const raw = match?.[1]?.toLowerCase() ?? "feat";
+  if (raw === "feature") return "feat";
+  if (raw === "refactor") return "chore";
+  return (KNOWN_TYPES as string[]).includes(raw) ? (raw as SpecType) : "feat";
+}
+
+// ─── gate extraction ──────────────────────────────────────────────────────
 
 function extractGates(markdown: string): string[] {
   const lines = markdown.split(/\r?\n/);
@@ -100,53 +240,43 @@ function extractGates(markdown: string): string[] {
   const re = /- \[[ xX]\]\s+\*\*Pre-deploy gate[:\s*]*\*?\s*(.+)$/i;
   for (const line of lines) {
     const m = line.match(re);
-    if (m) {
-      gates.push(m[1].trim().replace(/\*+$/, "").trim());
-    }
+    if (m) gates.push(m[1].trim().replace(/\*+$/, "").trim());
   }
   return gates;
 }
 
-export function scoreSpec(markdown: string): ScoreResult {
-  const sections: Record<SectionKey, SectionStatus> = {
-    intent: checkIntent(markdown),
-    decision_tree: checkDecisionTree(markdown),
-    draft_of_thoughts: checkDraftOfThoughts(markdown),
-    final_spec: checkFinalSpec(markdown),
-    game_theory: checkGameTheory(markdown),
-    migration_summary: checkMigrationSummary(markdown),
-    files_list: checkFilesList(markdown),
-  };
-  const gates = extractGates(markdown);
-  const passCount = Object.values(sections).filter((s) => s === "PASS").length;
-  const skipCount = Object.values(sections).filter((s) => s === "SKIP").length;
+// ─── entry point ──────────────────────────────────────────────────────────
+
+export function scoreSpec(markdown: string, filename: string = ""): ScoreResult {
+  const specType = detectSpecType(filename);
+  const defs = SECTIONS_BY_TYPE[specType];
+
+  const sections: Record<string, SectionStatus> = {};
+  const section_labels: Record<string, string> = {};
+  const section_order: string[] = [];
+  for (const def of defs) {
+    sections[def.key] = def.check(markdown);
+    section_labels[def.key] = def.label;
+    section_order.push(def.key);
+  }
+
+  const required_count = defs.length;
+  const passOrSkip = Object.values(sections).filter(
+    (s) => s === "PASS" || s === "SKIP"
+  ).length;
   const passed = Object.values(sections).every((s) => s !== "FAIL");
+  const gates = extractGates(markdown);
+
   return {
     rubric_version: RUBRIC_VERSION,
-    score: `${passCount + skipCount}/7`,
+    spec_type: specType,
+    score: `${passOrSkip}/${required_count}`,
+    required_count,
     passed,
     evaluated_at: new Date().toISOString(),
     sections,
+    section_order,
+    section_labels,
     gates,
   };
 }
-
-export const SECTION_LABELS: Record<SectionKey, string> = {
-  intent: "Intent",
-  decision_tree: "Decision Tree",
-  draft_of_thoughts: "Draft-of-thoughts",
-  final_spec: "Final Spec",
-  game_theory: "Game Theory Review",
-  migration_summary: "Subject Migration Summary",
-  files_list: "Files list",
-};
-
-export const SECTION_ORDER: SectionKey[] = [
-  "intent",
-  "decision_tree",
-  "draft_of_thoughts",
-  "final_spec",
-  "game_theory",
-  "migration_summary",
-  "files_list",
-];

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -31,6 +31,7 @@ function buildScoredSpec(
   lines.push("## ZAI Spec Score");
   lines.push("");
   lines.push(`- **Rubric version:** ${result.rubric_version}`);
+  lines.push(`- **Spec type:** ${result.spec_type}`);
   lines.push(`- **Evaluated at:** ${result.evaluated_at}`);
   lines.push(`- **Score:** ${result.score}`);
   lines.push(`- **Passed:** ${result.passed ? "YES" : "NO"}`);
@@ -60,7 +61,7 @@ export default function AppPage() {
   const handleFile = useCallback((name: string, contents: string) => {
     setFilename(name);
     setMarkdown(contents);
-    setResult(scoreSpec(contents));
+    setResult(scoreSpec(contents, name));
   }, []);
 
   const handleDownloadTemplate = useCallback(() => {


### PR DESCRIPTION
## Summary

Client-side half of \`2026-04-13__feat__zilin-bs-rubric-spec-types.md\`. Makes the ZAI \`/app\` scorer rubric type-aware: \`feat\` / \`research\` / \`bug\` / \`chore\` / \`hotfix\` each get their own section list and denominator. Fixes false FAILs on research and chore specs that were previously judged by the feat rubric.

Rubric version bumped to **v1.1.0**.

## Scope (Path A — zai only)

The issue spans two repos. The \`htu-foundation\` half (\`tools/zilin-bs/spec-rubric.yaml\`, \`classify-spec.ts\`, \`classify-spec.test.ts\`, README) is **deferred** — that directory does not exist in \`htu-foundation\` and the prereq spec (\`2026-04-12__feat__zilin-bs-classify-command.md\`) has never been implemented there. There is no v1.0.0 to bump. A follow-up spec will scaffold the \`tools/zilin-bs/\` tree from scratch.

Acceptance criteria rows 1, 2, 3, and 14 are explicitly left for that follow-up. All other rows are hit in this PR.

## Type detection

\`detectSpecType(filename)\` reads the \`YYYY-MM-DD__TYPE__title.md\` prefix from the basename, strips any directory components, normalizes aliases (\`feature\` → \`feat\`, \`refactor\` → \`chore\`), and falls back to \`feat\` for unknown or missing types.

## Per-type section tables

| Type | Sections | Denominator |
|---|---|---|
| **feat** | intent, decision tree, draft-of-thoughts (SKIPable), final spec, game theory, migration summary, files list | **7** |
| **research** | intent, research questions, acceptance criteria, report format, migration summary, files list | **6** |
| **bug** | intent, reproduction steps, fix (w/ ≥ 2 AC boxes), migration summary, files list | **5** |
| **chore** | intent, files list | **2** |
| **hotfix** | intent, fix (w/ ≥ 2 AC boxes), files list | **3** |

## Acceptance fixtures verified

Ran both explicit acceptance fixtures through \`scoreSpec()\` end-to-end:

| File | Result |
|---|---|
| \`2026-04-13__research__zai-app-readme-homepage-alignment.md\` | **6/6 PASS** |
| \`2026-04-12__feat__zai-hero-tagline-governance.md\` | **7/7 PASS** (with gate "confirm ZZV Chain anchoring status…" extracted) |

## UI changes

- **\`ScorePanel\`**: small purple type badge next to "Spec score" reading \`FEAT\` / \`RESEARCH\` / \`BUG\` / \`CHORE\` / \`HOTFIX\`. Counter is now \`N/{denominator}\` (not hardcoded \`/7\`). Section list renders from \`result.section_order\` / \`result.section_labels\` — no hardcoded identities. Wider 160px label column to fit "Reproduction Steps" without truncation.
- **\`ScoreResult\`** now exposes \`spec_type\`, \`required_count\`, \`section_order\`, \`section_labels\` alongside the existing fields.
- **\`AppPage\`**: passes \`file.name\` into \`scoreSpec()\`; the downloaded scored spec gains a \`**Spec type**\` row in the appended score block.
- **\`ScoreExample\`**: keeps its hardcoded governance-tagline example (still a feat) and inlines its own copy of the label/order constants now that \`scoreSpec.ts\` no longer exports them.

## Tests

- \`npm run test\` — **25 / 25** unit tests (was 13). New coverage: \`detectSpecType\` (6 cases), research (4), bug (3), chore (2), hotfix (1), meta (3), plus the 6 existing feat regressions.
- \`npm run test:e2e\` — **18 / 18** Playwright tests still pass unchanged.
- \`npm run build\` — ✅ (225 kB JS / 22 kB CSS).

## Spec deviations called out

The spec's YAML block lists \`draft_of_thoughts\` as an optional section under \`research\`, \`bug\`, etc. But the acceptance target for research is explicitly **6/6**, and the chore target is **2/2**. The only consistent interpretation is that non-feat types don't evaluate \`draft_of_thoughts\` at all — it's a feat-only section. That's what this PR implements. If you'd rather have \`draft_of_thoughts\` evaluated as optional (and just not in the denominator), say the word and I'll refactor.

## Acceptance criteria

- [ ] ~~\`spec-rubric.yaml\` bumped to v1.1.0 with \`spec_types\` map~~ **(deferred — htu-foundation)**
- [ ] ~~\`classify-spec.ts\` extracts type from filename~~ **(deferred — htu-foundation)**
- [ ] ~~Unknown/aliased types normalize correctly in classify-spec.ts~~ **(deferred — implemented on zai side; criterion targets htu-foundation)**
- [x] Research fixture scores 6/6 PASS
- [x] Feat governance-tagline fixture still scores 7/7 PASS
- [x] Chore spec scores 2/2 PASS
- [x] Score block (downloaded) includes \`spec_type\` row
- [x] Score denominator is dynamic (not hardcoded 7)
- [x] \`src/lib/scoreSpec.ts\` updated to match v1.1.0 type routing
- [x] \`AppPage.tsx\` passes \`file.name\` to \`scoreSpec()\`
- [x] Score panel shows type badge
- [x] Score panel denominator updates correctly per type
- [x] Unit tests updated — research, bug, chore, hotfix type cases added
- [x] 18/18 e2e tests still pass
- [ ] ~~\`README.md\` in \`tools/zilin-bs/\` updated~~ **(deferred — htu-foundation)**

Reviewer: daniel-silvers