### PR TITLE
chore: CLAUDE.md score gate — hard rule, no override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,29 @@
 
 ZAI — Zero Ambiguity Intelligence. The engine of Spec Driven Development by High Tech United.
 
+## Hard Rules — impl gate
+
+**SCORE GATE — EXPLICIT DISALLOW**
+
+`impl` is forbidden on any spec file that does not contain a valid ZAI score block.
+
+Before executing any `impl` or `implw` command, ZiLin-Dev MUST:
+
+1. Read the spec file
+2. Search for the pattern: `<!-- zilin-bs:score`
+3. If the block is absent → STOP. Emit exactly:
+   `needs_input: score this spec at dev.zai.htu.io/app first, then re-download the .scored.md`
+4. If the block is present, parse the JSON and check `"passed": true`
+5. If `passed` is false or missing → STOP. Emit exactly:
+   `needs_input: spec score is not passing — fix failing sections and re-score before impl`
+6. If `passed` is true → proceed with impl normally
+
+No exceptions. No overrides. No "I'll proceed anyway since the intent is clear."
+A spec without a passing score block is not a valid impl input.
+
+The correct workflow is:
+  Write spec → upload to dev.zai.htu.io/app → download .scored.md → run impl on .scored.md
+
 ## Layer 2 Commands
 
 Commands in `.claude/commands/` are **symlinks** into `~/dev/streettt-private/.claude/commands/`.


### PR DESCRIPTION
## Summary

Adds a **Hard Rules — impl gate** section to \`CLAUDE.md\` directly below the tagline. \`impl\` and \`implw\` are now forbidden on any spec file that does not contain a valid ZAI score block with \`"passed": true\`. No exceptions, no overrides.

Shipping in parallel to the same change on \`streettt-private\`.

## What the rule does

Before executing any \`impl\` or \`implw\` command, ZiLin-Dev must:

1. Read the spec file
2. Search for \`<!-- zilin-bs:score\`
3. If the block is absent → stop and emit: \`needs_input: score this spec at dev.zai.htu.io/app first, then re-download the .scored.md\`
4. If present, parse JSON and check \`"passed": true\`
5. If \`passed\` is false or missing → stop and emit: \`needs_input: spec score is not passing — fix failing sections and re-score before impl\`
6. If \`passed\` is true → proceed normally

Correct workflow:
> Write spec → upload to dev.zai.htu.io/app → download .scored.md → run impl on .scored.md

## Diff

\`CLAUDE.md\` — +23 / -0. Single insert immediately after the "ZAI — Zero Ambiguity Intelligence. The engine of Spec Driven Development by High Tech United." tagline.

## Spec

\`2026-04-13__chore__claude-md-score-gate.scored.md\` · **2/2 PASS** · chore rubric v1.1.0

Reviewer: daniel-silvers