### PR TITLE
fix: Run impl dispatches to wrong repo

### DIFF
--- a/functions/api/impl.ts
+++ b/functions/api/impl.ts
@@ -55,7 +55,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     return new Response('issue_number required', { status: 400, headers: cors });
   }
 
-  const repo = body.repo ?? 'zi007lin/streettt-private';
+  const repo = body.repo ?? 'zi007lin/zai';
 
   const response = await fetch(
     `https://api.github.com/repos/${repo}/dispatches`,

--- a/functions/api/issue.ts
+++ b/functions/api/issue.ts
@@ -63,7 +63,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     return new Response('title, body, label required', { status: 400, headers: cors });
   }
 
-  const repo = body.repo ?? 'zi007lin/streettt-private';
+  const repo = body.repo ?? 'zi007lin/zai';
 
   const ghHeaders: Record<string, string> = {
     'Authorization': `Bearer ${env.ZZV_DISPATCH_TOKEN}`,

--- a/src/components/ScorePanel.tsx
+++ b/src/components/ScorePanel.tsx
@@ -247,7 +247,16 @@ export default function ScorePanel({
           className="mt-3 text-sm text-[var(--zai-teal)]"
           data-testid="run-impl-queued"
         >
-          ✅ Queued for issue #{issueNumber} — PR will open in ~2 min.{" "}
+          ✅ Queued —{" "}
+          <a
+            href={`https://github.com/${targetRepo}/issues/${issueNumber}`}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            Issue #{issueNumber}
+          </a>{" "}
+          — PR will open in ~2 min.{" "}
           <a
             href={`https://github.com/${targetRepo}/actions`}
             target="_blank"

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -54,7 +54,7 @@ function buildScoredSpec(
 
 type ImplState = "idle" | "dispatching" | "queued" | "error";
 
-const TARGET_REPO = "zi007lin/streettt-private";
+const TARGET_REPO = "zi007lin/zai";
 
 export default function AppPage() {
   const [filename, setFilename] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

- Change default dispatch target from `zi007lin/streettt-private` to `zi007lin/zai` in `functions/api/impl.ts`, `functions/api/issue.ts`, and `src/pages/AppPage.tsx`
- Add issue link to ScorePanel queued status so users can navigate directly to the created issue

Closes #33

## Test plan

- [ ] Upload a passing scored spec to dev.zai.htu.io/app
- [ ] Click "Run impl →" — verify issue is created in `zi007lin/zai`
- [ ] Verify dispatch fires to `zi007lin/zai` runner (check Actions tab)
- [ ] Verify queued status shows clickable issue link
- [ ] Verify PR is created in `zi007lin/zai` after impl completes