### PR TITLE
hotfix: score gate pattern — match live scorer output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,19 +16,25 @@ ZAI — Zero Ambiguity Intelligence. The engine of Spec Driven Development by Hi
 Before executing any `impl` or `implw` command, ZiLin-Dev MUST:
 
 1. Read the spec file
-2. Search for the pattern: `<!-- zilin-bs:score`
-3. If the block is absent → STOP. Emit exactly:
+2. Search for the pattern: `## ZAI Spec Score` (exact heading, case-sensitive)
+3. If the heading is absent → STOP. Emit exactly:
    `needs_input: score this spec at dev.zai.htu.io/app first, then re-download the .scored.md`
-4. If the block is present, parse the JSON and check `"passed": true`
-5. If `passed` is false or missing → STOP. Emit exactly:
+4. If the heading is present, check that the section contains a line
+   matching exactly: `- **Passed:** YES`
+   If that line is absent or reads `- **Passed:** NO` → STOP. Emit exactly:
    `needs_input: spec score is not passing — fix failing sections and re-score before impl`
-6. If `passed` is true → proceed with impl normally
+5. If the `- **Passed:** YES` line is present → proceed with impl normally
 
 No exceptions. No overrides. No "I'll proceed anyway since the intent is clear."
 A spec without a passing score block is not a valid impl input.
 
 The correct workflow is:
   Write spec → upload to dev.zai.htu.io/app → download .scored.md → run impl on .scored.md
+
+Note: a future update will add a machine-parseable `<!-- zilin-bs:score {json} -->`
+block alongside the markdown section. When that ships, update this rule to check
+the JSON block instead. Until then, the `## ZAI Spec Score` + `- **Passed:** YES`
+pattern is authoritative.
 
 ## Layer 2 Commands
 

--- a/issues/2026-04-13__hotfix__claude-md-score-gate-pattern.scored.md
+++ b/issues/2026-04-13__hotfix__claude-md-score-gate-pattern.scored.md
@@ -1,0 +1,104 @@
+# 2026-04-13__hotfix__claude-md-score-gate-pattern
+
+**Repos:** `streettt-private` + `zi007lin/zai`
+**Label:** `hotfix`
+**Branch:** `stt/hotfix-claude-md-score-gate-pattern` / `zai/hotfix-claude-md-score-gate-pattern`
+**Reviewer:** daniel-silvers
+**Fixes:** `2026-04-13__chore__claude-md-score-gate` (PR #26 / PR #19)
+
+## Intent
+
+Fix the score gate pattern in both CLAUDE.mds. The gate was written against a planned `<!-- zilin-bs:score -->` HTML comment format that was never implemented in `buildScoredSpec()`. The live scorer at `dev.zai.htu.io/app` emits a markdown section (`## ZAI Spec Score`) with a `- **Passed:** YES` line. The rule as merged rejects every valid scored spec because the pattern it searches for does not exist in any real output. This hotfix corrects the pattern to match reality.
+
+## Repro
+
+```
+impl i 2026-04-13__chore__park-score-signing-issue.scored.md
+→ needs_input: score this spec at dev.zai.htu.io/app first
+```
+
+File contains `## ZAI Spec Score` + `- **Passed:** YES` — correctly scored.
+File does not contain `<!-- zilin-bs:score` — rule rejects it incorrectly.
+
+## Fix
+
+In each CLAUDE.md, find the "Hard Rules — impl gate" section. Replace the two affected steps:
+
+**Current (wrong):**
+```markdown
+2. Search for the pattern: `<!-- zilin-bs:score`
+...
+4. If the block is present, parse the JSON and check `"passed": true`
+```
+
+**Replace with:**
+```markdown
+2. Search for the pattern: `## ZAI Spec Score` (exact heading, case-sensitive)
+
+3. If the heading is absent → STOP. Emit exactly:
+   `needs_input: score this spec at dev.zai.htu.io/app first, then re-download the .scored.md`
+
+4. If the heading is present, check that the section contains a line
+   matching exactly: `- **Passed:** YES`
+   If that line is absent or reads `- **Passed:** NO` → STOP. Emit exactly:
+   `needs_input: spec score is not passing — fix failing sections and re-score before impl`
+```
+
+No other changes to the gate rule. Steps 1, 5, 6, 7 (where present) are unchanged.
+
+## Future compatibility note
+
+Add the following sentence at the end of the gate section in both CLAUDE.mds:
+
+```markdown
+Note: a future update will add a machine-parseable `<!-- zilin-bs:score {json} -->`
+block alongside the markdown section. When that ships, update this rule to check
+the JSON block instead. Until then, the `## ZAI Spec Score` + `- **Passed:** YES`
+pattern is authoritative.
+```
+
+## Acceptance Criteria
+
+- [ ] `streettt-private/CLAUDE.md` gate pattern updated to `## ZAI Spec Score` + `- **Passed:** YES`
+- [ ] `zi007lin/zai/CLAUDE.md` gate pattern updated to `## ZAI Spec Score` + `- **Passed:** YES`
+- [ ] Future compatibility note added to both CLAUDE.mds
+- [ ] `impl i` on `2026-04-13__chore__park-score-signing-issue.scored.md` proceeds without `needs_input`
+- [ ] `impl i` on a plain unscored `.md` still stops with correct `needs_input` message
+- [ ] `impl i` on a scored spec with `- **Passed:** NO` still stops with correct `needs_input` message
+- [ ] Two PRs — one per repo — daniel-silvers reviewer
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | Score gate pattern fix — `<!-- zilin-bs:score` → `## ZAI Spec Score` + `- **Passed:** YES` |
+| State | Spec complete; needs scoring before impl |
+| Root cause | `buildScoredSpec()` in PR #15 emits markdown section; gate rule was written against planned HTML comment format that was never implemented |
+| Open questions | None |
+| Next action | Score at `/app` → download `.scored.md` → `impl i` |
+| Repos | `streettt-private` + `zi007lin/zai` |
+
+## Files
+
+```
+streettt-private/CLAUDE.md  ← pattern fix + future compat note
+zi007lin/zai/CLAUDE.md      ← pattern fix + future compat note
+```
+
+---
+
+## ZAI Spec Score
+
+- **Rubric version:** 1.1.0
+- **Spec type:** hotfix
+- **Evaluated at:** 2026-04-13T07:13:19.906Z
+- **Score:** 3/3
+- **Passed:** YES
+
+| Section | Status |
+|---|---|
+| intent | PASS |
+| fix | PASS |
+| files_list | PASS |
+
+_Source: 2026-04-13__hotfix__claude-md-score-gate-pattern.md_


### PR DESCRIPTION
## Summary

Fixes the score gate installed one commit ago in PR #19. The gate searched for \`<!-- zilin-bs:score\`, which never exists in any real file — \`buildScoredSpec()\` in \`src/pages/AppPage.tsx\` (PR #15) writes a human-readable markdown section instead. The rule as merged rejects every valid scored spec on the first real run.

Shipping in parallel to the same fix on \`streettt-private\`.

## Diff

\`CLAUDE.md\` — +11 / -5. Pattern-check steps swapped for markdown form; adds a future-compatibility note.

Also includes the scored spec copy at \`issues/2026-04-13__hotfix__claude-md-score-gate-pattern.scored.md\` for traceability.

## Before / after

**Before** (rejects every real scored spec):
\`\`\`markdown
2. Search for the pattern: \`<!-- zilin-bs:score\`
3. If the block is absent → STOP. …
4. If the block is present, parse the JSON and check \`"passed": true\`
\`\`\`

**After** (matches what the scorer actually writes):
\`\`\`markdown
2. Search for the pattern: \`## ZAI Spec Score\` (exact heading, case-sensitive)
3. If the heading is absent → STOP. Emit exactly:
   \`needs_input: score this spec at dev.zai.htu.io/app first, then re-download the .scored.md\`
4. If the heading is present, check that the section contains a line
   matching exactly: \`- **Passed:** YES\`
   If that line is absent or reads \`- **Passed:** NO\` → STOP. …
\`\`\`

All other steps, the disallow language, and the "correct workflow" block are unchanged.

## Future compatibility note (new, end of section)

> Note: a future update will add a machine-parseable \`<!-- zilin-bs:score {json} -->\` block alongside the markdown section. When that ships, update this rule to check the JSON block instead. Until then, the \`## ZAI Spec Score\` + \`- **Passed:** YES\` pattern is authoritative.

## Why this happened

The chore spec that installed the gate was written against a planned JSON-in-HTML-comment format. That format was never implemented — \`buildScoredSpec()\` in PR #15 only ever emitted the markdown section. The gate and the scorer were specified by different specs on different days; the mismatch only surfaced on the first real \`impl\` attempt against an unrelated scored spec.

## Spec

\`2026-04-13__hotfix__claude-md-score-gate-pattern.scored.md\` · **3/3 PASS** · hotfix rubric v1.1.0

Reviewer: daniel-silvers