### PR TITLE
chore: Gate 1 solo-operator path — public stub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ Before impl runs, every spec is classified:
 
 See the private layer for the full classifier implementation.
 
+Solo operator: ZiLin may self-approve non-trivial specs via session reply
+`approved` or label removal. PR review at merge is always required.
+See the private layer for the full solo-operator rule.
+
 ## Layer 2 Commands
 
 Implementation details live in the private layer (never in this public repo).


### PR DESCRIPTION
## Summary

Appends a three-line pointer to the Gate 1 stub so public-repo readers know the solo-operator path exists. The full rule ships in parallel on the private layer.

## Diff

\`CLAUDE.md\` — +4 lines. One pointer paragraph after the existing "See the private layer for the full classifier implementation." line.

## Stub text shipped

> Solo operator: ZiLin may self-approve non-trivial specs via session reply \`approved\` or label removal. PR review at merge is always required. See the private layer for the full solo-operator rule.

No paths, no commands, no private repo names. Matches the existing "the private layer" convention from PR #24.

## Why this chore exists

Gate 1 (installed in PR #28) holds non-trivial specs — \`feat\`, \`research\`, \`bug\`, anything with pre-deploy gates — behind daniel-silvers approval via the \`needs-approval\` label. In a solo-operator session (ZiLin acting as both author and reviewer), the label is a courtesy hold with no second actor to remove it. The spec landed **this week**: streettt-private issue #32 (the ZZV backend research) is currently held by exactly that self-stall.

The solo-operator path makes the unblock explicit: reply \`approved\` in-session, or remove the label directly, then run \`implw\`. The PR review at merge remains mandatory — that is the real enforceable dual-control gate, and it does not relax.

## Governance claim preserved

The spec's Game-Theory-level observation: **every merged PR was reviewed before merge**. The pre-impl issue approval was always a team-scale courtesy, not the enforceable gate. PR review at merge is where dual-control actually lives, and this amendment does not touch that.

## Forward compatibility

When a second operator joins (daniel-silvers as a distinct actor, or any other reviewer account), \`needs-approval\` becomes a hard gate again automatically. No rule change needed — the solo-operator path is a self-applied exception that stops applying the moment there are two actors.

## Privacy posture

Scored spec file **not** committed to \`zai/issues/\`. Its body names the private repo on lines 3, 17, 25, and committing the traceability copy would re-introduce the name into public history. Same pattern as PRs #27 and #28. The scored spec goes to \`streettt-private/issues/\` in the parallel PR.

## Self-check

- \`chore 2/2 PASS\`, no gates, no destructive-op strings in the shipped content
- Trivial under Gate 1 → auto-proceeds
- The 4-line stub being shipped contains zero forbidden content — no paths, no IPs, no provider names, no command inventories, no private repo names

## Parallel PR

- \`streettt-private\` — full solo-operator rule with the explicit session-reply / label-removal mechanism and the \`gh issue edit\` reference command

Reviewer: daniel-silvers