### PR TITLE
chore: Park CF Worker score-signing spec + standard label inventory

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,27 @@
+# Standard HTU label set — managed by chore spec
+# 2026-04-13__chore__park-score-signing-issue
+# Canonical source of truth. Any new label must be added here before being created in GitHub.
+- name: feat
+  color: AFA9EC
+  description: New feature
+- name: research
+  color: 85B7EB
+  description: Research/audit task — produces a report, no code
+- name: chore
+  color: D3D1C7
+  description: Maintenance, deployment, config
+- name: bug
+  color: F09595
+  description: Something is broken
+- name: hotfix
+  color: EF9F27
+  description: Urgent fix for a live issue
+- name: parked
+  color: "888780"
+  description: Blocked on prerequisite — do not impl
+- name: spec
+  color: 9FE1CB
+  description: Specification or design document
+- name: refactor
+  color: D3D1C7
+  description: Code restructure, no behavior change

--- a/issues/2026-04-13__chore__park-score-signing-issue.scored.md
+++ b/issues/2026-04-13__chore__park-score-signing-issue.scored.md
@@ -1,0 +1,213 @@
+# 2026-04-13__chore__park-score-signing-issue
+
+**Repos:** `zi007lin/zai` + `zi007lin/streettt` + `htu-foundation`
+**Label:** `chore`
+**Branch:** `zai/park-score-signing-issue` / `stt/park-score-signing-issue` / `htu/park-score-signing-issue`
+**Reviewer:** daniel-silvers
+
+## Intent
+
+Commit the parked spec `2026-04-13__feat__zai-score-signing-cf-worker.md` to `issues/parked/` in the zai repo and create a matching GitHub Issue labeled `parked`. Additionally, audit and create the full standard label set across all three HTU repos (`zai`, `streettt`, `htu-foundation`). Labels have been declared in spec metadata but never systematically created — this closes that gap.
+
+---
+
+## Files
+
+```
+zi007lin/zai/issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md  ← new
+```
+
+---
+
+## Steps
+
+### 1. Audit and create standard labels — ALL THREE REPOS
+
+Run the following for each repo. The `2>/dev/null || true` suppresses errors for labels that already exist.
+
+**Standard label set (apply identically to zai, streettt, htu-foundation):**
+
+```bash
+for REPO in zi007lin/zai zi007lin/streettt zi007lin/htu-foundation; do
+  echo "=== $REPO ==="
+
+  gh label create "feat" \
+    --repo $REPO \
+    --description "New feature" \
+    --color "AFA9EC" 2>/dev/null || true
+
+  gh label create "research" \
+    --repo $REPO \
+    --description "Research/audit task — produces a report, no code" \
+    --color "85B7EB" 2>/dev/null || true
+
+  gh label create "chore" \
+    --repo $REPO \
+    --description "Maintenance, deployment, config" \
+    --color "D3D1C7" 2>/dev/null || true
+
+  gh label create "bug" \
+    --repo $REPO \
+    --description "Something is broken" \
+    --color "F09595" 2>/dev/null || true
+
+  gh label create "hotfix" \
+    --repo $REPO \
+    --description "Urgent fix for a live issue" \
+    --color "EF9F27" 2>/dev/null || true
+
+  gh label create "parked" \
+    --repo $REPO \
+    --description "Blocked on prerequisite — do not impl" \
+    --color "888780" 2>/dev/null || true
+
+  gh label create "spec" \
+    --repo $REPO \
+    --description "Specification or design document" \
+    --color "9FE1CB" 2>/dev/null || true
+
+  gh label create "refactor" \
+    --repo $REPO \
+    --description "Code restructure, no behavior change" \
+    --color "D3D1C7" 2>/dev/null || true
+
+  echo "Labels done for $REPO"
+done
+```
+
+After running, verify each repo:
+```bash
+for REPO in zi007lin/zai zi007lin/streettt zi007lin/htu-foundation; do
+  echo "=== $REPO ===" && gh label list --repo $REPO
+done
+```
+
+Expected: all 8 labels present in each repo.
+
+### 2. Create `issues/parked/` and commit the spec (zai only)
+
+```bash
+cd ~/dev/zai
+mkdir -p issues/parked
+cp /mnt/c/Users/zilin/Downloads/2026-04-13__feat__zai-score-signing-cf-worker.md \
+   issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md
+git add issues/parked/
+```
+
+### 3. Create GitHub Issue in zai (parked label)
+
+```bash
+gh issue create \
+  --repo zi007lin/zai \
+  --title "feat: ZAI score signing via CF Worker (PARKED)" \
+  --label "parked" \
+  --body "$(cat <<'BODY'
+## Status: PARKED
+
+Blocked on prerequisite — do not implement until the CF Worker scaffold
+exists in this repo.
+
+**Prerequisite:** CF Worker scaffold (`wrangler.jsonc` + worker entrypoint)
+must exist and be deployable before this spec runs.
+
+**What this builds:** Server-side spec scoring with HMAC-SHA256 signing.
+Every score block gets a cryptographic signature from a CF secret key.
+ZiLin-Dev verifies the signature before impl — hand-typed or altered score
+blocks are rejected cryptographically.
+
+**Supersedes:** Option B behavioral re-run check once deployed.
+
+**To unpark:** Change label `parked` → `feat`, score the spec at
+`/app`, download `.scored.md`, then run impl.
+
+**Spec file:** `issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md`
+BODY
+)"
+```
+
+### 4. Open one PR per repo
+
+- **zai:** adds `issues/parked/` directory + spec file
+- **streettt:** label-only change (no files) — empty commit with message `chore: Ensure standard GitHub labels exist`
+- **htu-foundation:** same as streettt
+
+For repos where only labels changed (no file changes), create a minimal commit touching a README or adding a `.github/labels.yml` inventory file so the PR has a diff:
+
+```bash
+# For streettt and htu-foundation
+cat > .github/labels.yml << 'LABELS'
+# Standard HTU label set — managed by chore spec
+# 2026-04-13__chore__park-score-signing-issue
+- name: feat
+  color: AFA9EC
+  description: New feature
+- name: research
+  color: 85B7EB
+  description: Research/audit task — produces a report, no code
+- name: chore
+  color: D3D1C7
+  description: Maintenance, deployment, config
+- name: bug
+  color: F09595
+  description: Something is broken
+- name: hotfix
+  color: EF9F27
+  description: Urgent fix for a live issue
+- name: parked
+  color: "888780"
+  description: Blocked on prerequisite — do not impl
+- name: spec
+  color: 9FE1CB
+  description: Specification or design document
+- name: refactor
+  color: D3D1C7
+  description: Code restructure, no behavior change
+LABELS
+git add .github/labels.yml
+git commit -m "chore: Add .github/labels.yml — standard HTU label inventory"
+```
+
+This `.github/labels.yml` file also serves as the canonical label source of truth going forward — any new label must be added here before being created in GitHub.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 8 standard labels exist in `zi007lin/zai`
+- [ ] All 8 standard labels exist in `zi007lin/streettt`
+- [ ] All 8 standard labels exist in `zi007lin/htu-foundation`
+- [ ] `.github/labels.yml` committed to all three repos
+- [ ] `issues/parked/` directory created in zai
+- [ ] Parked spec file committed to `issues/parked/` in zai
+- [ ] GitHub Issue created in zai with `parked` label and "(PARKED)" in title
+- [ ] Three PRs opened — one per repo — all assigned to daniel-silvers
+- [ ] `gh label list` output for all three repos shows all 8 labels
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | Standard labels across all 3 HTU repos + park CF Worker signing spec in zai |
+| State | Spec complete; needs scoring before impl |
+| Open questions | Does `htu-foundation` have a different org owner? Confirm repo path before running the label loop |
+| Next action | Score at `/app` → download `.scored.md` → `impl i` |
+| Repos | `zi007lin/zai` + `zi007lin/streettt` + `zi007lin/htu-foundation` |
+
+---
+
+## ZAI Spec Score
+
+- **Rubric version:** 1.1.0
+- **Spec type:** chore
+- **Evaluated at:** 2026-04-13T07:02:21.626Z
+- **Score:** 2/2
+- **Passed:** YES
+
+| Section | Status |
+|---|---|
+| intent | PASS |
+| files_list | PASS |
+
+_Source: 2026-04-13__chore__park-score-signing-issue.md_

--- a/issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md
+++ b/issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md
@@ -1,0 +1,191 @@
+# 2026-04-13__feat__zai-score-signing-cf-worker
+
+**Repo:** `zi007lin/zai`
+**Label:** `feat`
+**Branch:** `zai/score-signing-cf-worker`
+**Reviewer:** daniel-silvers
+**Status:** PARKED — depends on CF Worker scaffold (not yet built)
+**Supersedes:** Option B (CLAUDE.md re-run check) once deployed
+
+---
+
+## Intent
+
+Move spec scoring server-side and sign every score block with a private key stored in Cloudflare secrets. ZiLin-Dev verifies the signature before impl runs. A hand-typed or manually altered score block has no valid signature and fails the gate cryptographically. This is the ZZV Chain anchor at the spec layer — every spec decision is signed, timestamped, and independently verifiable.
+
+---
+
+## Decision Tree
+
+**Question:** How do we make the score block tamper-proof?
+
+| Option | Integrity | Infrastructure needed | Decision |
+|---|---|---|---|
+| Client-side score block (current) | None — string presence only | None | ❌ Hand-typeable |
+| CLAUDE.md re-run check (Option B) | Behavioral — catches accidents | None | ✅ Interim |
+| CF Worker HMAC signature | Cryptographic — catches all tampering | CF Worker + secret key | ✅ Target state |
+| ZZV Chain on-chain receipt | Maximum — immutable ledger | ZZV Chain node | ⏳ Future |
+
+**Decision:** CF Worker HMAC for now. ZZV Chain anchoring when chain nodes are operational.
+
+**Trigger for change:** Option B ships → this spec becomes the next priority. CF Worker scaffold must exist before this impl runs.
+
+---
+
+## Draft-of-thoughts
+
+The signing model: when the CF Worker scores a spec, it computes `HMAC-SHA256(score_block_json, SCORE_SIGNING_KEY)` where `SCORE_SIGNING_KEY` is a Cloudflare secret never exposed in the repo or bundle. The signature is appended to the score block:
+
+```json
+{
+  "rubric_version": "1.1.0",
+  "spec_type": "feat",
+  "score": "7/7",
+  "passed": true,
+  "evaluated_at": "2026-04-13T06:00:00.000Z",
+  "sections": { ... },
+  "gates": [],
+  "sig": "a3f8c2...d94e"
+}
+```
+
+ZiLin-Dev verification: re-compute the HMAC over the score block JSON (excluding the `sig` field) using the same key (available as `SCORE_SIGNING_KEY` env var on the Contabo runner). If `computed === stored_sig` → proceed. If mismatch → `needs_input: score block signature invalid`.
+
+The key rotation plan: SCORE_SIGNING_KEY rotates every 90 days. Old signatures remain valid for 30 days after rotation (grace period). Score blocks older than 120 days require re-scoring.
+
+The CF Worker also replaces the client-side `scoreSpec.ts` — the `/app` page sends the spec file to the Worker, receives the signed score block, appends it to the file for download. The client-side rubric becomes a preview-only tool (no signature issued).
+
+---
+
+## Final Spec
+
+### 1. CF Worker endpoint
+
+```
+POST /api/score
+Content-Type: multipart/form-data
+Body: { file: <spec.md> }
+
+Response 200:
+{
+  "score_block": "<!-- zilin-bs:score\n{...json with sig...}\n-->",
+  "passed": true,
+  "score": "7/7",
+  "spec_type": "feat"
+}
+
+Response 422:
+{
+  "passed": false,
+  "score": "4/7",
+  "failing": ["decision_tree", "game_theory"]
+}
+```
+
+### 2. Signing implementation
+
+```typescript
+// CF Worker — score.ts
+const encoder = new TextEncoder();
+
+async function signScoreBlock(
+  payload: object,
+  secret: string
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(JSON.stringify(payload))
+  );
+  return Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+```
+
+### 3. ZiLin-Dev verification (CLAUDE.md addition)
+
+```typescript
+// Verification pseudocode for CLAUDE.md instruction
+async function verifyScoreBlock(block: ScoreBlock, secret: string): boolean {
+  const { sig, ...payload } = block;
+  const computed = await hmacSha256(JSON.stringify(payload), secret);
+  return computed === sig;
+}
+```
+
+CLAUDE.md rule addition (appended after Option B rule):
+```
+When SCORE_SIGNING_KEY is available in the environment:
+- Extract score block JSON from spec file
+- Separate `sig` field from payload
+- Recompute HMAC-SHA256 over payload using SCORE_SIGNING_KEY
+- If signature does not match → STOP:
+  needs_input: score block signature invalid — re-score at zai.htu.io/app
+- If signature matches → proceed (Option B re-run check is skipped)
+
+When SCORE_SIGNING_KEY is not available → fall back to Option B re-run check.
+```
+
+### 4. `/app` page update
+
+- Remove client-side `scoreSpec()` call for final scoring
+- Replace with `fetch('/api/score', { method: 'POST', body: formData })`
+- Keep client-side `scoreSpec()` as a live preview while typing/uploading (no signature — labeled "preview")
+- Signed result only comes from the Worker response
+
+### 5. Secret management
+
+```
+CF Secret name: SCORE_SIGNING_KEY
+Rotation: every 90 days
+Grace period: 30 days (old sigs still valid)
+Never committed to repo
+Set via: npx wrangler secret put SCORE_SIGNING_KEY --env demo
+```
+
+---
+
+## Game Theory Review
+
+**Who benefits:** Every stakeholder in the impl pipeline. daniel-silvers can verify any PR's score block is genuine by checking the signature. The audit trail is cryptographically sound — not just process-controlled.
+
+**Abuse vector:** Attacker obtains `SCORE_SIGNING_KEY` and forges signatures. Mitigation: key lives only in CF secrets and Contabo runner env — never in code, never in logs. Key rotation every 90 days limits exposure window.
+
+**Abuse vector 2:** Attacker re-scores a failing spec with modified content to get a passing signature. Mitigation: the signature covers the full spec content hash (not just the score JSON). A modified spec produces a different payload and a different signature.
+
+**Abuse vector 3:** Replay attack — copy a valid signature from one spec to another. Mitigation: the payload includes `evaluated_at` ISO timestamp and the spec filename. A signature from spec A does not validate against spec B.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `POST /api/score` CF Worker endpoint exists and returns signed score block
+- [ ] `SCORE_SIGNING_KEY` set in CF secrets for dev, demo, prod environments
+- [ ] `/app` page calls Worker for final score, keeps client-side as preview only
+- [ ] ZiLin-Dev CLAUDE.md updated with signature verification step
+- [ ] `SCORE_SIGNING_KEY` available on Contabo runner as env var
+- [ ] Verification rejects hand-typed score block (no valid sig)
+- [ ] Verification rejects score block with modified JSON (sig mismatch)
+- [ ] Verification rejects score block from different spec (filename mismatch)
+- [ ] Falls back to Option B re-run check when key not available
+- [ ] Key rotation procedure documented in `docs/ops/score-key-rotation.md`
+
+---
+
+## Subject Migration Summary
+
+| | |
+|---|---|
+| What | CF Worker score signing — cryptographic tamper-proof guarantee |
+| State | PARKED — CF Worker scaffold required first |
+| Open questions | (1) Does `zai` already have a CF Worker or is it Pages-only? Check `wrangler.jsonc`. (2) Key distribution to Contabo runner — manual secret or pulled from CF API? |
+| Next action | Build CF Worker scaffold → then impl this spec |
+| Repo | `zi007lin/zai` |


### PR DESCRIPTION
## Summary

Parks the unshipped CF Worker score-signing spec and adds the canonical HTU label inventory at \`.github/labels.yml\`. Ships in parallel with matching \`labels.yml\` PRs on \`zi007lin/streettt\` and \`zi007lin/htu-foundation\`.

## Changes

- \`issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md\` — parked spec, not for impl. Needs a CF Worker scaffold as prerequisite.
- \`.github/labels.yml\` — canonical 8-label HTU set (feat, research, chore, bug, hotfix, parked, spec, refactor). Any new label must be added here before being created in GitHub.
- \`issues/2026-04-13__chore__park-score-signing-issue.scored.md\` — this chore's scored spec (2/2 PASS) for traceability.

## Labels created

All 8 labels now exist on \`zi007lin/zai\`, \`zi007lin/streettt\`, and \`zi007lin/htu-foundation\` via \`gh label create\` in the same run. \`gh label list --limit 500\` on all three confirms full coverage. Labels that pre-existed (bug, chore, spec, research) printed "already exists" and were left untouched.

## Parked issue

A companion GitHub Issue will be opened immediately after this PR with label \`parked\` and title \`feat: ZAI score signing via CF Worker (PARKED)\`. Its body will link to \`issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md\`.

## Spec

\`2026-04-13__chore__park-score-signing-issue.scored.md\` · **2/2 PASS** · chore rubric v1.1.0

Reviewer: daniel-silvers