### PR TITLE
feat: scorer fail row expansion

### DIFF
--- a/functions/api/score.ts
+++ b/functions/api/score.ts
@@ -1,0 +1,86 @@
+interface Env {
+  SCORE_ANALYTICS?: AnalyticsEngineDataset;
+}
+
+interface ScoreEvent {
+  section: string;
+  status: string;
+  reason: string | null;
+  spec_type: string;
+  rubric_version: string;
+}
+
+interface ScoreLogRequest {
+  rubric_version: string;
+  spec_type: string;
+  events: ScoreEvent[];
+}
+
+const ALLOWED_ORIGINS = new Set([
+  'https://zai.htu.io',
+  'https://demo.zai.htu.io',
+  'https://dev.zai.htu.io',
+  'http://localhost:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:5173',
+]);
+
+function originAllowed(request: Request): boolean {
+  const origin = request.headers.get('Origin');
+  if (!origin) return false;
+  return ALLOWED_ORIGINS.has(origin);
+}
+
+function corsHeaders(request: Request): Record<string, string> {
+  const origin = request.headers.get('Origin') ?? '';
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : '',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+}
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) => {
+  return new Response(null, { status: 204, headers: corsHeaders(request) });
+};
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const cors = corsHeaders(request);
+
+  if (!originAllowed(request)) {
+    return new Response('Forbidden origin', { status: 403, headers: cors });
+  }
+
+  let body: ScoreLogRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid JSON', { status: 400, headers: cors });
+  }
+
+  if (!body.events || !Array.isArray(body.events)) {
+    return new Response('events[] required', { status: 400, headers: cors });
+  }
+
+  if (env.SCORE_ANALYTICS) {
+    for (const event of body.events) {
+      env.SCORE_ANALYTICS.writeDataPoint({
+        blobs: [
+          event.section,
+          event.status,
+          event.reason ?? '',
+          event.spec_type,
+          event.rubric_version,
+        ],
+        indexes: [event.spec_type],
+      });
+    }
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, logged: body.events.length }),
+    { status: 200, headers: { ...cors, 'Content-Type': 'application/json' } }
+  );
+};

--- a/src/components/ScorePanel.tsx
+++ b/src/components/ScorePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type ScoreResult, type SectionStatus } from "../lib/scoreSpec";
 
 type ImplState = "idle" | "dispatching" | "queued" | "error";
@@ -45,6 +45,25 @@ export default function ScorePanel({
   const totalSections = result.section_order.length;
   const denominator = result.required_count;
   const [revealed, setRevealed] = useState(reducedMotion ? totalSections : 0);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Auto-expand all FAIL rows once reveal animation completes
+  useEffect(() => {
+    if (revealed < totalSections) return;
+    const failKeys = result.section_order.filter(
+      (k) => result.sections[k] === "FAIL" && result.section_reasons[k]
+    );
+    if (failKeys.length > 0) setExpanded(new Set(failKeys));
+  }, [revealed, totalSections, result.section_order, result.sections, result.section_reasons]);
 
   useEffect(() => {
     if (reducedMotion) {
@@ -52,6 +71,7 @@ export default function ScorePanel({
       return;
     }
     setRevealed(0);
+    setExpanded(new Set());
     const timers: number[] = [];
     for (let i = 1; i <= totalSections; i++) {
       timers.push(window.setTimeout(() => setRevealed(i), i * STAGGER_MS));
@@ -150,45 +170,98 @@ export default function ScorePanel({
       <div className="mt-6 space-y-3">
         {result.section_order.map((key, i) => {
           const status = result.sections[key];
+          const reason = result.section_reasons[key];
           const isRevealed = i < revealed;
           const fill = isRevealed ? 100 : 0;
+          const isFail = status === "FAIL" && reason;
+          const isExpanded = expanded.has(key);
           return (
-            <div
-              key={key}
-              className="grid grid-cols-[1fr_auto] sm:grid-cols-[160px_1fr_auto] gap-3 items-center"
-              data-testid={`section-${key}`}
-            >
+            <div key={key} data-testid={`section-${key}`}>
               <div
-                className="text-xs sm:text-sm text-neutral-300 truncate"
-                style={{ fontFamily: "var(--font-mono-zai)" }}
-                title={result.section_labels[key]}
+                className={`grid grid-cols-[1fr_auto] sm:grid-cols-[160px_1fr_auto] gap-3 items-center${
+                  isFail ? " cursor-pointer" : ""
+                }`}
+                role={isFail ? "button" : undefined}
+                tabIndex={isFail ? 0 : undefined}
+                onClick={isFail ? () => toggleExpanded(key) : undefined}
+                onKeyDown={
+                  isFail
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          toggleExpanded(key);
+                        }
+                      }
+                    : undefined
+                }
               >
-                {result.section_labels[key]}
-              </div>
-              <div className="hidden sm:block h-2 rounded-full bg-[var(--zai-border)] overflow-hidden">
                 <div
-                  className="h-full rounded-full"
+                  className="text-xs sm:text-sm text-neutral-300 truncate flex items-center gap-1.5"
+                  style={{ fontFamily: "var(--font-mono-zai)" }}
+                  title={result.section_labels[key]}
+                >
+                  {result.section_labels[key]}
+                  {isFail && (
+                    <span
+                      className="text-[10px] transition-transform duration-150"
+                      style={{
+                        display: "inline-block",
+                        transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+                        color: "#E15B5B",
+                      }}
+                    >
+                      ▼
+                    </span>
+                  )}
+                </div>
+                <div className="hidden sm:block h-2 rounded-full bg-[var(--zai-border)] overflow-hidden">
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${fill}%`,
+                      background: statusColor(status),
+                      transition: reducedMotion
+                        ? undefined
+                        : "width 600ms cubic-bezier(0.4, 0, 0.2, 1)",
+                    }}
+                  />
+                </div>
+                <span
+                  className="justify-self-end text-[10px] px-2 py-0.5 rounded-full font-semibold"
                   style={{
-                    width: `${fill}%`,
-                    background: statusColor(status),
+                    fontFamily: "var(--font-mono-zai)",
+                    color: statusColor(status),
+                    border: `1px solid ${statusColor(status)}`,
+                    opacity: isRevealed ? 1 : 0.25,
+                    transition: "opacity 200ms",
+                  }}
+                >
+                  {statusLabel(status)}
+                </span>
+              </div>
+              {isFail && (
+                <div
+                  className="overflow-hidden"
+                  style={{
+                    maxHeight: isExpanded ? "200px" : "0",
                     transition: reducedMotion
                       ? undefined
-                      : "width 600ms cubic-bezier(0.4, 0, 0.2, 1)",
+                      : "max-height 150ms ease-in",
                   }}
-                />
-              </div>
-              <span
-                className="justify-self-end text-[10px] px-2 py-0.5 rounded-full font-semibold"
-                style={{
-                  fontFamily: "var(--font-mono-zai)",
-                  color: statusColor(status),
-                  border: `1px solid ${statusColor(status)}`,
-                  opacity: isRevealed ? 1 : 0.25,
-                  transition: "opacity 200ms",
-                }}
-              >
-                {statusLabel(status)}
-              </span>
+                  data-testid={`section-${key}-reason`}
+                >
+                  <div
+                    className="mt-1.5 px-3 py-2 rounded-md text-xs text-neutral-200"
+                    style={{
+                      fontFamily: "var(--font-mono-zai)",
+                      background: "rgba(225, 91, 91, 0.1)",
+                      border: "1px solid rgba(225, 91, 91, 0.2)",
+                    }}
+                  >
+                    {reason}
+                  </div>
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -175,20 +175,30 @@ describe("scoreSpec — feat", () => {
     expect(r.score).toBe("7/7");
     expect(r.passed).toBe(true);
     expect(r.sections.draft_of_thoughts).toBe("PASS");
+    // all passing sections have null reason
+    for (const key of r.section_order) {
+      if (r.sections[key] !== "FAIL") {
+        expect(r.section_reasons[key]).toBeNull();
+      }
+    }
   });
 
-  it("intent FAILs on empty body", () => {
+  it("intent FAILs on empty body with reason", () => {
     const md = featSpec.replace(
       /## Intent\nA tight paragraph[^\n]*\n/,
       "## Intent\n\n"
     );
-    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.intent).toBe("FAIL");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.intent).toBe("FAIL");
+    expect(r.section_reasons.intent).toBe("intent section is empty");
   });
 
-  it("intent FAILs when body exceeds 150 words", () => {
+  it("intent FAILs when body exceeds 150 words with reason", () => {
     const long = "word ".repeat(200);
     const md = `## Intent\n${long}\n\n## Next\n`;
-    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.intent).toBe("FAIL");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.intent).toBe("FAIL");
+    expect(r.section_reasons.intent).toMatch(/exceeds 150-word limit/);
   });
 
   it("decision_tree FAILs without a table", () => {
@@ -196,13 +206,16 @@ describe("scoreSpec — feat", () => {
       /\| Option \| Risk \| Decision \|\n\|---\|---\|---\|\n\| A \| low \| ✅ \|\n/,
       ""
     );
-    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.decision_tree).toBe("FAIL");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.decision_tree).toBe("FAIL");
+    expect(r.section_reasons.decision_tree).toMatch(/missing decision table/);
   });
 
   it("draft_of_thoughts SKIPs when absent (never FAIL)", () => {
     const md = featSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.draft_of_thoughts).toBe("SKIP");
+    expect(r.section_reasons.draft_of_thoughts).toBeNull();
     expect(r.passed).toBe(true);
     expect(r.score).toBe("7/7");
   });
@@ -212,12 +225,16 @@ describe("scoreSpec — feat", () => {
       /- \[ \] one\n- \[ \] two\n- \[ \] three\n/,
       "- [ ] one\n- [ ] two\n"
     );
-    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.final_spec).toBe("FAIL");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.final_spec).toBe("FAIL");
+    expect(r.section_reasons.final_spec).toMatch(/minimum 3 acceptance criteria/);
   });
 
   it("game_theory FAILs when Mitigation is missing", () => {
     const md = featSpec.replace(/Mitigation:[^\n]*\n/, "");
-    expect(scoreSpec(md, "2026-04-13__feat__x.md").sections.game_theory).toBe("FAIL");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.game_theory).toBe("FAIL");
+    expect(r.section_reasons.game_theory).toMatch(/Mitigation/);
   });
 });
 
@@ -310,6 +327,44 @@ describe("scoreSpec — hotfix", () => {
     expect(r.required_count).toBe(3);
     expect(r.score).toBe("3/3");
     expect(r.passed).toBe(true);
+  });
+});
+
+// ─── section_reasons ──────────────────────────────────────────────────────
+
+describe("scoreSpec — section_reasons", () => {
+  it("all passing sections return null reasons", () => {
+    const r = scoreSpec(featSpec, "2026-04-12__feat__example.md");
+    for (const key of r.section_order) {
+      expect(r.section_reasons[key]).toBeNull();
+    }
+  });
+
+  it("failing sections return non-null reason strings", () => {
+    const r = scoreSpec("# README\n\nJust a readme.\n", "2026-04-13__feat__x.md");
+    for (const key of r.section_order) {
+      if (r.sections[key] === "FAIL") {
+        expect(typeof r.section_reasons[key]).toBe("string");
+        expect((r.section_reasons[key] as string).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("files_list reason mentions code block when section exists but has no code block", () => {
+    const md = `${featSpec.replace(/```\nsrc\/foo\.ts\n```/, "no code block here")}`;
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.files_list).toBe("FAIL");
+    expect(r.section_reasons.files_list).toMatch(/no code block/);
+  });
+
+  it("migration_summary reason mentions Open questions when row is empty", () => {
+    const md = featSpec.replace(
+      /\| Open questions \| confirm name \|/,
+      "| Open questions | |"
+    );
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.migration_summary).toBe("FAIL");
+    expect(r.section_reasons.migration_summary).toMatch(/Open questions/);
   });
 });
 

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -10,6 +10,7 @@ export interface ScoreResult {
   passed: boolean;
   evaluated_at: string;
   sections: Record<string, SectionStatus>;
+  section_reasons: Record<string, string | null>;
   section_order: string[];
   section_labels: Record<string, string>;
   gates: string[];
@@ -67,6 +68,25 @@ function acceptanceCriteriaCheckboxes(markdown: string): number {
   return checkboxCount(slice);
 }
 
+// ─── section check result ─────────────────────────────────────────────────
+
+interface CheckResult {
+  status: SectionStatus;
+  reason: string | null;
+}
+
+function pass(): CheckResult {
+  return { status: "PASS", reason: null };
+}
+
+function skip(): CheckResult {
+  return { status: "SKIP", reason: null };
+}
+
+function fail(reason: string): CheckResult {
+  return { status: "FAIL", reason };
+}
+
 // ─── section checks ───────────────────────────────────────────────────────
 
 const INTENT_HEADING = /^##\s+Intent\b/mi;
@@ -82,87 +102,136 @@ const REPORT_FORMAT_HEADING = /^##\s+Report\s+Format\b/mi;
 const REPRO_HEADING = /^##\s+Repro(duction)?(\s+Steps)?\b/mi;
 const FIX_HEADING = /^##\s+Fix\b/mi;
 
-function checkIntentStrict(md: string): SectionStatus {
-  if (!headingPresent(md, INTENT_HEADING)) return "FAIL";
+function checkIntentStrict(md: string): CheckResult {
+  if (!headingPresent(md, INTENT_HEADING))
+    return fail("\"## Intent\" heading not found");
   const body = sectionBody(md, INTENT_HEADING);
   const words = wordCount(body);
-  return words > 0 && words <= 150 ? "PASS" : "FAIL";
+  if (words === 0) return fail("intent section is empty");
+  if (words > 150)
+    return fail(`intent exceeds 150-word limit — found ${words} words`);
+  return pass();
 }
 
-function checkIntentLoose(md: string): SectionStatus {
-  return headingPresent(md, INTENT_HEADING) ? "PASS" : "FAIL";
+function checkIntentLoose(md: string): CheckResult {
+  if (!headingPresent(md, INTENT_HEADING))
+    return fail("\"## Intent\" heading not found");
+  return pass();
 }
 
-function checkDecisionTree(md: string): SectionStatus {
-  if (!headingPresent(md, DECISION_TREE_HEADING)) return "FAIL";
+function checkDecisionTree(md: string): CheckResult {
+  if (!headingPresent(md, DECISION_TREE_HEADING))
+    return fail("\"## Decision Tree\" heading not found");
   const body = sectionBody(md, DECISION_TREE_HEADING);
   const hasTable = tablePresent(body);
   const hasTrigger = /trigger\s+for\s+change/i.test(body);
-  return hasTable && hasTrigger ? "PASS" : "FAIL";
+  if (!hasTable && !hasTrigger)
+    return fail("missing decision table and \"Trigger for change\" statement");
+  if (!hasTable) return fail("missing decision table (expected \"| | |\" pattern)");
+  if (!hasTrigger) return fail("missing \"Trigger for change\" statement");
+  return pass();
 }
 
-function checkDraftOfThoughts(md: string): SectionStatus {
-  return headingPresent(md, DRAFT_HEADING) ? "PASS" : "SKIP";
+function checkDraftOfThoughts(md: string): CheckResult {
+  return headingPresent(md, DRAFT_HEADING) ? pass() : skip();
 }
 
-function checkFinalSpec(md: string): SectionStatus {
-  if (!headingPresent(md, FINAL_SPEC_HEADING)) return "FAIL";
-  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
-  return acceptanceCriteriaCheckboxes(md) >= 3 ? "PASS" : "FAIL";
+function checkFinalSpec(md: string): CheckResult {
+  if (!headingPresent(md, FINAL_SPEC_HEADING))
+    return fail("\"## Final Spec\" heading not found");
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
+    return fail("\"## Acceptance Criteria\" heading not found");
+  const count = acceptanceCriteriaCheckboxes(md);
+  if (count < 3)
+    return fail(
+      `minimum 3 acceptance criteria checkboxes required — found ${count}`
+    );
+  return pass();
 }
 
-function checkGameTheory(md: string): SectionStatus {
-  if (!headingPresent(md, GAME_THEORY_HEADING)) return "FAIL";
+function checkGameTheory(md: string): CheckResult {
+  if (!headingPresent(md, GAME_THEORY_HEADING))
+    return fail("\"## Game Theory\" heading not found");
   const body = sectionBody(md, GAME_THEORY_HEADING);
-  const ok =
-    /who\s+benefits/i.test(body) &&
-    /abuse\s+vector/i.test(body) &&
-    /mitigation/i.test(body);
-  return ok ? "PASS" : "FAIL";
+  const missing: string[] = [];
+  if (!/who\s+benefits/i.test(body)) missing.push("\"Who benefits\"");
+  if (!/abuse\s+vector/i.test(body)) missing.push("\"Abuse vector\"");
+  if (!/mitigation/i.test(body)) missing.push("\"Mitigation\"");
+  if (missing.length > 0)
+    return fail(`missing required subsections: ${missing.join(", ")}`);
+  return pass();
 }
 
-function checkMigrationSummary(md: string): SectionStatus {
-  if (!headingPresent(md, MIGRATION_HEADING)) return "FAIL";
+function checkMigrationSummary(md: string): CheckResult {
+  if (!headingPresent(md, MIGRATION_HEADING))
+    return fail("\"## Subject Migration Summary\" heading not found");
   const body = sectionBody(md, MIGRATION_HEADING);
-  return openQuestionsNotEmpty(body) ? "PASS" : "FAIL";
+  if (!openQuestionsNotEmpty(body))
+    return fail("\"Open questions\" row is empty or missing in migration table");
+  return pass();
 }
 
-function checkFilesList(md: string): SectionStatus {
-  if (!headingPresent(md, FILES_HEADING)) return "FAIL";
-  return codeBlockPresent(sectionBody(md, FILES_HEADING)) ? "PASS" : "FAIL";
+function checkFilesList(md: string): CheckResult {
+  if (!headingPresent(md, FILES_HEADING))
+    return fail("\"## Files\" heading not found");
+  if (!codeBlockPresent(sectionBody(md, FILES_HEADING)))
+    return fail("no code block found in Files section");
+  return pass();
 }
 
-function checkResearchQuestions(md: string): SectionStatus {
-  if (!headingPresent(md, RESEARCH_QUESTIONS_HEADING)) return "FAIL";
-  return subheadingCount(sectionBody(md, RESEARCH_QUESTIONS_HEADING)) >= 1
-    ? "PASS"
-    : "FAIL";
+function checkResearchQuestions(md: string): CheckResult {
+  if (!headingPresent(md, RESEARCH_QUESTIONS_HEADING))
+    return fail("\"## Research Questions\" heading not found");
+  if (subheadingCount(sectionBody(md, RESEARCH_QUESTIONS_HEADING)) < 1)
+    return fail("at least one ### subheading required under Research Questions");
+  return pass();
 }
 
-function checkAcceptanceCriteriaResearch(md: string): SectionStatus {
-  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
-  if (acceptanceCriteriaCheckboxes(md) < 3) return "FAIL";
-  return /report\s+saved/i.test(md) ? "PASS" : "FAIL";
+function checkAcceptanceCriteriaResearch(md: string): CheckResult {
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
+    return fail("\"## Acceptance Criteria\" heading not found");
+  const count = acceptanceCriteriaCheckboxes(md);
+  if (count < 3)
+    return fail(
+      `minimum 3 acceptance criteria checkboxes required — found ${count}`
+    );
+  if (!/report\s+saved/i.test(md))
+    return fail("missing \"report saved\" reference in acceptance criteria");
+  return pass();
 }
 
-function checkReportFormat(md: string): SectionStatus {
-  return headingPresent(md, REPORT_FORMAT_HEADING) ? "PASS" : "FAIL";
+function checkReportFormat(md: string): CheckResult {
+  if (!headingPresent(md, REPORT_FORMAT_HEADING))
+    return fail("\"## Report Format\" heading not found");
+  return pass();
 }
 
-function checkReproSteps(md: string): SectionStatus {
-  return headingPresent(md, REPRO_HEADING) ? "PASS" : "FAIL";
+function checkReproSteps(md: string): CheckResult {
+  if (!headingPresent(md, REPRO_HEADING))
+    return fail("\"## Repro\" heading not found");
+  return pass();
 }
 
-function checkBugFixSection(md: string): SectionStatus {
-  if (!headingPresent(md, FIX_HEADING)) return "FAIL";
-  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING)) return "FAIL";
-  return acceptanceCriteriaCheckboxes(md) >= 2 ? "PASS" : "FAIL";
+function checkBugFixSection(md: string): CheckResult {
+  if (!headingPresent(md, FIX_HEADING))
+    return fail("\"## Fix\" heading not found");
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
+    return fail("\"## Acceptance Criteria\" heading not found");
+  const count = acceptanceCriteriaCheckboxes(md);
+  if (count < 2)
+    return fail(
+      `minimum 2 acceptance criteria checkboxes required — found ${count}`
+    );
+  return pass();
 }
 
-function checkMigrationSummaryBug(md: string): SectionStatus {
-  if (!headingPresent(md, MIGRATION_HEADING)) return "FAIL";
+function checkMigrationSummaryBug(md: string): CheckResult {
+  if (!headingPresent(md, MIGRATION_HEADING))
+    return fail("\"## Subject Migration Summary\" heading not found");
   const body = sectionBody(md, MIGRATION_HEADING);
-  return openQuestionsNotEmpty(body) ? "PASS" : "FAIL";
+  if (!openQuestionsNotEmpty(body))
+    return fail("\"Open questions\" row is empty or missing in migration table");
+  return pass();
 }
 
 // ─── section definitions per spec type ────────────────────────────────────
@@ -170,7 +239,7 @@ function checkMigrationSummaryBug(md: string): SectionStatus {
 interface SectionDef {
   key: string;
   label: string;
-  check: (md: string) => SectionStatus;
+  check: (md: string) => CheckResult;
 }
 
 const FEAT_SECTIONS: SectionDef[] = [
@@ -252,10 +321,13 @@ export function scoreSpec(markdown: string, filename: string = ""): ScoreResult 
   const defs = SECTIONS_BY_TYPE[specType];
 
   const sections: Record<string, SectionStatus> = {};
+  const section_reasons: Record<string, string | null> = {};
   const section_labels: Record<string, string> = {};
   const section_order: string[] = [];
   for (const def of defs) {
-    sections[def.key] = def.check(markdown);
+    const result = def.check(markdown);
+    sections[def.key] = result.status;
+    section_reasons[def.key] = result.reason;
     section_labels[def.key] = def.label;
     section_order.push(def.key);
   }
@@ -275,6 +347,7 @@ export function scoreSpec(markdown: string, filename: string = ""): ScoreResult 
     passed,
     evaluated_at: new Date().toISOString(),
     sections,
+    section_reasons,
     section_order,
     section_labels,
     gates,

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -67,10 +67,29 @@ export default function AppPage() {
   const handleFile = useCallback((name: string, contents: string) => {
     setFilename(name);
     setMarkdown(contents);
-    setResult(scoreSpec(contents, name));
+    const scored = scoreSpec(contents, name);
+    setResult(scored);
     setImplState("idle");
     setIssueNumber(null);
     setErrorMsg("");
+
+    // Fire-and-forget: log section results to CF Analytics
+    const events = scored.section_order.map((key) => ({
+      section: key,
+      status: scored.sections[key],
+      reason: scored.section_reasons[key],
+      spec_type: scored.spec_type,
+      rubric_version: scored.rubric_version,
+    }));
+    fetch("/api/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rubric_version: scored.rubric_version,
+        spec_type: scored.spec_type,
+        events,
+      }),
+    }).catch(() => {});
   }, []);
 
   const handleDownloadTemplate = useCallback(() => {


### PR DESCRIPTION
## Summary
- Add `reason` field to scoring check functions — each FAIL section now includes a human-readable explanation of the structural rule that was violated
- FAIL rows in the ScorePanel are clickable accordions with 150ms expand/collapse animation; all FAIL rows auto-expand on initial score render
- PASS rows remain non-clickable with no expansion
- New `functions/api/score.ts` endpoint logs `{ section, status, reason, spec_type, rubric_version }` per score event to Cloudflare Workers Analytics Engine for aggregate failure pattern analysis
- 29/29 tests pass including new `section_reasons` coverage

Closes #36

## Test plan
- [ ] Upload a spec with failing sections — verify FAIL rows show chevron and expand on click
- [ ] Verify all FAIL rows auto-expand on initial score render
- [ ] Verify PASS rows are not clickable and show no expansion
- [ ] Upload a fully passing spec — verify all reasons are null and no chevrons appear
- [ ] Check that score API response includes `section_reasons` field
- [ ] Verify CF Analytics logging fires on score (check Network tab for `/api/score` POST)