### PR TITLE
chore: ZiLin pipeline SVG + "How it works" section + widen privacy rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Sensitive operational details are NEVER committed to public repos:
 - Command inventories or toolchain invocations
 - Symlink structures pointing to private repos
 - Internal module paths or test invocations
+- Public IPs, hostnames, or server or provider identifiers for internal infrastructure
 
 These belong in the private layer only. Violations are reverted immediately
 and the committer must run `git filter-repo` to scrub history (coordinate

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ The first piece of the SDD pipeline is live as a web scorer at **[demo.zai.htu.i
 
 ---
 
+## How it works
+
+![ZiLin autonomous pipeline](docs/assets/zilin-pipeline.svg)
+
+ZiLin sends intent — text, images, or a video URL — through the HTU entry window. The Spec Agent on the ZZV backend (cloud VPS) extracts video frames if needed, generates a spec, and runs it through the ZiSpec score gate. Two governance gates control what proceeds: trivial specs (chore, hotfix) auto-approve; non-trivial specs (feat, bug, research) require daniel-silvers approval before impl runs. Every PR requires daniel-silvers review before merge. No single actor merges alone.
+
+---
+
 ## ZAI Architecture — Agentic Traffic Controller
 
 ZAI is not a single agent. It is a **traffic controller** that routes work across specialized subagents, each with bounded authority and a clear handoff protocol.

--- a/docs/assets/zilin-pipeline.svg
+++ b/docs/assets/zilin-pipeline.svg
@@ -1,0 +1,124 @@
+<svg width="100%" viewBox="0 0 680 820" xmlns="http://www.w3.org/2000/svg" role="img">
+<title>ZiLin autonomous pipeline — full architecture</title>
+<desc>Shows ZiLin human input through HTU entry window to ZiLin Spec Agent on a cloud VPS, through two governance gates, to PR review and deploy</desc>
+<defs>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+    <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </marker>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #24292f; }
+    .th { font-size: 13px; font-weight: 600; }
+    .ts { font-size: 11px; fill: #57606a; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e6edf3; }
+      .ts { fill: #8b949e; }
+      .box-bg { fill: #161b22; stroke: #30363d; }
+      .outer-bg { fill: #0d1117; stroke: #30363d; }
+      .gate-bg { fill: #161b22; }
+    }
+    .box-bg { fill: #f6f8fa; stroke: #d0d7de; }
+    .outer-bg { fill: #f0f0ff; stroke: #7f77dd; }
+    .gate-bg { fill: #fff5f5; stroke: #ff8182; }
+    .amber-box { fill: #fff8e1; stroke: #d4a017; }
+    .teal-box { fill: #e6f9f3; stroke: #1d9e75; }
+    .gray-box { fill: #f6f8fa; stroke: #d0d7de; }
+    .red-box { fill: #fff0f0; stroke: #e24b4a; }
+    .auto-box { fill: #e6f9f3; stroke: #1d9e75; }
+  </style>
+</defs>
+
+<!-- ZiLin human -->
+<rect x="220" y="20" width="240" height="50" rx="10" class="amber-box" stroke-width="1"/>
+<text class="th" x="340" y="41" text-anchor="middle">ZiLin (human)</text>
+<text class="ts" x="340" y="59" text-anchor="middle">text · images · video URL</text>
+<line x1="340" y1="70" x2="340" y2="100" stroke="#d4a017" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+<!-- HTU Entry Window -->
+<rect x="190" y="100" width="300" height="44" rx="10" class="teal-box" stroke-width="1.5"/>
+<text class="th" x="340" y="118" text-anchor="middle">HTU entry window</text>
+<text class="ts" x="340" y="134" text-anchor="middle">chat.zzv.io — primary channel</text>
+
+<!-- Future channels -->
+<rect x="44" y="112" width="130" height="32" rx="8" class="gray-box" stroke-width="0.5"/>
+<text class="th" x="109" y="132" text-anchor="middle" style="font-size:11px">Twitter / X</text>
+<rect x="506" y="112" width="130" height="32" rx="8" class="gray-box" stroke-width="0.5"/>
+<text class="th" x="571" y="132" text-anchor="middle" style="font-size:11px">WhatsApp · TG</text>
+<line x1="174" y1="128" x2="190" y2="128" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+<line x1="506" y1="128" x2="490" y2="128" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+<text class="ts" x="109" y="158" text-anchor="middle">future</text>
+<text class="ts" x="571" y="158" text-anchor="middle">future</text>
+
+<line x1="340" y1="144" x2="340" y2="174" stroke="#1d9e75" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+<!-- ZZV Backend outer -->
+<rect x="44" y="174" width="592" height="568" rx="16" class="outer-bg" stroke-width="1"/>
+<text class="th" x="340" y="198" text-anchor="middle">ZZV backend — Cloud VPS</text>
+
+<!-- Spec Agent -->
+<rect x="70" y="214" width="540" height="100" rx="10" class="box-bg" stroke-width="0.5"/>
+<text class="th" x="340" y="236" text-anchor="middle">ZiLin Spec Agent (Issuer role)</text>
+
+<rect x="88" y="250" width="130" height="44" rx="8" class="gray-box" stroke-width="0.5"/>
+<text class="th" x="153" y="268" text-anchor="middle" style="font-size:11px">Video extractor</text>
+<text class="ts" x="153" y="284" text-anchor="middle">ffmpeg 30fps</text>
+
+<rect x="245" y="250" width="130" height="44" rx="8" class="gray-box" stroke-width="0.5"/>
+<text class="th" x="310" y="268" text-anchor="middle" style="font-size:11px">Vision + intent</text>
+<text class="ts" x="310" y="284" text-anchor="middle">frames → spec</text>
+
+<rect x="402" y="250" width="130" height="44" rx="8" class="teal-box" stroke-width="0.5"/>
+<text class="th" x="467" y="268" text-anchor="middle" style="font-size:11px">Score gate</text>
+<text class="ts" x="467" y="284" text-anchor="middle">ZiSpec 7/7 PASS</text>
+
+<line x1="218" y1="272" x2="245" y2="272" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<line x1="375" y1="272" x2="402" y2="272" stroke="#1d9e75" stroke-width="1" marker-end="url(#arrow)"/>
+<line x1="340" y1="314" x2="340" y2="344" stroke="#7f77dd" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+<!-- Gate 1 -->
+<rect x="70" y="344" width="540" height="132" rx="10" class="gate-bg" stroke-width="1"/>
+<text class="th" x="340" y="366" text-anchor="middle" style="fill:#a32d2d">Gate 1 — spec approval (before impl)</text>
+
+<polygon points="340,382 388,404 340,426 292,404" fill="white" stroke="#888780" stroke-width="1"/>
+<text x="340" y="408" text-anchor="middle" style="font-size:11px;font-weight:600;fill:#24292f">trivial?</text>
+
+<line x1="388" y1="404" x2="476" y2="404" stroke="#1d9e75" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="ts" x="432" y="396" text-anchor="middle" style="fill:#0f6e56">yes — chore/hotfix</text>
+<rect x="476" y="382" width="110" height="44" rx="8" class="auto-box" stroke-width="0.5"/>
+<text class="th" x="531" y="400" text-anchor="middle" style="font-size:11px">AUTO</text>
+<text class="ts" x="531" y="416" text-anchor="middle">immediate</text>
+
+<line x1="292" y1="404" x2="196" y2="404" stroke="#e24b4a" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="ts" x="244" y="396" text-anchor="middle" style="fill:#a32d2d">no — feat/bug/research</text>
+<rect x="86" y="382" width="110" height="44" rx="8" class="red-box" stroke-width="0.5"/>
+<text class="th" x="141" y="400" text-anchor="middle" style="font-size:11px">daniel-silvers</text>
+<text class="ts" x="141" y="416" text-anchor="middle">approves spec</text>
+
+<path d="M531 426 L531 454 L340 454" fill="none" stroke="#1d9e75" stroke-width="0.8" marker-end="url(#arrow)"/>
+<path d="M141 426 L141 454 L340 454" fill="none" stroke="#e24b4a" stroke-width="0.8" marker-end="url(#arrow)"/>
+<line x1="340" y1="476" x2="340" y2="510" stroke="#7f77dd" stroke-width="1.5" marker-end="url(#arrow)"/>
+<text class="ts" x="380" y="496" style="fill:#57606a">reads from GitHub</text>
+
+<!-- ZiLin Dev -->
+<rect x="70" y="510" width="540" height="60" rx="10" class="box-bg" stroke-width="0.5"/>
+<text class="th" x="340" y="532" text-anchor="middle">ZiLin Dev (impl role)</text>
+<text class="ts" x="340" y="552" text-anchor="middle">branch → implement → test → PR</text>
+<line x1="340" y1="570" x2="340" y2="600" stroke="#7f77dd" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+<!-- Gate 2 -->
+<rect x="70" y="600" width="540" height="60" rx="10" class="gate-bg" stroke-width="1"/>
+<text class="th" x="340" y="622" text-anchor="middle" style="fill:#a32d2d">Gate 2 — PR review (always daniel-silvers)</text>
+<text class="ts" x="340" y="644" text-anchor="middle">dual-control — no single actor merges alone</text>
+<line x1="340" y1="660" x2="340" y2="694" stroke="#888780" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+
+<!-- Deploy -->
+<rect x="220" y="694" width="240" height="36" rx="8" class="gray-box" stroke-width="0.5"/>
+<text class="th" x="340" y="712" text-anchor="middle">deploy dev → demo → prod</text>
+
+<!-- Legend -->
+<rect x="70" y="746" width="10" height="10" rx="2" fill="#ffb0b0" stroke="#e24b4a" stroke-width="0.5"/>
+<text class="ts" x="86" y="755">governance gate</text>
+<rect x="190" y="746" width="10" height="10" rx="2" fill="#e6f9f3" stroke="#1d9e75" stroke-width="0.5"/>
+<text class="ts" x="206" y="755">auto path</text>
+<rect x="290" y="746" width="10" height="10" rx="2" fill="#f0f0ff" stroke="#7f77dd" stroke-width="0.5"/>
+<text class="ts" x="306" y="755">ZZV backend</text>
+</svg>


### PR DESCRIPTION
## Summary

Ships the ZiLin full pipeline diagram into README and widens the permanent privacy rule in one PR. Three files touched, all in zi007lin/zai.

| File | Change |
|---|---|
| \`docs/assets/zilin-pipeline.svg\` | New 124-line dark-mode-aware SVG diagram |
| \`README.md\` | New "How it works" section between "How to use ZAI" and "ZAI Architecture" — embeds the SVG + one-paragraph narrative |
| \`CLAUDE.md\` | Privacy rule bullet list gains a fifth entry for IPs/hostnames/server-or-provider identifiers |

## Privacy catch the system made on itself

The source spec for this chore hard-coded a specific public IP address **and** the VPS provider name into the SVG's backend label. Committing it verbatim would have:

- Advertised the dev server's SSH target in a public README diagram (automated scanners find freshly-advertised IPs within hours)
- Pinned the diagram to a specific commercial provider, which the widened privacy rule would then flag
- Tied the repo's public face to mutable operational infrastructure

### What got scrubbed before commit

**SVG** — two places:
- Main backend label: \`ZZV backend — Contabo 147.93.181.126\` → \`ZZV backend — Cloud VPS\`
- \`<desc>\` accessibility text: \`Spec Agent on Contabo\` → \`Spec Agent on a cloud VPS\`

**README narrative** — one place:
- \`The Spec Agent on the ZZV backend (Contabo VPS) extracts…\` → \`The Spec Agent on the ZZV backend (cloud VPS) extracts…\`

Post-scrub grep in both files returns **zero matches** for \`Contabo\` and \`147\.93\`.

### Scored spec intentionally not committed to \`issues/\`

Previous chore PRs in this session committed the scored spec file to \`issues/\` for traceability. This one does not. Reason: the raw spec at \`/mnt/c/Users/zilin/Downloads/2026-04-13__chore__zai-readme-pipeline-diagram.scored.md\` contains the un-scrubbed \`Contabo 147.93.181.126\` string on line 84 as part of the SVG source, and committing it would re-introduce the exact leak this PR removes from the rendered file. The commit message + this PR body are the traceability record for this one.

## Privacy rule — widened

The permanent privacy rule in \`CLAUDE.md\` now reads (fifth bullet new):

> Sensitive operational details are NEVER committed to public repos:
> - Local filesystem paths (\`~/dev/...\`)
> - Command inventories or toolchain invocations
> - Symlink structures pointing to private repos
> - Internal module paths or test invocations
> - **Public IPs, hostnames, or server or provider identifiers for internal infrastructure** ← new

Next time the pattern comes up, the rule catches it without a judgment call.

## Out of scope for this PR

The same privacy rule ships in \`streettt/CLAUDE.md\` (PR #931, merged). That copy still has the **4-bullet** version. A tiny follow-up should sync the new fifth bullet to streettt too — say the word and I'll do it. This PR is scoped to zai only per the explicit "same PR" instruction.

## Score gate

\`2026-04-13__chore__zai-readme-pipeline-diagram.scored.md\` — **chore 2/2 PASS** · rubric v1.1.0. Presence check + \`- **Passed:** YES\` + Option B re-run integrity all green before commit.

Reviewer: daniel-silvers