### PR TITLE
feat: CF Pages Function /api/impl dispatch endpoint (#44)

### DIFF
--- a/functions/api/impl.ts
+++ b/functions/api/impl.ts
@@ -1,0 +1,60 @@
+interface Env {
+  ZZV_DISPATCH_TOKEN: string;
+}
+
+interface ImplRequest {
+  issue_number: number;
+  repo?: string;
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+
+  const auth = request.headers.get('Authorization');
+  if (!auth || auth !== `Bearer ${env.ZZV_DISPATCH_TOKEN}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  let body: ImplRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  if (!body.issue_number) {
+    return new Response('issue_number required', { status: 400 });
+  }
+
+  const repo = body.repo ?? 'zi007lin/streettt-private';
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repo}/dispatches`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${env.ZZV_DISPATCH_TOKEN}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({
+        event_type: 'zilin_impl',
+        client_payload: {
+          issue_number: body.issue_number,
+          repo,
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    return new Response(`GitHub API error: ${text}`, { status: 502 });
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, issue_number: body.issue_number, repo }),
+    { status: 202, headers: { 'Content-Type': 'application/json' } }
+  );
+};


### PR DESCRIPTION
Closes part of streettt-private#44 (CF Pages Function side). Workflow side: streettt-private PR.

## Summary

Adds `functions/api/impl.ts` — CF Pages Function at `/api/impl` that validates a Bearer token against `ZZV_DISPATCH_TOKEN` and forwards a `repository_dispatch` event of type `zilin_impl` to GitHub. Forms the CF Pages side of the ZZV queue listener.

## Files

- `functions/api/impl.ts` (new)

## Auth model

- Bearer token must equal `ZZV_DISPATCH_TOKEN` (CF Pages secret)
- Missing/invalid → 401
- Missing `issue_number` → 400
- GitHub API error → 502 with body
- Success → 202 with `{ ok, issue_number, repo }`

## Test plan

- [ ] Deploy to demo: `curl https://demo.zai.htu.io/api/impl` → 401 (no auth)
- [ ] Bearer token + valid body → 202; GitHub run appears in streettt-private Actions
- [ ] Wrong token → 401
- [ ] Empty body → 400

## ZAI Spec Score

- **Rubric version:** 1.1.0
- **Spec type:** feat
- **Score:** 7/7
- **Passed:** YES

(daniel-silvers not a collaborator on zai — review requested in the streettt-private companion PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)