### PR TITLE
chore: CLAUDE.md Gate 1 spec approval stub + needs-approval label inventory

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -25,3 +25,6 @@
 - name: refactor
   color: D3D1C7
   description: Code restructure, no behavior change
+- name: needs-approval
+  color: FBCA04
+  description: Non-trivial spec — awaiting daniel-silvers approval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,19 @@ Note: the re-run integrity check (Option B) is superseded by CF Worker signature
 verification (Option A) once `SCORE_SIGNING_KEY` is live on the runner. See
 `issues/parked/2026-04-13__feat__zai-score-signing-cf-worker.md`.
 
+### Gate 1 — spec approval
+
+Before impl runs, every spec is classified:
+
+- **Trivial** (`chore` 2/2, `hotfix` 3/3, no gates listed in the score block):
+  AUTO — proceeds immediately
+- **Non-trivial** (`feat`, `bug`, `research`, or any spec with one or more items
+  in `gates[]`, or any spec referencing a force-push / history rewrite /
+  destructive operation): HOLD — daniel-silvers approves the GitHub issue
+  before ZiLin-Dev reads it
+
+See the private layer for the full classifier implementation.
+
 ## Layer 2 Commands
 
 Implementation details live in the private layer (never in this public repo).


### PR DESCRIPTION
## Summary

Public stub half of the Gate 1 spec approval classifier. The full rule lives in the private layer (parallel PR); this file carries only the trivial-vs-non-trivial summary so readers of public GitHub history know the gate exists and understand how it decides.

## Changes

| File | Change |
|---|---|
| \`CLAUDE.md\` | New \`### Gate 1 — spec approval\` subsection under Hard Rules, directly after the Option B re-run check note |
| \`.github/labels.yml\` | New \`needs-approval\` entry at the end (9th label in the HTU set) |

\`gh label create needs-approval\` already ran against \`zi007lin/zai\` before this PR — the label is live, this PR records it in the canonical inventory.

## The stub in full

\`\`\`markdown
### Gate 1 — spec approval

Before impl runs, every spec is classified:

- **Trivial** (\`chore\` 2/2, \`hotfix\` 3/3, no gates listed in the score block):
  AUTO — proceeds immediately
- **Non-trivial** (\`feat\`, \`bug\`, \`research\`, or any spec with one or more items
  in \`gates[]\`, or any spec referencing a force-push / history rewrite /
  destructive operation): HOLD — daniel-silvers approves the GitHub issue
  before ZiLin-Dev reads it

See the private layer for the full classifier implementation.
\`\`\`

## Ordering in Hard Rules

The runtime flow is now explicit in the file: **score gate** confirms the spec is valid → **re-run check** (Option B) confirms the stored score is accurate → **Gate 1** classifies whether impl auto-proceeds or waits for daniel-silvers. Each step catches a different failure mode; together they form the operational version of the "zero ambiguity" claim.

## Privacy catch

The spec file's proposed text said \`"See streettt-private for full classifier implementation."\` — naming the private repo explicitly. I substituted \`"See the private layer for..."\` to match the existing convention in this file (set by PR #24) and avoid re-introducing the private repo name into public history.

The scored spec file itself is **not** committed to \`issues/\`. Its body names the private repo multiple times, and the traceability copy would re-introduce the leak the rule just caught. Same pattern as PR #27. Commit message + this PR body are the trail.

## Self-check

This chore applies Gate 1 to itself: \`chore 2/2 PASS\` with no gates, no destructive-op references in the text I'm shipping. Trivial under its own rules. Auto-proceeds.

## Parallel PRs

- \`streettt-private\` — full classifier implementation (needs_input message, override mechanism, content scan for destructive-operation strings)
- \`zi007lin/streettt\` — \`needs-approval\` added to that repo's \`.github/labels.yml\`

All three share the same spec. Any merge order works.

Reviewer: daniel-silvers