### PR TITLE
fix: defensive guard for claude CLI on ZAI runner + daily health check

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -1,0 +1,70 @@
+name: Runner health check
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: [self-hosted, contabo, zilin, zai]
+    timeout-minutes: 5
+    steps:
+      - name: Derive HOME if unset
+        run: |
+          if [ -z "$HOME" ]; then
+            HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+            echo "HOME=$HOME" >> "$GITHUB_ENV"
+            echo "::warning::HOME was unset; derived $HOME"
+          fi
+          echo "PATH=$HOME/.npm-global/bin:$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
+
+      - name: Claude Code CLI present
+        run: |
+          which claude
+          claude --version
+
+      - name: MAX OAuth state present
+        run: |
+          test -d "$HOME/.claude" && ls "$HOME/.claude/" | head
+
+      - name: npm-global on PATH
+        run: |
+          case ":$PATH:" in
+            *":$HOME/.npm-global/bin:"*) echo "ok" ;;
+            *) echo "npm-global not on PATH"; exit 1 ;;
+          esac
+
+      - name: Notify Telegram on failure
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TEXT="$(cat <<EOF
+          🚨 *ZAI Runner Health FAILED*
+
+          Repo: \`${{ github.repository }}\`
+          Run: [${{ github.run_id }}](${RUN_URL})
+          Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          Consult the runner runbook in the private layer.
+          EOF
+          )"
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown" \
+            --data-urlencode "disable_web_page_preview=true"
+
+      - name: Notify Telegram on manual success
+        if: success() && github.event_name == 'workflow_dispatch'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=✅ ZAI runner health OK (manual check)" \
+            --data-urlencode "parse_mode=Markdown"

--- a/.github/workflows/zilin-queue.yml
+++ b/.github/workflows/zilin-queue.yml
@@ -9,11 +9,31 @@ jobs:
     runs-on: [self-hosted, contabo, zilin, zai]
     timeout-minutes: 60
     steps:
+      - name: Ensure Claude Code CLI on PATH
+        run: |
+          # Systemd services don't source ~/.bashrc; if the unit file is missing
+          # Environment="HOME=..." then $HOME is empty and PATH expansion breaks.
+          if [ -z "$HOME" ]; then
+            HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+            export HOME
+            echo "::warning::HOME was unset; derived HOME=$HOME"
+          fi
+          export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+          if ! command -v claude >/dev/null 2>&1; then
+            echo "::warning::claude CLI missing on runner; installing"
+            npm config set prefix "$HOME/.npm-global"
+            npm install -g @anthropic-ai/claude-code
+          fi
+          claude --version
+          {
+            echo "HOME=$HOME"
+            echo "PATH=$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+          } >> "$GITHUB_ENV"
+
       - name: Dispatch to ZAI router
         env:
           GITHUB_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN }}
         run: |
-          export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
           ISSUE_NUMBER="${{ github.event.client_payload.issue_number }}"
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "Error: issue_number not provided in client_payload"


### PR DESCRIPTION
## Summary

Closes #44 — partial (Layers 3 + 4 only).

- **Layer 3** — `.github/workflows/zilin-queue.yml`: pre-dispatch step that derives `HOME` if the systemd unit forgot to set it, auto-installs `@anthropic-ai/claude-code` if missing, and persists `HOME`/`PATH` into `$GITHUB_ENV` so the dispatch step inherits them. Self-heals against the class of regression that caused run #22 (exit 127, `claude: command not found`).
- **Layer 4** — `.github/workflows/runner-health.yml`: daily smoke test at 12:00 UTC + `workflow_dispatch`. Verifies CLI present, MAX OAuth dir exists, npm-global on PATH. Telegram push on failure; opt-in success ping on manual dispatch.

## Scope notes

- **Layers 1 + 2** (runner shell install, systemd unit `HOME=`/`PATH=` patch) are manual SSH operations and cannot run from CI. Apply per spec before this PR lands to actually unblock issue #43.
- **Layer 5** (full runbook with host/IP/path detail) belongs in the private layer per CLAUDE.md privacy rule — not committed here. File a follow-up in the private repo.
- **Streettt-private mirror** of the Layer 3 guard — out of scope; separate PR in that repo.
- **Scored spec file** not committed to `issues/` per Option 3 — issue #44 body is the governance anchor and already has the passing score block.

## Prerequisites before Layer 4 goes live

Repo secrets in `zi007lin/zai`:

- `TELEGRAM_BOT_TOKEN` — from `@BotFather`, new bot per spec Layer 4 instructions
- `TELEGRAM_CHAT_ID` — from `getUpdates` after starting the bot

Until those are set, the `Notify Telegram on failure` step will fail silently (curl non-zero) but the job will still surface the underlying health failure on the Actions page.

## Test plan

- [ ] Layer 1 + 2 applied manually on the runner host (prereq)
- [ ] `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` stored in repo secrets
- [ ] Re-run failed run #22 on the merge commit — expect exit 0, issue #43 PR opens
- [ ] Manual `workflow_dispatch` of `runner-health.yml` → ✅ Telegram push within ~10s
- [ ] Rename `~/.npm-global/bin/claude` on the runner → dispatch a job → Layer 3 guard auto-reinstalls, job succeeds
- [ ] Restore break → manual `workflow_dispatch` of `runner-health.yml` → ✅ Telegram push
- [ ] Break again → scheduled run fires within 24h → 🚨 Telegram push