### PR TITLE
feat: Run Impl button — auto-create issue + dispatch (#31)

### DIFF
--- a/functions/api/impl.ts
+++ b/functions/api/impl.ts
@@ -7,23 +7,52 @@ interface ImplRequest {
   repo?: string;
 }
 
+const ALLOWED_ORIGINS = new Set([
+  'https://zai.htu.io',
+  'https://demo.zai.htu.io',
+  'https://dev.zai.htu.io',
+  'http://localhost:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:5173',
+]);
+
+function originAllowed(request: Request): boolean {
+  const origin = request.headers.get('Origin');
+  if (!origin) return false;
+  return ALLOWED_ORIGINS.has(origin);
+}
+
+function corsHeaders(request: Request): Record<string, string> {
+  const origin = request.headers.get('Origin') ?? '';
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : '',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+}
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => {
+  return new Response(null, { status: 204, headers: corsHeaders(request) });
+};
+
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
+  const cors = corsHeaders(request);
 
-  const auth = request.headers.get('Authorization');
-  if (!auth || auth !== `Bearer ${env.ZZV_DISPATCH_TOKEN}`) {
-    return new Response('Unauthorized', { status: 401 });
+  if (!originAllowed(request)) {
+    return new Response('Forbidden origin', { status: 403, headers: cors });
   }
 
   let body: ImplRequest;
   try {
     body = await request.json();
   } catch {
-    return new Response('Invalid JSON', { status: 400 });
+    return new Response('Invalid JSON', { status: 400, headers: cors });
   }
 
   if (!body.issue_number) {
-    return new Response('issue_number required', { status: 400 });
+    return new Response('issue_number required', { status: 400, headers: cors });
   }
 
   const repo = body.repo ?? 'zi007lin/streettt-private';
@@ -36,6 +65,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         'Authorization': `Bearer ${env.ZZV_DISPATCH_TOKEN}`,
         'Accept': 'application/vnd.github+json',
         'Content-Type': 'application/json',
+        'User-Agent': 'zai-pages-fn',
         'X-GitHub-Api-Version': '2022-11-28',
       },
       body: JSON.stringify({
@@ -50,11 +80,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
   if (!response.ok) {
     const text = await response.text();
-    return new Response(`GitHub API error: ${text}`, { status: 502 });
+    return new Response(`GitHub API error: ${text}`, { status: 502, headers: cors });
   }
 
   return new Response(
     JSON.stringify({ ok: true, issue_number: body.issue_number, repo }),
-    { status: 202, headers: { 'Content-Type': 'application/json' } }
+    { status: 202, headers: { ...cors, 'Content-Type': 'application/json' } }
   );
 };

--- a/functions/api/issue.ts
+++ b/functions/api/issue.ts
@@ -1,0 +1,120 @@
+interface Env {
+  ZZV_DISPATCH_TOKEN: string;
+}
+
+interface IssueRequest {
+  title: string;
+  body: string;
+  label: string;
+  repo?: string;
+}
+
+interface GitHubIssue {
+  number: number;
+  html_url: string;
+  title: string;
+}
+
+const ALLOWED_ORIGINS = new Set([
+  'https://zai.htu.io',
+  'https://demo.zai.htu.io',
+  'https://dev.zai.htu.io',
+  'http://localhost:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:5173',
+]);
+
+function originAllowed(request: Request): boolean {
+  const origin = request.headers.get('Origin');
+  if (!origin) return false;
+  return ALLOWED_ORIGINS.has(origin);
+}
+
+function corsHeaders(request: Request): Record<string, string> {
+  const origin = request.headers.get('Origin') ?? '';
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : '',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+}
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => {
+  return new Response(null, { status: 204, headers: corsHeaders(request) });
+};
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const cors = corsHeaders(request);
+
+  if (!originAllowed(request)) {
+    return new Response('Forbidden origin', { status: 403, headers: cors });
+  }
+
+  let body: IssueRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid JSON', { status: 400, headers: cors });
+  }
+
+  if (!body.title || !body.body || !body.label) {
+    return new Response('title, body, label required', { status: 400, headers: cors });
+  }
+
+  const repo = body.repo ?? 'zi007lin/streettt-private';
+
+  const ghHeaders: Record<string, string> = {
+    'Authorization': `Bearer ${env.ZZV_DISPATCH_TOKEN}`,
+    'Accept': 'application/vnd.github+json',
+    'Content-Type': 'application/json',
+    'User-Agent': 'zai-pages-fn',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // Dedupe: look for existing open issue with same title under the same label
+  const dedupeUrl =
+    `https://api.github.com/repos/${repo}/issues` +
+    `?state=open&labels=${encodeURIComponent(body.label)}&per_page=50`;
+  const dedupeRes = await fetch(dedupeUrl, { headers: ghHeaders });
+  if (dedupeRes.ok) {
+    const list = (await dedupeRes.json()) as GitHubIssue[];
+    const match = list.find((i) => i.title === body.title);
+    if (match) {
+      return new Response(
+        JSON.stringify({
+          issue_number: match.number,
+          url: match.html_url,
+          deduped: true,
+        }),
+        { status: 200, headers: { ...cors, 'Content-Type': 'application/json' } }
+      );
+    }
+  }
+
+  const createRes = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: 'POST',
+    headers: ghHeaders,
+    body: JSON.stringify({
+      title: body.title,
+      body: body.body,
+      labels: [body.label],
+    }),
+  });
+
+  if (!createRes.ok) {
+    const text = await createRes.text();
+    return new Response(`GitHub API error: ${text}`, { status: 502, headers: cors });
+  }
+
+  const issue = (await createRes.json()) as GitHubIssue;
+  return new Response(
+    JSON.stringify({
+      issue_number: issue.number,
+      url: issue.html_url,
+      deduped: false,
+    }),
+    { status: 201, headers: { ...cors, 'Content-Type': 'application/json' } }
+  );
+};

--- a/src/components/ScorePanel.tsx
+++ b/src/components/ScorePanel.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { type ScoreResult, type SectionStatus } from "../lib/scoreSpec";
 
+type ImplState = "idle" | "dispatching" | "queued" | "error";
+
 interface Props {
   result: ScoreResult;
   filename: string;
   onDownloadScored: () => void;
-  onCopyImplCommand: () => void;
-  justCopied: boolean;
+  onRunImpl: () => void;
+  implState: ImplState;
+  issueNumber: number | null;
+  errorMsg: string;
+  targetRepo: string;
 }
 
 const STAGGER_MS = 200;
@@ -30,8 +35,11 @@ export default function ScorePanel({
   result,
   filename,
   onDownloadScored,
-  onCopyImplCommand,
-  justCopied,
+  onRunImpl,
+  implState,
+  issueNumber,
+  errorMsg,
+  targetRepo,
 }: Props) {
   const reducedMotion = useMemo(() => prefersReducedMotion(), []);
   const totalSections = result.section_order.length;
@@ -222,13 +230,44 @@ export default function ScorePanel({
         </button>
         <button
           type="button"
-          onClick={onCopyImplCommand}
-          className="flex-1 px-4 py-2.5 rounded-md bg-[var(--zai-teal)] text-white font-medium hover:opacity-90 transition-opacity"
+          onClick={onRunImpl}
+          disabled={!result.passed || implState === "dispatching" || implState === "queued"}
+          className="flex-1 px-4 py-2.5 rounded-md bg-[var(--zai-teal)] text-white font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
           style={{ fontFamily: "var(--font-sans-zai)" }}
+          data-testid="run-impl-button"
         >
-          {justCopied ? "Copied!" : "Run impl →"}
+          {implState === "dispatching" && "Dispatching…"}
+          {implState === "queued" && "Run impl → (queued)"}
+          {(implState === "idle" || implState === "error") && "Run impl →"}
         </button>
       </div>
+
+      {implState === "queued" && issueNumber !== null && (
+        <div
+          className="mt-3 text-sm text-[var(--zai-teal)]"
+          data-testid="run-impl-queued"
+        >
+          ✅ Queued for issue #{issueNumber} — PR will open in ~2 min.{" "}
+          <a
+            href={`https://github.com/${targetRepo}/actions`}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            Watch run →
+          </a>
+        </div>
+      )}
+
+      {implState === "error" && (
+        <div
+          className="mt-3 text-sm text-[#E15B5B]"
+          data-testid="run-impl-error"
+        >
+          ❌ {errorMsg || "Pipeline error — retry or run implw manually"}
+        </div>
+      )}
+
     </div>
   );
 }

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -52,16 +52,25 @@ function buildScoredSpec(
   return lines.join("\n");
 }
 
+type ImplState = "idle" | "dispatching" | "queued" | "error";
+
+const TARGET_REPO = "zi007lin/streettt-private";
+
 export default function AppPage() {
   const [filename, setFilename] = useState<string | null>(null);
   const [markdown, setMarkdown] = useState<string | null>(null);
   const [result, setResult] = useState<ScoreResult | null>(null);
-  const [justCopied, setJustCopied] = useState(false);
+  const [implState, setImplState] = useState<ImplState>("idle");
+  const [issueNumber, setIssueNumber] = useState<number | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string>("");
 
   const handleFile = useCallback((name: string, contents: string) => {
     setFilename(name);
     setMarkdown(contents);
     setResult(scoreSpec(contents, name));
+    setImplState("idle");
+    setIssueNumber(null);
+    setErrorMsg("");
   }, []);
 
   const handleDownloadTemplate = useCallback(() => {
@@ -75,17 +84,46 @@ export default function AppPage() {
     downloadBlob(scoredName, out);
   }, [filename, markdown, result]);
 
-  const handleCopyImplCommand = useCallback(async () => {
-    if (!filename) return;
-    const cmd = `impl i ${filename}`;
+  const handleRunImpl = useCallback(async () => {
+    if (!filename || !markdown || !result || !result.passed) return;
+    setImplState("dispatching");
+    setErrorMsg("");
     try {
-      await navigator.clipboard.writeText(cmd);
-    } catch {
-      // silently ignore — toast still fires
+      const scoredBody = buildScoredSpec(filename, markdown, result);
+      const titleSlug = filename.replace(/\.md$/i, "").replace(/^.*__/, "");
+      const issueRes = await fetch("/api/issue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: `${result.spec_type}: ${titleSlug}`,
+          body: scoredBody,
+          label: result.spec_type,
+          repo: TARGET_REPO,
+        }),
+      });
+      if (!issueRes.ok) {
+        throw new Error(`/api/issue ${issueRes.status}: ${await issueRes.text()}`);
+      }
+      const issueData = (await issueRes.json()) as { issue_number: number };
+      setIssueNumber(issueData.issue_number);
+
+      const dispatchRes = await fetch("/api/impl", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          issue_number: issueData.issue_number,
+          repo: TARGET_REPO,
+        }),
+      });
+      if (!dispatchRes.ok) {
+        throw new Error(`/api/impl ${dispatchRes.status}: ${await dispatchRes.text()}`);
+      }
+      setImplState("queued");
+    } catch (e) {
+      setImplState("error");
+      setErrorMsg(e instanceof Error ? e.message : "Unknown error");
     }
-    setJustCopied(true);
-    window.setTimeout(() => setJustCopied(false), 1600);
-  }, [filename]);
+  }, [filename, markdown, result]);
 
   const header = useMemo(
     () => (
@@ -134,8 +172,11 @@ export default function AppPage() {
               result={result}
               filename={filename}
               onDownloadScored={handleDownloadScored}
-              onCopyImplCommand={handleCopyImplCommand}
-              justCopied={justCopied}
+              onRunImpl={handleRunImpl}
+              implState={implState}
+              issueNumber={issueNumber}
+              errorMsg={errorMsg}
+              targetRepo={TARGET_REPO}
             />
           ) : (
             <div


### PR DESCRIPTION
Closes #31

## Summary

Replaces the clipboard-copy "Run impl →" button with a single click that:
1. Calls `POST /api/issue` to create (or dedupe) a GitHub issue on \`zi007lin/streettt-private\`
2. Calls `POST /api/impl` to dispatch a \`zilin_impl\` event to the Contabo runner
3. Shows a queued state with an Actions watch link, or inline error

## Files

- \`functions/api/impl.ts\` — replaced Bearer auth with Origin allowlist + CORS
- \`functions/api/issue.ts\` (new) — creates GitHub issue, dedupes by title
- \`src/pages/AppPage.tsx\` — new \`handleRunImpl\` flow + state
- \`src/components/ScorePanel.tsx\` — new button states (idle/dispatching/queued/error)

## Auth model

Per spec game-theory mitigation §3: **no Bearer token in the frontend**. Both functions validate the \`Origin\` request header against an allowlist (\`zai.htu.io\`, \`demo.zai.htu.io\`, \`dev.zai.htu.io\`, localhost dev ports). \`ZZV_DISPATCH_TOKEN\` lives only in CF Pages env and is only sent to the GitHub API.

## Deviation from literal spec

Issue creation fires **on button click**, not on a \`useEffect\` after score pass. Reasons:
- Addresses abuse vector #1 (no duplicate issues from repeat uploads)
- Avoids creating GitHub issues just from viewing a spec
- Preserves the existing e2e contract (\"Run impl →\" button visible after score pass)
- One explicit user action → one side effect

## Test plan

- [x] \`npm run build\` — clean (tsc + vite)
- [x] \`npm test\` — 25/25 unit tests pass
- [ ] e2e: \`npm run test:e2e\` — button still labeled \"Run impl →\" after PASS
- [ ] After deploy to demo: upload a passing chore spec → click → issue created → PR appears
- [ ] Wrong-origin curl returns 403
- [ ] Repeat upload of same spec → dedupe → same issue number returned

## ZAI Spec Score

- **Rubric:** 1.1.0 · **Type:** feat · **Score:** 7/7 · **Passed:** YES