### PR TITLE
docs: README P1 alignment fixes — sync tagline, surface /app, scope chain claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZAI — Zero Ambiguity Intelligence
 
-**The engine of Spec Driven Development (SDD) by [High Tech United](https://htu.io).**
+**ZAI gives you governance, not guardrails — a complete audit trail from human intent to deployed code, with nothing lost in translation. By [High Tech United](https://htu.io).**
 
 <div align="center">
   <a href="https://htu.io"><img src="https://htu.io/logo.png" width="600" alt="ZAI by High Tech United"/></a>
@@ -29,6 +29,12 @@ Intent  →  Spec  →  Eval  →  Impl  →  Review  →  Deploy  →  ZZV Chai
 ```
 
 Each stage has a command: `spec`, `eval`, `impl`, `review`, `deploy`, `autopilot`. Outputs from one stage feed cleanly into the next. Nothing is lost between brain and branch.
+
+---
+
+## Try the scorer
+
+The first piece of the SDD pipeline is live as a web scorer at **[dev.zai.htu.io/app](https://dev.zai.htu.io/app)**. Drop any `.md` spec file into the upload zone and you'll get a deterministic, type-aware score — `feat` 7/7, `research` 6/6, `bug` 5/5, `chore` 2/2, or `hotfix` 3/3 — with a per-section breakdown and any pre-deploy gates the spec declares. Pure structural analysis, no LLM judgment; human review still required.
 
 ---
 
@@ -117,7 +123,7 @@ RGB is the universal status language — humans and agents read the same signals
 
 ## ZZV Chain
 
-Every merged PR, every deploy, every spec revision is anchored to the **ZZV Chain** — an append-only record that makes the SDD pipeline auditable end-to-end. When a regulator, a reviewer, or a future-you asks *"why does this code exist?"*, the chain has the answer: the spec, the eval, the reviewer, the deploy, the intent.
+Every merged PR, every deploy, every spec revision is *designed* to be anchored to the **ZZV Chain** — an append-only record that makes the SDD pipeline auditable end-to-end. Today, the spec→PR audit trail is live and verifiable via the ZiLin Command workflow (branch → impl → tests → PR → dual-control merge), and every artifact is recoverable from git. On-chain cryptographic anchoring ships with the Enterprise edition. When a regulator, a reviewer, or a future-you asks *"why does this code exist?"*, the chain will have the answer: the spec, the eval, the reviewer, the deploy, the intent.
 
 Learn more at [zzv.io](https://zzv.io).
 


### PR DESCRIPTION
## Summary

Follow-up to the alignment audit in PR #17 (research report at \`issues/reports/2026-04-13__research__zai-app-readme-homepage-alignment.md\`). Ships the three **P1** items so README, Home, and /app tell the same story for demo promotion. **No P2 items** in this PR.

| # | P1 item | Target | Change |
|---|---|---|---|
| 1 | Tagline sync | \`README.md:3\` | Replace pre-PR-#13 "engine of Spec Driven Development" with the governance-positioning line already on Home |
| 2 | Surface /app | After "What is SDD?" | New "Try the scorer" section linking \`https://dev.zai.htu.io/app\` with a 2-sentence how-to |
| 3 | Scope chain claim | \`README.md\` ZZV Chain section | Soften present-tense anchoring claim to future/scoped; name what's live today (ZiLin Command workflow) vs what ships with Enterprise |

## Diff summary

\`\`\`
README.md | 10 ++++++++--
1 file changed, 8 insertions(+), 2 deletions(-)
\`\`\`

One file, three targeted edits. No code, no tests, no infra.

## P1.1 — Tagline sync

**Before:**
> **The engine of Spec Driven Development (SDD) by [High Tech United](https://htu.io).**

**After:**
> **ZAI gives you governance, not guardrails — a complete audit trail from human intent to deployed code, with nothing lost in translation. By [High Tech United](https://htu.io).**

Matches \`src/locales/en.json::hero.title\` phrasing. A demo attendee who reads README then hits \`/\` now sees one consistent message instead of two generations of positioning.

## P1.2 — "Try the scorer" section

New section inserted between **What is SDD?** and **ZAI Architecture**. Contains:

- Link to \`https://dev.zai.htu.io/app\`
- 2-sentence how-to (drop a \`.md\` spec, get a deterministic score)
- Explicit denominator table for every spec type (feat 7/7, research 6/6, bug 5/5, chore 2/2, hotfix 3/3) so the claim stays accurate against rubric v1.1.0 shipped in PR #16
- "No LLM judgment; human review still required" — echoes the framing in \`AppPage.tsx\` so Home, /app, and README all say the same thing about the scorer's guarantees

## P1.3 — ZZV Chain claim softened

**Before:** "Every merged PR, every deploy, every spec revision **is anchored** to the **ZZV Chain** — …"

**After:** "Every merged PR, every deploy, every spec revision is ***designed* to be anchored** … Today, the spec→PR audit trail is live and verifiable via the ZiLin Command workflow (branch → impl → tests → PR → dual-control merge), and every artifact is recoverable from git. On-chain cryptographic anchoring ships with the Enterprise edition. … the chain **will** have the answer …"

This is the same pre-deploy gate PR #13's game-theory review flagged for Home and did not enforce on README. Now honest: what's live today is spec-→-PR via ZiLin Command; on-chain anchoring is future/Enterprise. Positioning intact, claim verifiable.

### Note on the methodology link

My first draft linked "ZiLin Command" to \`docs/METHODOLOGY/2026-04-08__methodology__zilin-command.md\` — that doc lives in \`htu-foundation\`, **not** in this repo (confirmed by \`gh pr view 9 --repo zi007lin/htu-foundation\`). I removed the inline link rather than point README at a doc that doesn't exist here. If \`htu-foundation\` is public and you want README to link there, call it out in review and I'll add the cross-repo link in a tiny follow-up.

## Out of scope (P2 — deliberately not in this PR)

Per the instruction "all P1 items only — no P2 items":

- Home narrative bridge between the RGB ambiguity viz and the /app scorer
- README "How scoring works" section documenting the 7-section rubric + 5 spec types + v1.1.0
- Editions table clarification (Free tier = web scorer, not CLI)
- Hackathon Memorabilia section citing shipped PRs

Each deserves its own spec when promoted.

## Dependencies

- Research PR #17 (report file) is still open — this PR does **not** depend on #17 merging first since it only touches README. You can merge either order.

Reviewer: daniel-silvers