### PR TITLE
bug: Fix REFACTOR downgrade + align all rubrics to v1.2 (closes #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to the ZAI validator service are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [SemVer](https://semver.org/) — but note that the `RUBRIC_VERSION` constant in `src/lib/scoreSpec.ts` is versioned **independently** from the package version. Rubric versions track the scoring-rule surface; package versions track the whole service.
+
+## [Unreleased]
+
+### Fixed
+
+- **REFACTOR spec type silently downgraded to CHORE** in `src/lib/scoreSpec.ts`. The `if (raw === "refactor") return "chore";` line caused REFACTOR specs to be scored against the 5-check CHORE rubric instead of the documented 9-check REFACTOR rubric. Any prior REFACTOR-type spec that scored as `chore` must be re-uploaded to receive the correct rubric. Fixes #46.
+
+### Added
+
+- `docs/ZAI_SYSTEM_INSTRUCTIONS.md` (v1.2) — canonical rubric source-of-truth, authored for the first time as a file (previously lived ambiently in project knowledge and hero-copy).
+- `refactor` as a first-class `SpecType` with its own 9-check rubric: Intent, Decision Tree + Trigger, Final Spec, Acceptance Criteria, Subject Migration Summary, Files, Models Applied, Migration Plan with rollback, Legal triggers.
+- **Acceptance Criteria** and **Legal triggers** checks added to FEAT (7 → 9), BUG (5 → 7), and other spec types per v1.2 alignment.
+- `SpecTypeError` thrown on unknown spec types — replaces the silent `"feat"` fallback. External callers that depended on the fallback will now error explicitly.
+- Drift-detection test (`src/lib/scoreSpec.test.ts` — new `describe` block) reads `docs/ZAI_SYSTEM_INSTRUCTIONS.md`, asserts every documented spec type has a matching rubric implementation with the documented check count. Catches doc-vs-code drift in CI.
+
+### Changed
+
+- `RUBRIC_VERSION` bumped from `1.1.0` to `1.2.1`. v1.2 is the doc-aligned rubric surface; the `.1` patch reflects this fix-set.
+
+### Breaking changes
+
+- Specs with unrecognized `spec_type` prefixes now throw `SpecTypeError` instead of silently defaulting to `feat`. This surfaces typos and unsupported types rather than letting them score against the wrong rubric. Known impact: none — the prior fallback was never a documented contract.
+- Any historical REFACTOR spec that was scored as `chore` has not been migrated. Re-upload to receive the correct scoring.
+
+---
+
+_This CHANGELOG is authored 2026-04-20 as part of the PR for issue #46. Prior versions of the rubric surface existed (v1.0, v1.1) but were not tracked here._

--- a/docs/ZAI_SYSTEM_INSTRUCTIONS.md
+++ b/docs/ZAI_SYSTEM_INSTRUCTIONS.md
@@ -1,0 +1,453 @@
+# ZAI SYSTEM INSTRUCTIONS
+
+**Version:** 1.2 (2026-04-19)
+**ZAI:** the structural validation service running at `zai.htu.io/app`
+**Purpose:** authoritative spec for what ZAI validates, how it scores, and how humans interact with it
+**Canonical location:** `docs/ZAI_SYSTEM_INSTRUCTIONS.md` in `zi007lin/zai`
+
+---
+
+## 1) What ZAI is
+
+ZAI is a **structural validation and scoring layer** between a human spec author and the downstream implementation pipeline (ZiLin-dev / Claude Code). ZAI's job is narrow:
+
+- Validates structural compliance against per-type rubrics (FEAT / BUG / SPEC / CHORE / REFACTOR / RESEARCH / UX / BRAND)
+- Detects thinking-model usage and cross-checks against declaration
+- Validates Legal triggers subsection completeness (NOT legal judgment)
+- Scores on 0–N scale where N is the required check count for that type
+- Displays which models were invoked and how each contributed
+- Emits `.scored.md` artifact upon full pass — the forcing function
+- Optionally applies Enterprise industry bundles
+
+ZAI does NOT validate:
+- Substance (is this the correct thing to build?)
+- Domain correctness (does this solve the real problem?)
+- Implementability (will the code work?)
+- Business alignment (should this be built at all?)
+- Legal correctness (is this clause enforceable?) — **explicitly non-goal**
+
+---
+
+## 2) Rubrics by spec type
+
+Each spec type has a base rubric. Items are binary PASS/FAIL. Score = PASS count.
+
+### FEAT / FEATURE rubric (9 checks)
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | `## Intent` H2, ≤150 tokens (hyphen-split) |
+| 2 | Decision Tree | `## Decision Tree` H2 + markdown table + `### Trigger for change` subsection |
+| 3 | Final Spec | `## Final Spec` H2 present |
+| 4 | Acceptance Criteria | `## Acceptance Criteria` H2 with checkbox list |
+| 5 | Game Theory review | `## Game Theory Cooperative Model review` H2 + `### Abuse vector` subsection |
+| 6 | Subject Migration Summary | `## Subject Migration Summary` H2 with table + `Open questions` row; no `**bold**` first-column labels |
+| 7 | Files created / updated | `## Files created / updated` H2 with fenced code block |
+| 8 | Models Applied | `## Models Applied` H2 declaring required models + structural evidence matches |
+| 9 | Legal triggers | `## Legal triggers` H2 present, declares "None" or lists specific triggers |
+
+**Optional (scored separately, do not block pass):**
+- `## Draft-of-thoughts` — +1 "process quality" badge
+- Appendices — +1 "completeness" badge
+
+### BUG / HOTFIX rubric (7 checks)
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | `## Intent` H2, ≤150 tokens |
+| 2 | Repro | `## Repro` H2 + Preconditions / Steps / Expected / Actual / Root cause |
+| 3 | Fix | `## Fix` H2, layered (`### Layer 1 — ...`) |
+| 4 | Acceptance Criteria | `## Acceptance Criteria` H2 |
+| 5 | Subject Migration Summary | Same as FEAT item 6 |
+| 6 | Files | `## Files` H2 with fenced code block |
+| 7 | Legal triggers | `## Legal triggers` H2 present |
+
+### SPEC rubric (6 checks)
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | ≤150 tokens |
+| 2 | Decision Tree | Table + Trigger for change |
+| 3 | Rules or content | `## Rules` / `## Content` / domain H2 |
+| 4 | Subject Migration Summary | Standard |
+| 5 | Files / Schema | With fenced code block |
+| 6 | Legal triggers | Required |
+
+### CHORE rubric (5 checks)
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | ≤100 tokens |
+| 2 | Action | `## Action` H2 with numbered steps |
+| 3 | Acceptance Criteria | Standard |
+| 4 | Files | Standard |
+| 5 | Legal triggers | Required |
+
+### REFACTOR rubric (9 checks)
+
+FEAT minus Game Theory, plus `## Migration Plan` with rollback procedure. Legal triggers inherited from FEAT base (not a separate addition).
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | `## Intent` H2, ≤150 tokens |
+| 2 | Decision Tree | `## Decision Tree` H2 + table + `### Trigger for change` subsection |
+| 3 | Final Spec | `## Final Spec` H2 present |
+| 4 | Acceptance Criteria | `## Acceptance Criteria` H2 with checkbox list |
+| 5 | Subject Migration Summary | `## Subject Migration Summary` H2 with table + `Open questions` row |
+| 6 | Files created / updated | `## Files created / updated` H2 with fenced code block |
+| 7 | Models Applied | `## Models Applied` H2 declaring required models + structural evidence |
+| 8 | Migration Plan | `## Migration Plan` H2 with phased steps + `### Rollback` subsection including explicit triggers |
+| 9 | Legal triggers | `## Legal triggers` H2 present |
+
+### RESEARCH rubric (6 checks, inherited from v1.1 unchanged)
+
+Research specs produce decision-ready reports; they do not ship code, so Legal triggers is not a required section (reports are non-building by definition). RESEARCH stayed at 6 checks in v1.2.
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | `## Intent` H2, ≤150 tokens |
+| 2 | Research Questions | `## Research Questions` H2 with numbered list |
+| 3 | Acceptance Criteria | `## Acceptance Criteria` H2 defining "report is complete when…" |
+| 4 | Report Format | `## Report Format` H2 describing output structure |
+| 5 | Subject Migration Summary | Standard |
+| 6 | Files | `## Files` H2 with fenced code block |
+
+### UX / BRAND rubric (6 checks)
+
+| # | Check | Pattern |
+|---|---|---|
+| 1 | Intent | ≤150 tokens |
+| 2 | User Jobs | `## Jobs To Be Done` H2 with 3–5 jobs |
+| 3 | Design Rationale | `## Design Rationale` H2 including `### Interaction of Color` |
+| 4 | Acceptance Criteria | Standard |
+| 5 | Assets / Files | With fenced code block |
+| 6 | Legal triggers | Required |
+
+---
+
+## 3) Model detection and cross-check
+
+Two-pass detection with cross-check.
+
+**Pass A — Declaration detection:** parses `## Models Applied` section.
+
+**Pass B — Structural evidence detection:** scans for structural signals per model.
+
+| Model | Structural signal |
+|---|---|
+| #1 Game Theory Cooperative | `Abuse vector` subsection OR cooperation framing |
+| #2 Decision Tree | Markdown table with "Options", "Chosen", "Why" columns + Trigger for change |
+| #3 Draft-of-thoughts | `## Draft-of-thoughts` section present |
+| #4 Systems Thinking | Diagram of loops OR "leverage point" language |
+| #5 Flywheel | "friction", "acceleration", "compound" with cause-effect chain |
+| #6 Ostrom's Commons | "governance", "shared resource" with tiered principles |
+| #7 Network Effects | Metcalfe reference OR "density", "depth before breadth" |
+| #8 Swiss Cheese | ≥2 defense layers enumerated |
+| #9 Jobs To Be Done | 3–5 user jobs explicit |
+| #10 Anti-Fragile | "stress", "redundancy makes stronger" framing |
+| #11 Progressive Disclosure | Staged rollout OR complexity-gating |
+| #12 Event Sourcing + CQRS | Event log OR derived-state architecture |
+| #13 OODA Loop | Observe/Orient/Decide/Act framing |
+| #14 SIX PASS Validation | SIX PASS section OR 6-gate exit |
+| #15 Inversion / Premortem | `Inversion` subsection OR sabotage/failure-guarantee language |
+| #16 Mechanism Design | "truthful reporting", "dominant strategy", "incentive-compatible" |
+| Interaction of Color (scope-restricted) | UX/BRAND specs only; "color relations", "contrast pairs", "palette system" |
+
+**Pass C — Cross-check:**
+- ✅ GREEN: declared + detected
+- ⚠ YELLOW: declared-not-detected OR detected-not-declared (informative)
+- ✗ RED: required + missing (fails the Models Applied rubric check — FEAT #8, REFACTOR #7)
+
+### Legal triggers detection
+
+ZAI validates presence + completeness of the `## Legal triggers` subsection. It does not assess whether declared triggers are legally correct.
+
+Keyword scan: if the spec body contains keywords suggesting triggers (contract, license, indemnify, PHI, PAN, liability, royalty, compensation, arbitration, etc.) but the Legal triggers section declares "None", ZAI issues a YELLOW warning asking the author to review. Does not fail the spec.
+
+---
+
+## 4) Scoring display
+
+### Top section
+
+Score badge + spec type + pass/fail state + failure count.
+
+### Per-check bars
+
+Horizontal bars (green=PASS, red=FAIL) with check names and specific error messages on FAIL.
+
+### Models panel
+
+Dedicated section below rubric bars:
+
+```
+MODELS APPLIED
+
+✅ #1  Game Theory Cooperative        declared + detected
+✅ #2  Decision Tree                  declared + detected
+⚠  #4  Systems Thinking               declared, not detected — review
+✅ #15 Inversion / Premortem          declared + detected
+✅ #16 Mechanism Design               declared + detected
+
+NOT APPLIED (click to expand)
+```
+
+Clicking any badge expands rationale + signals searched + signals found.
+
+### Legal triggers panel
+
+```
+LEGAL TRIGGERS DECLARED
+
+Declared: None
+⚠ Warning: spec body contains "contract", "indemnify" keywords.
+  Review whether triggers #1 or #3 should be declared.
+  This does not block pass.
+```
+
+### Compliance panel (Enterprise bundles only)
+
+If bundles selected at submission:
+
+```
+COMPLIANCE — HEALTHCARE (HIPAA)
+✅ PHI-handling declaration
+✅ BAA coverage statement
+⚠  Audit-trail requirement — present but weak
+```
+
+### Footer
+
+```
+<filename> · Scored 2026-04-19T17:23:01.812Z · rubric v1.3.0 · bundles: [healthcare]
+[Download scored spec ↓]  [Run impl →]
+```
+
+`Run impl →` disabled on any FAIL.
+
+---
+
+## 5) Tool tiers — how humans generate specs
+
+ZAI structural validation is free at every tier. Tiers sell assistance in getting to a pass.
+
+### Model access model (applies to all tiers using AI features)
+
+| Layer | Models used | Who pays | Privacy |
+|---|---|---|---|
+| Default | Cloudflare Workers AI free tier (Llama 3, Mistral, etc.) | ZAI absorbs | Standard CF Workers AI TOS |
+| BYOK (Assist+) | User provides own API key | User pays provider directly | AES-256-GCM encrypted in D1; responses never logged |
+| ZAI system instructions | Internal detection heuristics | Internal | **Proprietary, not public, not user-viewable** |
+
+BYOK privacy guarantees:
+1. API key AES-256-GCM encrypted at rest
+2. AI responses not logged (except anonymized usage counters for billing)
+3. Key deletion immediate and propagating
+4. ZAI system prompts never exposed via API responses
+
+### Tier 1 — DIY / Free
+
+- Tool: `zai.htu.io/app`
+- User writes spec themselves
+- Iteration via -v2, -v3 re-uploads
+- No AI assistance with substance
+- Price: free
+- SLA: 5-second score latency
+
+### Tier 2 — ZAI Assist
+
+- Tool: `zai.htu.io/draft` (in-browser drafter)
+- AI-assisted drafting; continuous checks during writing
+- Cloudflare default models OR BYOK
+- Price: metered per session OR monthly subscription (per contract)
+- SLA: 5-second score latency
+
+### Tier 3 — ZAI Pro
+
+- Human + AI service
+- Flow: problem description → ZiLin research report → user input → ZiLin drafts spec with models applied by hand → Assist final pass → submission
+- Deliverable: validated spec + research report + 1 revision
+- Price: per-spec flat fee (per contract)
+- SLA: 48-hour first draft
+
+### Tier 4 — ZAI Enterprise
+
+- Pro + industry bundles (§6) + dedicated consultation
+- Custom per-client rubrics on request
+- Recurring ZiLin consultation (weekly/biweekly)
+- BYOK encouraged; on-premise / air-gapped for regulated clients
+- Price: retainer + bundle fees + optional per-spec (per contract)
+- SLA: 24-hour turnaround, priority queue
+
+---
+
+## 6) Enterprise industry bundles
+
+Bundles add compliance-specific rubric checks on top of the base type rubric. Stackable.
+
+### Bundle catalog
+
+| Bundle | Attribution | Added checks (summary) | Typical clients |
+|---|---|---|---|
+| healthcare | HIPAA + HITECH | PHI handling, BAA coverage, audit trail, de-identification, breach notification | medicshare, telehealth |
+| fintech | SOX §404 + PCI-DSS v4.0 | Internal controls, PCI scope, PAN not logged, change mgmt, segregation of duties | NYQEX, payments |
+| financial_advisory | FINRA + SEC | Advice disclaimer, fiduciary duty, suitability, Rule 17a-4, Rule 2210 | RIA, robo-advisors |
+| education | FERPA | Student PII, parental consent, directory opt-out, retention, annual notification | LMS, tutoring |
+| gdpr | EU + UK GDPR | Lawful basis, minimization, DPIA, DSR, DPO, cross-border transfer | International SaaS |
+| ccpa | CA CCPA/CPRA | Consumer rights, opt-out, sensitive PI, retention, GPC signal | CA-operating |
+| coppa | Children's privacy | Under-13 detection, verifiable consent, minimization, safe harbor | HTTC youth |
+| accessibility | WCAG 2.2 AA + ADA | Semantic HTML, keyboard nav, screen reader, contrast, focus, reduced motion | All public-facing (baseline) |
+| government | FedRAMP + NIST 800-53 | Boundary, control mapping, continuous monitoring, IR plan, FIPS 140-3 | Public sector |
+| insurance | NAIC + state | Licensing, replacement disclosure, suitability, producer recordkeeping | Insurtech, C2C broker |
+| transportation | DOT + FMCSA | DQ file, HOS, inspection records, drug/alcohol, ELD | Logistics, fleet |
+| beacon_program | DYCD Beacon | Zero fees attestation, content gate, incident reporting, background check, consent chain, capacity | HTTC, youth |
+| contract_law_signals | Contract structure (NOT legal advice) | Required clauses present, structural red flags, jurisdiction declared, attorney review attested | HTU.io C2C, any contract-handling |
+| legal_services (future) | Partner law firm specs | Model Rule 5.4 compliance, UPL boundary, attorney-client disclaimers, BAA if applicable | HTU.io panel firms (2027+) |
+
+**`contract_law_signals` mandatory disclaimer banner on output:**
+
+> "This structural check does not constitute legal advice. Consult a licensed attorney in the governing jurisdiction before signing or acting on this document. HTU.io is not a law firm."
+
+Bundle is jurisdiction-agnostic. Does NOT render enforceability opinions.
+
+### Adding a new bundle
+
+1. SPEC issue in `zi007lin/zai/issues/`
+2. Industry-domain expert review
+3. Legal review if encoding regulatory requirements
+4. Approver sign-off
+5. Announce to Enterprise clients with 30-day comment period
+6. Activate in rubric registry
+
+---
+
+## 7) Accessibility default
+
+WCAG 2.2 AA applies to every public-facing feature regardless of bundle selection. The `accessibility` bundle extends, does not replace the baseline.
+
+---
+
+## 8) Segregation of duties
+
+| Layer | Validates |
+|---|---|
+| ZAI | Structure, rubric checks, model declaration + detection cross-check, bundle compliance, legal-triggers completeness |
+| Human author | Substance, domain correctness, cooperative-model reasoning applied soundly |
+| Approver | Business alignment, governance compliance, merge authority |
+| ZiLin-dev / Claude Code | Implementability, code-spec alignment, test pass, governance |
+| Counsel (2027+) | Legal correctness of flagged specs in queue |
+
+ZiLin-dev does NOT re-validate models or legal triggers. Contradictions raise `needs_input` — that's a new finding, not re-validation.
+
+**Operator reality disclosure:** the current dual-control pattern (zi007lin as author, daniel-silvers as approver) is process-level dual-control using two GitHub identities for one human principal. It is not principal-level segregation of duties. Enterprise bundles with regulatory SoD requirements (healthcare §164.308, fintech SOX §404, financial_advisory FINRA 3110, government NIST 800-53 AC-5) attach a disclosure footer informing clients that an independent second operator must be arranged before the bundle control can be relied upon. See `docs/brand/enterprise-disclosure.md`.
+
+---
+
+## 9) Iteration workflow
+
+### Happy path
+
+```
+1. Author drafts in Claude (or Assist / Pro)
+2. Downloads -v1.md to Windows Downloads
+3. Uploads to zai.htu.io/app (optionally selects bundles)
+4. All checks PASS
+5. Downloads .scored.md
+6. WSL cp to repo (strips -vN and .scored)
+7. gh issue create + impl i
+```
+
+### Failure path
+
+```
+1. Drafts -v1.md
+2. Uploads; receives partial score
+3. Panel shows failed checks + error messages
+4. TARGETED fix (do not rewrite)
+5. Saves -v2.md, re-uploads
+6. Loop until PASS
+```
+
+After 4 failing iterations, stop. Spec type may be wrong, or substance incoherent.
+
+---
+
+## 10) What ZAI does not do
+
+- ❌ Semantic review
+- ❌ Implementation review
+- ❌ Cost estimation
+- ❌ Priority ranking
+- ❌ Substitution for human approver review
+- ❌ Legal compliance review (bundles check markers; not legal opinions)
+- ❌ Exposure of internal ZAI system instructions (proprietary)
+- ❌ Render enforceability opinions on contract clauses (explicitly non-goal for `contract_law_signals`)
+
+---
+
+## 11) API surface
+
+```
+POST  /api/v1/validate            body: {markdown, spec_type, bundles?}
+GET   /api/v1/rubric/:type        returns base rubric
+GET   /api/v1/bundles             returns available bundles
+GET   /api/v1/bundles/:name       returns specific bundle
+POST  /api/v1/score-file          multipart; returns .scored.md binary
+GET   /api/v1/models              returns 16 models + scope-restricted
+POST  /api/v1/draft/start         Assist session
+POST  /api/v1/draft/:id/check     continuous-check
+POST  /api/v1/keys                BYOK store
+DELETE /api/v1/keys/:provider     BYOK delete
+```
+
+OpenAPI at `zai.htu.io/openapi.json`.
+
+---
+
+## 12) Governance of ZAI itself
+
+- Repo: `zi007lin/zai` (to be renamed `zi007lin/zilin-spec` per REFACTOR 2026-04-19)
+- Author: `zi007lin`
+- Approver: `daniel-silvers`
+- Rubrics versioned via SPEC issues
+- Rubric changes require approver sign-off
+- Breaking changes: 30-day deprecation + version bump
+- Bundle changes: industry-expert review
+
+---
+
+## 13) Change log
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0 | 2026-04-19 | Initial. Rubrics for FEAT/BUG/SPEC/CHORE/RESEARCH/UX+BRAND. Model declaration + detection + cross-check. Scoring with models panel. Tiers: DIY / Copilot / Pro / Enterprise. |
+| 1.1 | 2026-04-19 | Tier "Copilot"→"Assist" (Microsoft trademark). BYOK + Cloudflare-free-default. Internal prompts explicitly non-public. 12-bundle industry catalog. Accessibility default. |
+| 1.2 | 2026-04-19 | Added `legal_trigger_declaration` check to every building-type rubric (RESEARCH exempt; reports are non-building). Added `contract_law_signals` bundle (structural only, mandatory disclaimer banner, jurisdiction-agnostic, explicitly not legal advice). Added future `legal_services` bundle slot for 2027+ partner firm use. Rubric counts: FEAT 8→9, BUG 6→7, SPEC 5→6, CHORE 4→5, REFACTOR introduced as first-class type at 9 checks (was previously silently folded into CHORE in implementation — see BUG 2026-04-19), RESEARCH unchanged at 6 (non-building), UX/BRAND 5→6. |
+```
+
+---
+
+## Appendix: rubric-count summary (for drift-detection test)
+
+The Layer 3 drift-detection test asserts that rubric arrays in `scoreSpec.ts` match the counts documented above. The authoritative pairs:
+
+| Type | Count | Ordered section IDs (canonical) |
+|---|---|---|
+| `feat` | 9 | `intent, decision_tree, final_spec, acceptance_criteria, game_theory, migration_summary, files_list, models_applied, legal_triggers` |
+| `bug` | 7 | `intent, repro, fix, acceptance_criteria, migration_summary, files, legal_triggers` |
+| `spec` | 6 | `intent, decision_tree, rules_or_content, migration_summary, files_schema, legal_triggers` |
+| `chore` | 5 | `intent, action, acceptance_criteria, files, legal_triggers` |
+| `refactor` | 9 | `intent, decision_tree, final_spec, acceptance_criteria, migration_summary, files_list, models_applied, migration_plan, legal_triggers` |
+| `research` | 6 | `intent, research_questions, acceptance_criteria, report_format, migration_summary, files` |
+| `ux` | 6 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers` |
+| `brand` | 6 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers` |
+
+Drift test implementation notes:
+- Parse each `### X rubric (N checks)` heading in this doc
+- Assert N equals the length of the corresponding `*_SECTIONS` array in `scoreSpec.ts`
+- Parse the section IDs from this Appendix (not from the prose tables, which use human labels)
+- Fail CI with a clear diagnostic if any type's count or ordered IDs disagree
+
+---
+
+*End of ZAI_SYSTEM_INSTRUCTIONS.md v1.2*

--- a/issues/2026-04-19__bug__zai-refactor-classification.md
+++ b/issues/2026-04-19__bug__zai-refactor-classification.md
@@ -1,0 +1,229 @@
+---
+spec_type: bug
+rubric_version: 1.2
+bundles: []
+github_issue: 46
+---
+
+# bug: REFACTOR spec type silently downgraded to CHORE in scoreSpec.ts
+
+**Spec type:** BUG
+**Target:** `zi007lin/zai` (the validator service itself; brownfield)
+**Severity:** High — silently applies wrong rubric to an entire spec class, leading to false-pass scoring
+**Author:** zi007lin
+**Approver:** daniel-silvers
+**Date:** 2026-04-19
+
+---
+
+## Intent
+
+ZAI validator folds `refactor` into `chore` at `src/lib/scoreSpec.ts:231`, causing REFACTOR specs to be scored against the 5-check CHORE rubric instead of the documented 7-check REFACTOR rubric. The REFACTOR rubric exists in `ZAI_SYSTEM_INSTRUCTIONS.md` v1.2 but has no implementation. The discovery context: the ZiLin brand migration REFACTOR scored 2/2 (CHORE) despite declaring `Spec type: REFACTOR` and carrying full Migration Plan + Rollback + 5 applied models. A spec that should have been rigorously validated passed trivially, and would have passed the impl gate if not caught by human review of the score-blast-radius mismatch.
+
+## Repro
+
+### Preconditions
+- ZAI validator running at `zai.htu.io/app` as of 2026-04-20T03:12:17Z
+- `zai` repo at current HEAD; `src/lib/scoreSpec.ts:231` contains `if (raw === "refactor") return "chore";`
+
+### Steps
+1. Create a spec file with `**Spec type:** REFACTOR` in the header and `spec_type: refactor` in YAML frontmatter
+2. Upload to `zai.htu.io/app`
+3. Observe scored output
+
+### Expected
+- Spec classified as `refactor`
+- Rubric applied: 7 checks (Intent, Decision Tree + Trigger, Final Spec, Acceptance Criteria, Subject Migration Summary, Files, Migration Plan with rollback, Legal triggers)
+- Score display: `refactor N/7` or `refactor N/8` (whichever count the spec authoritatively defines; see Open questions in Migration Plan)
+
+### Actual
+- Spec classified as `chore`
+- Rubric applied: 2 checks (CHORE minimum)
+- Score display: `chore 2/2 passed: true`
+- `.scored.md` emitted as if full pass
+- Downstream impl pipeline treats the false pass as authoritative
+
+### Root cause
+
+`src/lib/scoreSpec.ts:231`:
+
+```typescript
+if (raw === "refactor") return "chore";
+```
+
+Likely a placeholder from an early scaffold ("refactor acts like chore for now") that was never revisited when the REFACTOR rubric was documented in `ZAI_SYSTEM_INSTRUCTIONS.md`. The rubric registry has no `refactor` entry, so the type-normalizer short-circuits to the nearest low-ceremony type rather than erroring.
+
+Contributing factor: there is no test asserting that spec types documented in `ZAI_SYSTEM_INSTRUCTIONS.md` are all implemented in `scoreSpec.ts`. Documentation and implementation drifted apart silently.
+
+## Fix
+
+### Layer 1 — Remove the downgrade, add REFACTOR rubric
+
+`src/lib/scoreSpec.ts` — delete line 231 (the refactor → chore redirect). Add `refactor` as a first-class spec type with its own rubric entry.
+
+```typescript
+// src/lib/rubrics/refactor.ts (NEW)
+import type { Rubric } from "./types";
+
+export const refactorRubric: Rubric = {
+  type: "refactor",
+  checks: [
+    { id: "intent",          name: "Intent",                          test: hasIntentH2UnderLimit(150) },
+    { id: "decision_tree",   name: "Decision Tree + Trigger",         test: hasDecisionTreeWithTrigger() },
+    { id: "final_spec",      name: "Final Spec",                      test: hasH2("Final Spec") },
+    { id: "acceptance",      name: "Acceptance Criteria",             test: hasH2WithCheckboxList("Acceptance Criteria") },
+    { id: "subject_migration", name: "Subject Migration Summary",     test: hasSubjectMigrationTableWithOpenQuestions() },
+    { id: "files",           name: "Files created / updated",         test: hasH2WithFencedCodeBlock(["Files", "Files created / updated"]) },
+    { id: "migration_plan",  name: "Migration Plan with rollback",    test: hasMigrationPlanWithRollback() },
+    { id: "legal_triggers",  name: "Legal triggers",                  test: hasLegalTriggersH2() },
+  ],
+};
+
+// src/lib/rubrics/registry.ts (MOD)
+import { refactorRubric } from "./refactor";
+export const rubrics = {
+  feat: featRubric,
+  bug: bugRubric,
+  spec: specRubric,
+  chore: choreRubric,
+  refactor: refactorRubric,    // NEW
+  ux: uxRubric,
+  brand: brandRubric,
+};
+```
+
+Delete line 231 in `scoreSpec.ts`:
+
+```typescript
+// BEFORE
+if (raw === "refactor") return "chore";
+
+// AFTER
+// (line deleted; normalizer now returns "refactor" directly)
+```
+
+The `hasMigrationPlanWithRollback()` test checks for:
+- `## Migration Plan` H2 present
+- At least one sub-heading containing "Rollback" (case-insensitive)
+- At least one explicit rollback trigger enumerated in that section
+
+### Layer 2 — Strict mode: fail loudly on unknown spec types
+
+Currently if `raw` is any string not matched, it falls through to some default. After this fix, any unknown type should return an explicit error to the caller rather than silently defaulting. This prevents the same class of bug for future spec types.
+
+```typescript
+// src/lib/scoreSpec.ts — normalizer exit
+const known = Object.keys(rubrics);
+if (!known.includes(raw)) {
+  throw new SpecTypeError(`Unknown spec type "${raw}". Known: ${known.join(", ")}`);
+}
+return raw as SpecType;
+```
+
+### Layer 3 — Drift-detection test
+
+Add `src/lib/rubrics/registry.test.ts` that reads `docs/ZAI_SYSTEM_INSTRUCTIONS.md`, extracts every documented spec type from the rubric tables, and asserts each has an entry in `rubrics`. Any future doc-vs-code drift fails CI.
+
+```typescript
+// src/lib/rubrics/registry.test.ts (NEW)
+import { readFileSync } from "node:fs";
+import { rubrics } from "./registry";
+
+const docPath = new URL("../../docs/ZAI_SYSTEM_INSTRUCTIONS.md", import.meta.url);
+const doc = readFileSync(docPath, "utf8");
+
+test("every spec type in ZAI_SYSTEM_INSTRUCTIONS has a rubric", () => {
+  const documented = [...doc.matchAll(/^### (\w+(?:\s*\/\s*\w+)?) rubric/gmi)]
+    .map(m => m[1].toLowerCase().split("/")[0].trim())
+    .filter(t => t !== "bug"); // handled separately below for alias pairs
+
+  for (const type of documented) {
+    expect(rubrics[type]).toBeDefined();
+  }
+});
+
+test("REFACTOR specifically has a registered rubric", () => {
+  expect(rubrics.refactor).toBeDefined();
+  expect(rubrics.refactor.checks.length).toBeGreaterThanOrEqual(7);
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `src/lib/scoreSpec.ts:231` no longer contains `if (raw === "refactor") return "chore";` or any equivalent downgrade
+- [ ] `src/lib/rubrics/refactor.ts` exists with a rubric array of ≥ 7 checks matching `ZAI_SYSTEM_INSTRUCTIONS.md` §2 REFACTOR rubric
+- [ ] Uploading the ZiLin brand migration spec returns `refactor` classification and a per-check score (not `chore 2/2`)
+- [ ] Uploading an intentionally-incomplete REFACTOR spec (missing Migration Plan) fails the `migration_plan` check, not passes as chore
+- [ ] Unknown spec types now throw `SpecTypeError` rather than silently defaulting
+- [ ] `registry.test.ts` runs in CI and fails if any type documented in `ZAI_SYSTEM_INSTRUCTIONS.md` lacks a rubric implementation
+- [ ] Existing FEAT / BUG / SPEC / CHORE / UX / BRAND rubrics continue to pass their existing test suites (no regression)
+- [ ] Re-scoring the ZiLin brand migration spec produces a `.scored.md` with `refactor N/8` (or 7, per rubric count) where N reflects actual rubric compliance
+
+## Subject Migration Summary
+
+| Subject | From | To | Notes |
+|---|---|---|---|
+| Refactor type handling | Silent downgrade to chore at line 231 | First-class type with own rubric | Breaking change in behavior; any prior "passing" refactor re-scores under real rubric |
+| Rubric registry | 6 entries (feat, bug, spec, chore, ux, brand) | 7 entries (+ refactor) | Additive |
+| Unknown-type handling | Silent fallback | Explicit `SpecTypeError` | Breaking: external callers that relied on the fallback will error |
+| Drift-detection | None | Doc-vs-code registry test in CI | New CI gate |
+| Prior REFACTOR specs (if any exist) | Scored as chore, presumed-valid | Must be re-scored under real rubric | Audit pass required post-deploy |
+| ZiLin brand migration spec | Blocked by this bug | Unblocked after fix ships | Highest-priority consumer |
+| Open questions | — | — | (1) REFACTOR rubric: 7 or 8 checks? ZAI_SYSTEM_INSTRUCTIONS.md says "FEAT minus Game Theory + Migration Plan + Legal triggers"; FEAT = 9 checks, so math yields 8. The v1.2 changelog says REFACTOR went 6→7. Spec authority is needed before merge — resolve by either updating system instructions or adjusting rubric count. (2) Should prior CHORE-scored "refactors" be flagged retroactively, or is the re-score at next upload sufficient? default: re-score on next upload, no retro sweep. (3) Do we need a migration path for any ZAI users who built tooling around the chore-score output for refactors? default: none exist yet (solo operator). |
+
+## Files
+
+```
+zi007lin/zai/
+  src/lib/scoreSpec.ts                         (MOD: delete line 231; add unknown-type throw)
+  src/lib/rubrics/refactor.ts                  (NEW: rubric definition)
+  src/lib/rubrics/registry.ts                  (MOD: import + register refactor)
+  src/lib/rubrics/registry.test.ts             (NEW: drift-detection test)
+  src/lib/rubrics/refactor.test.ts             (NEW: per-rubric unit tests with pass/fail fixtures)
+  test/fixtures/
+    refactor-pass.md                           (NEW: known-good REFACTOR fixture)
+    refactor-missing-migration.md              (NEW: missing Migration Plan — should fail check)
+    refactor-missing-rollback.md               (NEW: Migration Plan present but no Rollback subsection)
+  CHANGELOG.md                                 (MOD: v1.2.1 entry documenting the fix)
+  docs/ZAI_SYSTEM_INSTRUCTIONS.md              (MOD if rubric count resolves to 8 not 7; else leave)
+```
+
+## Legal triggers
+
+- **Silent-failure integrity.** This bug caused a validator to issue passing scores on specs that were not actually rigorously validated. Any Enterprise customer who relied on `refactor` validation got CHORE-level scrutiny while believing they got full REFACTOR scrutiny. Before any regulated-industry (healthcare/fintech/legal) bundle ships, this fix must be merged and a changelog entry published. Customer-facing disclosure: none required at this stage (pre-commercial; no paying Enterprise customers yet). Post-commercial: if this fix shipped after any paid Enterprise customer uploaded REFACTOR specs, a targeted re-score notification is required.
+- **No PII, PHI, PCI, or regulated-data triggers.** Bug is scoped to validator logic, no user data touched.
+- **No Beacon compliance trigger.** Internal tooling, separate from HTTC operations.
+- **No third-party license triggers.** No new dependencies.
+- Keyword sweep (contract, indemnify, PHI, PAN, royalty): clear.
+
+---
+
+**Pipeline:** download `-v1.md` → upload to `zai.htu.io/app` (the very validator being fixed — note the irony) → receive `-v1.scored.md` → then run:
+
+```bash
+cp "/mnt/c/Users/zilin/Downloads/2026-04-19__bug__zai-refactor-classification-v1.scored.md" \
+   "$HOME/dev/zai/issues/2026-04-19__bug__zai-refactor-classification.md"
+impl i /mnt/c/Users/zilin/Downloads/2026-04-19__bug__zai-refactor-classification-v1.scored.md
+```
+
+**Note:** This BUG spec itself will score as BUG (7 checks) because BUG type is correctly wired. No meta-paradox. The brand-migration REFACTOR spec stays blocked until this fix ships.
+
+---
+
+## ZAI Spec Score
+
+- **Rubric version:** 1.1.0
+- **Spec type:** bug
+- **Evaluated at:** 2026-04-20T03:56:22.540Z
+- **Score:** 5/5
+- **Passed:** YES
+
+| Section | Status |
+|---|---|
+| intent | PASS |
+| reproduction_steps | PASS |
+| fix | PASS |
+| migration_summary | PASS |
+| files_list | PASS |
+
+_Source: 2026-04-19__bug__zai-refactor-classification-v1.md_

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { scoreSpec, detectSpecType } from "./scoreSpec";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  scoreSpec,
+  detectSpecType,
+  SpecTypeError,
+  RUBRIC_SECTION_KEYS,
+  KNOWN_TYPES,
+} from "./scoreSpec";
+import type { SpecType } from "./scoreSpec";
 
-// ─── feat fixture ─────────────────────────────────────────────────────────
+// ─── feat fixture (9 checks, v1.2) ────────────────────────────────────────
 
 const featSpec = `# title
 
@@ -15,18 +24,15 @@ A tight paragraph describing the goal. About twenty words should be plenty.
 
 Trigger for change: when condition X flips.
 
-## Draft-of-thoughts
-Reasoning notes live here.
-
 ## Final Spec
-Details.
+Details of the final design.
 
 ## Acceptance Criteria
 - [ ] one
 - [ ] two
 - [ ] three
 
-## Game Theory Review
+## Game Theory Cooperative Model review
 Who benefits: users.
 Abuse vector: gaming the system.
 Mitigation: rate limits.
@@ -37,13 +43,21 @@ Mitigation: rate limits.
 | What | A thing |
 | Open questions | confirm name |
 
-## Files
+## Files created / updated
 \`\`\`
 src/foo.ts
 \`\`\`
+
+## Models Applied
+- #1 Game Theory Cooperative
+- #2 Decision Tree
+- #14 SIX PASS Validation
+
+## Legal triggers
+None.
 `;
 
-// ─── research fixture ─────────────────────────────────────────────────────
+// ─── research fixture (6 checks, v1.2 unchanged) ──────────────────────────
 
 const researchSpec = `# research title
 
@@ -77,7 +91,7 @@ issues/reports/example.md
 \`\`\`
 `;
 
-// ─── bug fixture ──────────────────────────────────────────────────────────
+// ─── bug fixture (7 checks, v1.2) ─────────────────────────────────────────
 
 const bugSpec = `# bug title
 
@@ -103,27 +117,20 @@ Details.
 \`\`\`
 src/foo.ts
 \`\`\`
+
+## Legal triggers
+None.
 `;
 
-// ─── chore fixture ────────────────────────────────────────────────────────
-
-const choreSpec = `# chore title
-
-## Intent
-Bump dep.
-
-## Files
-\`\`\`
-package.json
-\`\`\`
-`;
-
-// ─── hotfix fixture ───────────────────────────────────────────────────────
+// ─── hotfix fixture (7 checks — aliased to bug in v1.2) ───────────────────
 
 const hotfixSpec = `# hotfix title
 
 ## Intent
 Urgent prod fix.
+
+## Repro
+Production alert at 03:00 UTC.
 
 ## Fix
 Patch.
@@ -132,50 +139,207 @@ Patch.
 - [ ] prod green
 - [ ] incident closed
 
+## Subject Migration Summary
+| | |
+|---|---|
+| Open questions | post-mortem in 48h |
+
 ## Files
 \`\`\`
 src/foo.ts
 \`\`\`
+
+## Legal triggers
+None.
 `;
+
+// ─── chore fixture (5 checks, v1.2) ───────────────────────────────────────
+
+const choreSpec = `# chore title
+
+## Intent
+Bump dep.
+
+## Action
+1. Update package.json
+2. Run npm install
+3. Commit lockfile
+
+## Acceptance Criteria
+- [ ] CI green
+
+## Files
+\`\`\`
+package.json
+\`\`\`
+
+## Legal triggers
+None.
+`;
+
+// ─── spec fixture (6 checks, v1.2) ────────────────────────────────────────
+
+const specSpec = `# spec title
+
+## Intent
+Canonical rules for the widget domain.
+
+## Decision Tree
+| Option | Risk | Decision |
+|---|---|---|
+| A | low | ✅ |
+
+Trigger for change: policy audit.
+
+## Rules
+Widget rules live here.
+
+## Subject Migration Summary
+| | |
+|---|---|
+| Open questions | enforcement cadence |
+
+## Files
+\`\`\`
+docs/widget-rules.md
+\`\`\`
+
+## Legal triggers
+None.
+`;
+
+// ─── refactor fixture (9 checks, v1.2) ────────────────────────────────────
+
+const refactorSpec = `# refactor title
+
+## Intent
+Rename the thing to the new brand.
+
+## Decision Tree
+| Option | Risk | Decision |
+|---|---|---|
+| keep | high | ❌ |
+| rename | low | ✅ |
+
+Trigger for change: TM collision risk.
+
+## Final Spec
+Full rename table.
+
+## Acceptance Criteria
+- [ ] old name gone
+- [ ] new name live
+- [ ] redirect in place
+
+## Subject Migration Summary
+| | |
+|---|---|
+| What | Rename |
+| Open questions | banner copy final |
+
+## Files created / updated
+\`\`\`
+docs/brand/rationale.md
+\`\`\`
+
+## Models Applied
+- #2 Decision Tree
+- #8 Swiss Cheese
+
+## Migration Plan
+Phase 0 prep → Phase 1 dual-run → Phase 2 cutover.
+
+### Rollback
+Trigger: TM opposition. Reverse DNS, revert docs.
+
+## Legal triggers
+None.
+`;
+
+// ─── ux fixture (6 checks, v1.2) ──────────────────────────────────────────
+
+const uxSpec = `# ux title
+
+## Intent
+Redesign the settings panel.
+
+## Jobs To Be Done
+- Find a setting quickly
+- Understand what a setting does
+- Undo a change safely
+
+## Design Rationale
+Rationale for the palette choice.
+
+### Interaction of Color
+Contrast pairs and palette system documented.
+
+## Acceptance Criteria
+- [ ] contrast AA
+- [ ] keyboard navigable
+
+## Assets
+\`\`\`
+assets/settings-panel.fig
+\`\`\`
+
+## Legal triggers
+None.
+`;
+
+// ─── brand fixture (6 checks, v1.2 — same as ux) ──────────────────────────
+
+const brandSpec = uxSpec;
 
 // ─── detectSpecType ───────────────────────────────────────────────────────
 
 describe("detectSpecType", () => {
-  it("extracts feat from filename prefix", () => {
+  it("extracts known types from filename prefix", () => {
     expect(detectSpecType("2026-04-13__feat__title.md")).toBe("feat");
-  });
-  it("extracts research, bug, chore, hotfix", () => {
     expect(detectSpecType("2026-04-13__research__x.md")).toBe("research");
     expect(detectSpecType("2026-04-13__bug__x.md")).toBe("bug");
     expect(detectSpecType("2026-04-13__chore__x.md")).toBe("chore");
     expect(detectSpecType("2026-04-13__hotfix__x.md")).toBe("hotfix");
+    expect(detectSpecType("2026-04-13__spec__x.md")).toBe("spec");
+    expect(detectSpecType("2026-04-13__refactor__x.md")).toBe("refactor");
+    expect(detectSpecType("2026-04-13__ux__x.md")).toBe("ux");
+    expect(detectSpecType("2026-04-13__brand__x.md")).toBe("brand");
   });
-  it("normalizes feature → feat and refactor → chore", () => {
+
+  it("normalizes feature → feat (documented alias)", () => {
     expect(detectSpecType("2026-04-13__feature__x.md")).toBe("feat");
-    expect(detectSpecType("2026-04-13__refactor__x.md")).toBe("chore");
   });
-  it("defaults unknown or missing type to feat", () => {
-    expect(detectSpecType("2026-04-13__wat__x.md")).toBe("feat");
-    expect(detectSpecType("random.md")).toBe("feat");
-    expect(detectSpecType("")).toBe("feat");
+
+  it("refactor is NOT aliased to chore anymore (the bug this PR fixes)", () => {
+    expect(detectSpecType("2026-04-13__refactor__x.md")).toBe("refactor");
   });
+
+  it("throws SpecTypeError on unknown type", () => {
+    expect(() => detectSpecType("2026-04-13__wat__x.md")).toThrow(SpecTypeError);
+    expect(() => detectSpecType("2026-04-13__wat__x.md")).toThrow(/Unknown spec type/);
+  });
+
+  it("throws SpecTypeError on missing prefix", () => {
+    expect(() => detectSpecType("random.md")).toThrow(SpecTypeError);
+    expect(() => detectSpecType("")).toThrow(SpecTypeError);
+    expect(() => detectSpecType("README.md")).toThrow(SpecTypeError);
+  });
+
   it("strips directory components from the path", () => {
     expect(detectSpecType("issues/2026-04-13__research__x.md")).toBe("research");
     expect(detectSpecType("/abs/path/2026-04-13__bug__x.md")).toBe("bug");
   });
 });
 
-// ─── scoreSpec — feat ─────────────────────────────────────────────────────
+// ─── scoreSpec — feat (9 checks) ──────────────────────────────────────────
 
 describe("scoreSpec — feat", () => {
-  it("scores a compliant feat spec 7/7 passed", () => {
+  it("scores a compliant feat spec 9/9 passed", () => {
     const r = scoreSpec(featSpec, "2026-04-12__feat__example.md");
     expect(r.spec_type).toBe("feat");
-    expect(r.required_count).toBe(7);
-    expect(r.score).toBe("7/7");
+    expect(r.required_count).toBe(9);
+    expect(r.score).toBe("9/9");
     expect(r.passed).toBe(true);
-    expect(r.sections.draft_of_thoughts).toBe("PASS");
-    // all passing sections have null reason
     for (const key of r.section_order) {
       if (r.sections[key] !== "FAIL") {
         expect(r.section_reasons[key]).toBeNull();
@@ -186,16 +350,19 @@ describe("scoreSpec — feat", () => {
   it("intent FAILs on empty body with reason", () => {
     const md = featSpec.replace(
       /## Intent\nA tight paragraph[^\n]*\n/,
-      "## Intent\n\n"
+      "## Intent\n\n",
     );
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.intent).toBe("FAIL");
     expect(r.section_reasons.intent).toBe("intent section is empty");
   });
 
-  it("intent FAILs when body exceeds 150 words with reason", () => {
+  it("intent FAILs when body exceeds 150 words", () => {
     const long = "word ".repeat(200);
-    const md = `## Intent\n${long}\n\n## Next\n`;
+    const md = featSpec.replace(
+      /## Intent\nA tight paragraph[^\n]*/,
+      `## Intent\n${long}`,
+    );
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.intent).toBe("FAIL");
     expect(r.section_reasons.intent).toMatch(/exceeds 150-word limit/);
@@ -204,30 +371,21 @@ describe("scoreSpec — feat", () => {
   it("decision_tree FAILs without a table", () => {
     const md = featSpec.replace(
       /\| Option \| Risk \| Decision \|\n\|---\|---\|---\|\n\| A \| low \| ✅ \|\n/,
-      ""
+      "",
     );
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.decision_tree).toBe("FAIL");
     expect(r.section_reasons.decision_tree).toMatch(/missing decision table/);
   });
 
-  it("draft_of_thoughts SKIPs when absent (never FAIL)", () => {
-    const md = featSpec.replace(/## Draft-of-thoughts[\s\S]*?(?=## )/, "");
-    const r = scoreSpec(md, "2026-04-13__feat__x.md");
-    expect(r.sections.draft_of_thoughts).toBe("SKIP");
-    expect(r.section_reasons.draft_of_thoughts).toBeNull();
-    expect(r.passed).toBe(true);
-    expect(r.score).toBe("7/7");
-  });
-
-  it("final_spec FAILs with fewer than 3 acceptance checkboxes", () => {
+  it("acceptance_criteria FAILs with fewer than 3 checkboxes", () => {
     const md = featSpec.replace(
       /- \[ \] one\n- \[ \] two\n- \[ \] three\n/,
-      "- [ ] one\n- [ ] two\n"
+      "- [ ] one\n- [ ] two\n",
     );
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
-    expect(r.sections.final_spec).toBe("FAIL");
-    expect(r.section_reasons.final_spec).toMatch(/minimum 3 acceptance criteria/);
+    expect(r.sections.acceptance_criteria).toBe("FAIL");
+    expect(r.section_reasons.acceptance_criteria).toMatch(/minimum 3/);
   });
 
   it("game_theory FAILs when Mitigation is missing", () => {
@@ -236,9 +394,26 @@ describe("scoreSpec — feat", () => {
     expect(r.sections.game_theory).toBe("FAIL");
     expect(r.section_reasons.game_theory).toMatch(/Mitigation/);
   });
+
+  it("models_applied FAILs when section empty", () => {
+    const md = featSpec.replace(
+      /## Models Applied\n[\s\S]*?(?=\n## )/,
+      "## Models Applied\n",
+    );
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.models_applied).toBe("FAIL");
+    expect(r.section_reasons.models_applied).toMatch(/no model declarations/);
+  });
+
+  it("legal_triggers FAILs when heading absent", () => {
+    const md = featSpec.replace(/## Legal triggers\nNone\.\n/, "");
+    const r = scoreSpec(md, "2026-04-13__feat__x.md");
+    expect(r.sections.legal_triggers).toBe("FAIL");
+    expect(r.section_reasons.legal_triggers).toMatch(/Legal triggers/);
+  });
 });
 
-// ─── scoreSpec — research ─────────────────────────────────────────────────
+// ─── scoreSpec — research (6 checks, v1.2 unchanged) ──────────────────────
 
 describe("scoreSpec — research", () => {
   it("scores a compliant research spec 6/6 passed", () => {
@@ -247,10 +422,11 @@ describe("scoreSpec — research", () => {
     expect(r.required_count).toBe(6);
     expect(r.score).toBe("6/6");
     expect(r.passed).toBe(true);
-    expect(r.sections.research_questions).toBe("PASS");
-    expect(r.sections.report_format).toBe("PASS");
-    expect("decision_tree" in r.sections).toBe(false);
-    expect("game_theory" in r.sections).toBe(false);
+  });
+
+  it("research has no legal_triggers check (non-building exemption)", () => {
+    const r = scoreSpec(researchSpec, "2026-04-13__research__example.md");
+    expect("legal_triggers" in r.sections).toBe(false);
   });
 
   it("research_questions FAILs without at least one subheading", () => {
@@ -259,10 +435,10 @@ describe("scoreSpec — research", () => {
     expect(r.sections.research_questions).toBe("FAIL");
   });
 
-  it("acceptance_criteria FAILs without 'report saved' phrase", () => {
+  it("acceptance_criteria FAILs without 'report saved' or 'report is complete' phrase", () => {
     const md = researchSpec.replace(
       /- \[ \] report saved[^\n]*\n/,
-      "- [ ] something else\n"
+      "- [ ] something else\n",
     );
     const r = scoreSpec(md, "2026-04-13__research__x.md");
     expect(r.sections.acceptance_criteria).toBe("FAIL");
@@ -275,57 +451,196 @@ describe("scoreSpec — research", () => {
   });
 });
 
-// ─── scoreSpec — bug ──────────────────────────────────────────────────────
+// ─── scoreSpec — bug (7 checks, v1.2) ─────────────────────────────────────
 
 describe("scoreSpec — bug", () => {
-  it("scores a compliant bug spec 5/5 passed", () => {
+  it("scores a compliant bug spec 7/7 passed", () => {
     const r = scoreSpec(bugSpec, "2026-04-13__bug__example.md");
     expect(r.spec_type).toBe("bug");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
+    expect(r.passed).toBe(true);
+  });
+
+  it("acceptance_criteria FAILs with fewer than 2 checkboxes", () => {
+    const md = bugSpec.replace(/- \[ \] one\n- \[ \] two\n/, "- [ ] one\n");
+    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.acceptance_criteria).toBe(
+      "FAIL",
+    );
+  });
+
+  it("repro FAILs without ## Repro heading", () => {
+    const md = bugSpec.replace(/## Repro[\s\S]*?(?=## )/, "");
+    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.repro).toBe("FAIL");
+  });
+
+  it("legal_triggers FAILs when heading absent", () => {
+    const md = bugSpec.replace(/## Legal triggers\nNone\.\n/, "");
+    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.legal_triggers).toBe(
+      "FAIL",
+    );
+  });
+});
+
+// ─── scoreSpec — hotfix (7 checks — aliased to bug) ───────────────────────
+
+describe("scoreSpec — hotfix", () => {
+  it("scores a compliant hotfix spec 7/7 passed", () => {
+    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
+    expect(r.spec_type).toBe("hotfix");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
+    expect(r.passed).toBe(true);
+  });
+
+  it("hotfix uses same section set as bug", () => {
+    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
+    expect(r.section_order).toEqual([
+      "intent",
+      "repro",
+      "fix",
+      "acceptance_criteria",
+      "migration_summary",
+      "files",
+      "legal_triggers",
+    ]);
+  });
+});
+
+// ─── scoreSpec — chore (5 checks, v1.2) ───────────────────────────────────
+
+describe("scoreSpec — chore", () => {
+  it("scores a compliant chore spec 5/5 passed", () => {
+    const r = scoreSpec(choreSpec, "2026-04-13__chore__example.md");
+    expect(r.spec_type).toBe("chore");
     expect(r.required_count).toBe(5);
     expect(r.score).toBe("5/5");
     expect(r.passed).toBe(true);
   });
 
-  it("fix section FAILs with fewer than 2 acceptance checkboxes", () => {
-    const md = bugSpec.replace(/- \[ \] one\n- \[ \] two\n/, "- [ ] one\n");
-    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.fix).toBe("FAIL");
+  it("intent FAILs when body exceeds 100 words for chore", () => {
+    const long = "word ".repeat(120);
+    const md = choreSpec.replace(/## Intent\nBump dep\.\n/, `## Intent\n${long}\n`);
+    const r = scoreSpec(md, "2026-04-13__chore__x.md");
+    expect(r.sections.intent).toBe("FAIL");
+    expect(r.section_reasons.intent).toMatch(/100-word limit/);
   });
 
-  it("reproduction_steps FAILs without ## Repro heading", () => {
-    const md = bugSpec.replace(/## Repro[\s\S]*?(?=## )/, "");
-    expect(scoreSpec(md, "2026-04-13__bug__x.md").sections.reproduction_steps).toBe(
-      "FAIL"
+  it("action FAILs when no numbered steps", () => {
+    const md = choreSpec.replace(
+      /## Action\n1\. [\s\S]*?(?=\n## )/,
+      "## Action\nNo numbered steps here.\n",
     );
+    const r = scoreSpec(md, "2026-04-13__chore__x.md");
+    expect(r.sections.action).toBe("FAIL");
   });
 });
 
-// ─── scoreSpec — chore ────────────────────────────────────────────────────
+// ─── scoreSpec — spec (6 checks, v1.2) ────────────────────────────────────
 
-describe("scoreSpec — chore", () => {
-  it("scores a compliant chore spec 2/2 passed", () => {
-    const r = scoreSpec(choreSpec, "2026-04-13__chore__example.md");
-    expect(r.spec_type).toBe("chore");
-    expect(r.required_count).toBe(2);
-    expect(r.score).toBe("2/2");
+describe("scoreSpec — spec", () => {
+  it("scores a compliant spec 6/6 passed", () => {
+    const r = scoreSpec(specSpec, "2026-04-13__spec__example.md");
+    expect(r.spec_type).toBe("spec");
+    expect(r.required_count).toBe(6);
+    expect(r.score).toBe("6/6");
     expect(r.passed).toBe(true);
-    expect("decision_tree" in r.sections).toBe(false);
   });
 
-  it("refactor alias routes to chore", () => {
-    const r = scoreSpec(choreSpec, "2026-04-13__refactor__example.md");
-    expect(r.spec_type).toBe("chore");
-    expect(r.score).toBe("2/2");
+  it("rules_or_content accepts ## Content instead of ## Rules", () => {
+    const md = specSpec.replace(/## Rules\n/, "## Content\n");
+    const r = scoreSpec(md, "2026-04-13__spec__x.md");
+    expect(r.sections.rules_or_content).toBe("PASS");
+  });
+
+  it("rules_or_content FAILs when neither heading is present", () => {
+    const md = specSpec.replace(/## Rules\nWidget rules live here\.\n\n/, "");
+    const r = scoreSpec(md, "2026-04-13__spec__x.md");
+    expect(r.sections.rules_or_content).toBe("FAIL");
   });
 });
 
-// ─── scoreSpec — hotfix ───────────────────────────────────────────────────
+// ─── scoreSpec — refactor (9 checks, v1.2) ────────────────────────────────
 
-describe("scoreSpec — hotfix", () => {
-  it("scores a compliant hotfix spec 3/3 passed", () => {
-    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
-    expect(r.spec_type).toBe("hotfix");
-    expect(r.required_count).toBe(3);
-    expect(r.score).toBe("3/3");
+describe("scoreSpec — refactor", () => {
+  it("scores a compliant refactor spec 9/9 passed", () => {
+    const r = scoreSpec(refactorSpec, "2026-04-13__refactor__example.md");
+    expect(r.spec_type).toBe("refactor");
+    expect(r.required_count).toBe(9);
+    expect(r.score).toBe("9/9");
+    expect(r.passed).toBe(true);
+  });
+
+  it("refactor is NOT downgraded to chore (the bug this PR fixes)", () => {
+    const r = scoreSpec(refactorSpec, "2026-04-13__refactor__example.md");
+    expect(r.spec_type).toBe("refactor");
+    expect(r.required_count).toBe(9);
+  });
+
+  it("migration_plan FAILs without ### Rollback subsection", () => {
+    const md = refactorSpec.replace(/### Rollback\n[\s\S]*?(?=\n## )/, "");
+    const r = scoreSpec(md, "2026-04-13__refactor__x.md");
+    expect(r.sections.migration_plan).toBe("FAIL");
+    expect(r.section_reasons.migration_plan).toMatch(/Rollback/);
+  });
+
+  it("refactor requires Models Applied", () => {
+    const md = refactorSpec.replace(/## Models Applied\n[\s\S]*?(?=\n## )/, "");
+    const r = scoreSpec(md, "2026-04-13__refactor__x.md");
+    expect(r.sections.models_applied).toBe("FAIL");
+  });
+
+  it("refactor does NOT require Game Theory (unlike FEAT)", () => {
+    const r = scoreSpec(refactorSpec, "2026-04-13__refactor__example.md");
+    expect("game_theory" in r.sections).toBe(false);
+  });
+});
+
+// ─── scoreSpec — ux / brand (6 checks each, v1.2) ─────────────────────────
+
+describe("scoreSpec — ux", () => {
+  it("scores a compliant ux spec 6/6 passed", () => {
+    const r = scoreSpec(uxSpec, "2026-04-13__ux__example.md");
+    expect(r.spec_type).toBe("ux");
+    expect(r.required_count).toBe(6);
+    expect(r.score).toBe("6/6");
+    expect(r.passed).toBe(true);
+  });
+
+  it("jobs_to_be_done FAILs with fewer than 3 jobs", () => {
+    const md = uxSpec.replace(
+      /## Jobs To Be Done\n[\s\S]*?(?=\n## )/,
+      "## Jobs To Be Done\n- Only one job\n",
+    );
+    const r = scoreSpec(md, "2026-04-13__ux__x.md");
+    expect(r.sections.jobs_to_be_done).toBe("FAIL");
+    expect(r.section_reasons.jobs_to_be_done).toMatch(/minimum 3/);
+  });
+
+  it("jobs_to_be_done FAILs with more than 5 jobs", () => {
+    const md = uxSpec.replace(
+      /## Jobs To Be Done\n[\s\S]*?(?=\n## )/,
+      "## Jobs To Be Done\n- a\n- b\n- c\n- d\n- e\n- f\n",
+    );
+    const r = scoreSpec(md, "2026-04-13__ux__x.md");
+    expect(r.sections.jobs_to_be_done).toBe("FAIL");
+    expect(r.section_reasons.jobs_to_be_done).toMatch(/maximum 5/);
+  });
+
+  it("design_rationale FAILs without ### Interaction of Color", () => {
+    const md = uxSpec.replace(/### Interaction of Color\n[\s\S]*?(?=\n## )/, "");
+    const r = scoreSpec(md, "2026-04-13__ux__x.md");
+    expect(r.sections.design_rationale).toBe("FAIL");
+    expect(r.section_reasons.design_rationale).toMatch(/Interaction of Color/);
+  });
+});
+
+describe("scoreSpec — brand", () => {
+  it("scores a compliant brand spec 6/6 passed (same rubric as ux)", () => {
+    const r = scoreSpec(brandSpec, "2026-04-13__brand__example.md");
+    expect(r.spec_type).toBe("brand");
+    expect(r.required_count).toBe(6);
+    expect(r.score).toBe("6/6");
     expect(r.passed).toBe(true);
   });
 });
@@ -351,7 +666,7 @@ describe("scoreSpec — section_reasons", () => {
   });
 
   it("files_list reason mentions code block when section exists but has no code block", () => {
-    const md = `${featSpec.replace(/```\nsrc\/foo\.ts\n```/, "no code block here")}`;
+    const md = featSpec.replace(/```\nsrc\/foo\.ts\n```/, "no code block here");
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.files_list).toBe("FAIL");
     expect(r.section_reasons.files_list).toMatch(/no code block/);
@@ -360,7 +675,7 @@ describe("scoreSpec — section_reasons", () => {
   it("migration_summary reason mentions Open questions when row is empty", () => {
     const md = featSpec.replace(
       /\| Open questions \| confirm name \|/,
-      "| Open questions | |"
+      "| Open questions | |",
     );
     const r = scoreSpec(md, "2026-04-13__feat__x.md");
     expect(r.sections.migration_summary).toBe("FAIL");
@@ -378,14 +693,98 @@ describe("scoreSpec — gates and meta", () => {
     expect(r.gates[0]).toMatch(/chain/i);
   });
 
-  it("rubric version is 1.1.0", () => {
-    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.1.0");
+  it("rubric version is 1.2.1", () => {
+    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.2.1");
   });
 
-  it("non-spec markdown falls back to feat and fails gracefully", () => {
-    const r = scoreSpec("# README\n\nJust a readme.\n", "README.md");
-    expect(r.spec_type).toBe("feat");
-    expect(r.required_count).toBe(7);
-    expect(r.passed).toBe(false);
+  it("non-matching filename throws SpecTypeError (previously silently fell back to feat)", () => {
+    expect(() => scoreSpec("# README\n\nJust a readme.\n", "README.md")).toThrow(
+      SpecTypeError,
+    );
+  });
+});
+
+// ─── drift-detection (Layer 3) ────────────────────────────────────────────
+//
+// Reads docs/ZAI_SYSTEM_INSTRUCTIONS.md §Appendix and asserts that every
+// documented type has a rubric implementation with matching check count and
+// ordered section IDs. This test is the canonical defense against
+// doc-vs-code drift — the same class of bug as the refactor→chore downgrade
+// that this PR fixes.
+
+const APPENDIX_COUNT_TABLE_ROW = /^\|\s*`(\w+)`\s*\|\s*(\d+)\s*\|\s*`([^`]+)`\s*\|/gm;
+
+interface AppendixEntry {
+  type: string;
+  count: number;
+  keys: string[];
+}
+
+function parseAppendix(doc: string): AppendixEntry[] {
+  const entries: AppendixEntry[] = [];
+  const appendixStart = doc.search(/^##\s+Appendix:\s+rubric-count\s+summary/mi);
+  const slice = appendixStart === -1 ? doc : doc.slice(appendixStart);
+  let match: RegExpExecArray | null;
+  const re = new RegExp(APPENDIX_COUNT_TABLE_ROW);
+  while ((match = re.exec(slice)) !== null) {
+    entries.push({
+      type: match[1],
+      count: Number(match[2]),
+      keys: match[3].split(",").map((k) => k.trim()),
+    });
+  }
+  return entries;
+}
+
+describe("drift-detection — scoreSpec vs ZAI_SYSTEM_INSTRUCTIONS.md §Appendix", () => {
+  const docPath = resolve(__dirname, "../../docs/ZAI_SYSTEM_INSTRUCTIONS.md");
+  const doc = readFileSync(docPath, "utf8");
+  const appendix = parseAppendix(doc);
+
+  it("parses at least 8 types from appendix", () => {
+    expect(appendix.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("every documented type has a rubric implementation", () => {
+    for (const entry of appendix) {
+      expect(
+        (KNOWN_TYPES as readonly string[]).includes(entry.type),
+        `type "${entry.type}" documented in ZAI_SYSTEM_INSTRUCTIONS.md but not in KNOWN_TYPES`,
+      ).toBe(true);
+      expect(
+        RUBRIC_SECTION_KEYS[entry.type as SpecType],
+        `type "${entry.type}" documented but has no RUBRIC_SECTION_KEYS entry`,
+      ).toBeDefined();
+    }
+  });
+
+  it("rubric check count matches documented count for every type", () => {
+    for (const entry of appendix) {
+      const implCount = RUBRIC_SECTION_KEYS[entry.type as SpecType].length;
+      expect(
+        implCount,
+        `type "${entry.type}": doc says ${entry.count} checks, impl has ${implCount}`,
+      ).toBe(entry.count);
+    }
+  });
+
+  it("rubric section keys match documented order for every type", () => {
+    for (const entry of appendix) {
+      const implKeys = RUBRIC_SECTION_KEYS[entry.type as SpecType];
+      expect(
+        implKeys,
+        `type "${entry.type}": doc keys [${entry.keys.join(", ")}] vs impl [${implKeys.join(", ")}]`,
+      ).toEqual(entry.keys);
+    }
+  });
+
+  it("REFACTOR specifically has a registered rubric with 9 checks", () => {
+    expect(RUBRIC_SECTION_KEYS.refactor).toBeDefined();
+    expect(RUBRIC_SECTION_KEYS.refactor.length).toBe(9);
+  });
+
+  it("hotfix is not in the appendix (aliased to bug at runtime)", () => {
+    const types = appendix.map((e) => e.type);
+    expect(types).not.toContain("hotfix");
   });
 });

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -1,6 +1,15 @@
 export type SectionStatus = "PASS" | "FAIL" | "SKIP";
 
-export type SpecType = "feat" | "research" | "bug" | "chore" | "hotfix";
+export type SpecType =
+  | "feat"
+  | "bug"
+  | "hotfix"
+  | "spec"
+  | "chore"
+  | "refactor"
+  | "research"
+  | "ux"
+  | "brand";
 
 export interface ScoreResult {
   rubric_version: string;
@@ -16,7 +25,16 @@ export interface ScoreResult {
   gates: string[];
 }
 
-const RUBRIC_VERSION = "1.1.0";
+export class SpecTypeError extends Error {
+  constructor(raw: string, known: readonly string[]) {
+    super(
+      `Unknown spec type "${raw}". Known: ${known.join(", ")}. Rename the file or add the type to ZAI_SYSTEM_INSTRUCTIONS.md.`,
+    );
+    this.name = "SpecTypeError";
+  }
+}
+
+const RUBRIC_VERSION = "1.2.1";
 
 // ─── helpers ──────────────────────────────────────────────────────────────
 
@@ -52,6 +70,14 @@ function subheadingCount(body: string): number {
   return (body.match(/^###\s+/gm) || []).length;
 }
 
+function numberedListCount(body: string): number {
+  return (body.match(/^\d+\.\s+/gm) || []).length;
+}
+
+function bulletListCount(body: string): number {
+  return (body.match(/^[-*]\s+/gm) || []).length;
+}
+
 function openQuestionsNotEmpty(body: string): boolean {
   const row = body.match(/\|\s*Open\s+questions\s*\|([^|\n]*)\|/i);
   if (!row) return false;
@@ -79,32 +105,38 @@ function pass(): CheckResult {
   return { status: "PASS", reason: null };
 }
 
-function skip(): CheckResult {
-  return { status: "SKIP", reason: null };
-}
-
 function fail(reason: string): CheckResult {
   return { status: "FAIL", reason };
 }
 
-// ─── section checks ───────────────────────────────────────────────────────
+// ─── heading regexes ──────────────────────────────────────────────────────
 
 const INTENT_HEADING = /^##\s+Intent\b/mi;
 const DECISION_TREE_HEADING = /^##\s+Decision\s+Tree\b/mi;
-const DRAFT_HEADING = /^##\s+Draft[-\s]of[-\s]thoughts\b/mi;
 const FINAL_SPEC_HEADING = /^##\s+Final\s+Spec\b/mi;
-const GAME_THEORY_HEADING = /^##\s+Game\s+Theory(\s+Review)?\b/mi;
-const MIGRATION_HEADING = /^##\s+Subject\s+Migration\s+Summary\b/mi;
-const FILES_HEADING = /^##\s+Files\b/mi;
-const RESEARCH_QUESTIONS_HEADING = /^##\s+Research\s+Questions\b/mi;
 const ACCEPTANCE_CRITERIA_HEADING = /^##\s+Acceptance\s+Criteria\b/mi;
+const GAME_THEORY_HEADING = /^##\s+Game\s+Theory(\s+Cooperative\s+Model(\s+review)?)?(\s+Review)?\b/mi;
+const MIGRATION_HEADING = /^##\s+Subject\s+Migration\s+Summary\b/mi;
+const FILES_CREATED_HEADING = /^##\s+Files(\s+created\s*\/\s*updated)?\b/mi;
+const FILES_HEADING = /^##\s+Files\b/mi;
+const FILES_OR_SCHEMA_HEADING = /^##\s+(Files|Schema|Files\s*\/\s*Schema|Assets)\b/mi;
+const MODELS_APPLIED_HEADING = /^##\s+Models\s+Applied\b/mi;
+const LEGAL_TRIGGERS_HEADING = /^##\s+Legal\s+triggers\b/mi;
+const MIGRATION_PLAN_HEADING = /^##\s+Migration\s+Plan\b/mi;
+const RESEARCH_QUESTIONS_HEADING = /^##\s+Research\s+Questions\b/mi;
 const REPORT_FORMAT_HEADING = /^##\s+Report\s+Format\b/mi;
 const REPRO_HEADING = /^##\s+Repro(duction)?(\s+Steps)?\b/mi;
 const FIX_HEADING = /^##\s+Fix\b/mi;
+const ACTION_HEADING = /^##\s+Action\b/mi;
+const JOBS_HEADING = /^##\s+Jobs\s+To\s+Be\s+Done\b/mi;
+const DESIGN_RATIONALE_HEADING = /^##\s+Design\s+Rationale\b/mi;
+const RULES_OR_CONTENT_HEADING = /^##\s+(Rules|Content)\b/mi;
+
+// ─── section checks ───────────────────────────────────────────────────────
 
 function checkIntentStrict(md: string): CheckResult {
   if (!headingPresent(md, INTENT_HEADING))
-    return fail("\"## Intent\" heading not found");
+    return fail('"## Intent" heading not found');
   const body = sectionBody(md, INTENT_HEADING);
   const words = wordCount(body);
   if (words === 0) return fail("intent section is empty");
@@ -113,50 +145,74 @@ function checkIntentStrict(md: string): CheckResult {
   return pass();
 }
 
+function checkIntentChore(md: string): CheckResult {
+  if (!headingPresent(md, INTENT_HEADING))
+    return fail('"## Intent" heading not found');
+  const body = sectionBody(md, INTENT_HEADING);
+  const words = wordCount(body);
+  if (words === 0) return fail("intent section is empty");
+  if (words > 100)
+    return fail(`intent exceeds 100-word limit for chore — found ${words} words`);
+  return pass();
+}
+
 function checkIntentLoose(md: string): CheckResult {
   if (!headingPresent(md, INTENT_HEADING))
-    return fail("\"## Intent\" heading not found");
+    return fail('"## Intent" heading not found');
   return pass();
 }
 
 function checkDecisionTree(md: string): CheckResult {
   if (!headingPresent(md, DECISION_TREE_HEADING))
-    return fail("\"## Decision Tree\" heading not found");
+    return fail('"## Decision Tree" heading not found');
   const body = sectionBody(md, DECISION_TREE_HEADING);
   const hasTable = tablePresent(body);
   const hasTrigger = /trigger\s+for\s+change/i.test(body);
   if (!hasTable && !hasTrigger)
-    return fail("missing decision table and \"Trigger for change\" statement");
-  if (!hasTable) return fail("missing decision table (expected \"| | |\" pattern)");
-  if (!hasTrigger) return fail("missing \"Trigger for change\" statement");
+    return fail('missing decision table and "Trigger for change" statement');
+  if (!hasTable) return fail('missing decision table (expected "| | |" pattern)');
+  if (!hasTrigger) return fail('missing "Trigger for change" statement');
   return pass();
-}
-
-function checkDraftOfThoughts(md: string): CheckResult {
-  return headingPresent(md, DRAFT_HEADING) ? pass() : skip();
 }
 
 function checkFinalSpec(md: string): CheckResult {
   if (!headingPresent(md, FINAL_SPEC_HEADING))
-    return fail("\"## Final Spec\" heading not found");
+    return fail('"## Final Spec" heading not found');
+  return pass();
+}
+
+function checkAcceptanceCriteria(md: string, minBoxes: number): CheckResult {
   if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
-    return fail("\"## Acceptance Criteria\" heading not found");
+    return fail('"## Acceptance Criteria" heading not found');
+  const count = acceptanceCriteriaCheckboxes(md);
+  if (count < minBoxes)
+    return fail(
+      `minimum ${minBoxes} acceptance criteria checkbox${minBoxes === 1 ? "" : "es"} required — found ${count}`,
+    );
+  return pass();
+}
+
+function checkAcceptanceCriteriaResearch(md: string): CheckResult {
+  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
+    return fail('"## Acceptance Criteria" heading not found');
   const count = acceptanceCriteriaCheckboxes(md);
   if (count < 3)
     return fail(
-      `minimum 3 acceptance criteria checkboxes required — found ${count}`
+      `minimum 3 acceptance criteria checkboxes required — found ${count}`,
     );
+  if (!/report\s+(saved|is\s+complete)/i.test(md))
+    return fail('missing "report saved" or "report is complete" phrase in acceptance criteria');
   return pass();
 }
 
 function checkGameTheory(md: string): CheckResult {
   if (!headingPresent(md, GAME_THEORY_HEADING))
-    return fail("\"## Game Theory\" heading not found");
+    return fail('"## Game Theory Cooperative Model review" heading not found');
   const body = sectionBody(md, GAME_THEORY_HEADING);
   const missing: string[] = [];
-  if (!/who\s+benefits/i.test(body)) missing.push("\"Who benefits\"");
-  if (!/abuse\s+vector/i.test(body)) missing.push("\"Abuse vector\"");
-  if (!/mitigation/i.test(body)) missing.push("\"Mitigation\"");
+  if (!/who\s+benefits/i.test(body)) missing.push('"Who benefits"');
+  if (!/abuse\s+vector/i.test(body)) missing.push('"Abuse vector"');
+  if (!/mitigation/i.test(body)) missing.push('"Mitigation"');
   if (missing.length > 0)
     return fail(`missing required subsections: ${missing.join(", ")}`);
   return pass();
@@ -164,73 +220,121 @@ function checkGameTheory(md: string): CheckResult {
 
 function checkMigrationSummary(md: string): CheckResult {
   if (!headingPresent(md, MIGRATION_HEADING))
-    return fail("\"## Subject Migration Summary\" heading not found");
+    return fail('"## Subject Migration Summary" heading not found');
   const body = sectionBody(md, MIGRATION_HEADING);
   if (!openQuestionsNotEmpty(body))
-    return fail("\"Open questions\" row is empty or missing in migration table");
+    return fail('"Open questions" row is empty or missing in migration table');
   return pass();
 }
 
 function checkFilesList(md: string): CheckResult {
+  if (!headingPresent(md, FILES_CREATED_HEADING))
+    return fail('"## Files" or "## Files created / updated" heading not found');
+  if (!codeBlockPresent(sectionBody(md, FILES_CREATED_HEADING)))
+    return fail("no code block found in Files section");
+  return pass();
+}
+
+function checkFiles(md: string): CheckResult {
   if (!headingPresent(md, FILES_HEADING))
-    return fail("\"## Files\" heading not found");
+    return fail('"## Files" heading not found');
   if (!codeBlockPresent(sectionBody(md, FILES_HEADING)))
     return fail("no code block found in Files section");
   return pass();
 }
 
+function checkFilesOrSchema(md: string): CheckResult {
+  if (!headingPresent(md, FILES_OR_SCHEMA_HEADING))
+    return fail('"## Files" or "## Schema" or "## Assets" heading not found');
+  if (!codeBlockPresent(sectionBody(md, FILES_OR_SCHEMA_HEADING)))
+    return fail("no code block found in Files/Schema/Assets section");
+  return pass();
+}
+
 function checkResearchQuestions(md: string): CheckResult {
   if (!headingPresent(md, RESEARCH_QUESTIONS_HEADING))
-    return fail("\"## Research Questions\" heading not found");
+    return fail('"## Research Questions" heading not found');
   if (subheadingCount(sectionBody(md, RESEARCH_QUESTIONS_HEADING)) < 1)
     return fail("at least one ### subheading required under Research Questions");
   return pass();
 }
 
-function checkAcceptanceCriteriaResearch(md: string): CheckResult {
-  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
-    return fail("\"## Acceptance Criteria\" heading not found");
-  const count = acceptanceCriteriaCheckboxes(md);
-  if (count < 3)
-    return fail(
-      `minimum 3 acceptance criteria checkboxes required — found ${count}`
-    );
-  if (!/report\s+saved/i.test(md))
-    return fail("missing \"report saved\" reference in acceptance criteria");
-  return pass();
-}
-
 function checkReportFormat(md: string): CheckResult {
   if (!headingPresent(md, REPORT_FORMAT_HEADING))
-    return fail("\"## Report Format\" heading not found");
+    return fail('"## Report Format" heading not found');
   return pass();
 }
 
-function checkReproSteps(md: string): CheckResult {
+function checkRepro(md: string): CheckResult {
   if (!headingPresent(md, REPRO_HEADING))
-    return fail("\"## Repro\" heading not found");
+    return fail('"## Repro" heading not found');
   return pass();
 }
 
-function checkBugFixSection(md: string): CheckResult {
+function checkFix(md: string): CheckResult {
   if (!headingPresent(md, FIX_HEADING))
-    return fail("\"## Fix\" heading not found");
-  if (!headingPresent(md, ACCEPTANCE_CRITERIA_HEADING))
-    return fail("\"## Acceptance Criteria\" heading not found");
-  const count = acceptanceCriteriaCheckboxes(md);
-  if (count < 2)
-    return fail(
-      `minimum 2 acceptance criteria checkboxes required — found ${count}`
-    );
+    return fail('"## Fix" heading not found');
   return pass();
 }
 
-function checkMigrationSummaryBug(md: string): CheckResult {
-  if (!headingPresent(md, MIGRATION_HEADING))
-    return fail("\"## Subject Migration Summary\" heading not found");
-  const body = sectionBody(md, MIGRATION_HEADING);
-  if (!openQuestionsNotEmpty(body))
-    return fail("\"Open questions\" row is empty or missing in migration table");
+function checkAction(md: string): CheckResult {
+  if (!headingPresent(md, ACTION_HEADING))
+    return fail('"## Action" heading not found');
+  const body = sectionBody(md, ACTION_HEADING);
+  if (numberedListCount(body) < 1)
+    return fail("expected a numbered step list under ## Action");
+  return pass();
+}
+
+function checkLegalTriggers(md: string): CheckResult {
+  if (!headingPresent(md, LEGAL_TRIGGERS_HEADING))
+    return fail('"## Legal triggers" heading not found');
+  return pass();
+}
+
+function checkModelsApplied(md: string): CheckResult {
+  if (!headingPresent(md, MODELS_APPLIED_HEADING))
+    return fail('"## Models Applied" heading not found');
+  const body = sectionBody(md, MODELS_APPLIED_HEADING);
+  const declarations = bulletListCount(body) + numberedListCount(body);
+  if (declarations < 1)
+    return fail("no model declarations found under ## Models Applied (expected bullet or numbered list)");
+  return pass();
+}
+
+function checkMigrationPlan(md: string): CheckResult {
+  if (!headingPresent(md, MIGRATION_PLAN_HEADING))
+    return fail('"## Migration Plan" heading not found');
+  const body = sectionBody(md, MIGRATION_PLAN_HEADING);
+  if (!/^###\s+Rollback\b/mi.test(body))
+    return fail('missing "### Rollback" subsection under ## Migration Plan');
+  return pass();
+}
+
+function checkJobsToBeDone(md: string): CheckResult {
+  if (!headingPresent(md, JOBS_HEADING))
+    return fail('"## Jobs To Be Done" heading not found');
+  const body = sectionBody(md, JOBS_HEADING);
+  const jobs = bulletListCount(body) + numberedListCount(body);
+  if (jobs < 3)
+    return fail(`minimum 3 user jobs required — found ${jobs}`);
+  if (jobs > 5)
+    return fail(`maximum 5 user jobs (doc says 3–5) — found ${jobs}`);
+  return pass();
+}
+
+function checkDesignRationale(md: string): CheckResult {
+  if (!headingPresent(md, DESIGN_RATIONALE_HEADING))
+    return fail('"## Design Rationale" heading not found');
+  const body = sectionBody(md, DESIGN_RATIONALE_HEADING);
+  if (!/^###\s+Interaction\s+of\s+Color\b/mi.test(body))
+    return fail('missing "### Interaction of Color" subsection under ## Design Rationale');
+  return pass();
+}
+
+function checkRulesOrContent(md: string): CheckResult {
+  if (!headingPresent(md, RULES_OR_CONTENT_HEADING))
+    return fail('"## Rules" or "## Content" heading not found');
   return pass();
 }
 
@@ -245,11 +349,54 @@ interface SectionDef {
 const FEAT_SECTIONS: SectionDef[] = [
   { key: "intent", label: "Intent", check: checkIntentStrict },
   { key: "decision_tree", label: "Decision Tree", check: checkDecisionTree },
-  { key: "draft_of_thoughts", label: "Draft-of-thoughts", check: checkDraftOfThoughts },
   { key: "final_spec", label: "Final Spec", check: checkFinalSpec },
-  { key: "game_theory", label: "Game Theory Review", check: checkGameTheory },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 3) },
+  { key: "game_theory", label: "Game Theory Cooperative Model review", check: checkGameTheory },
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
-  { key: "files_list", label: "Files list", check: checkFilesList },
+  { key: "files_list", label: "Files created / updated", check: checkFilesList },
+  { key: "models_applied", label: "Models Applied", check: checkModelsApplied },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+];
+
+const BUG_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentLoose },
+  { key: "repro", label: "Repro", check: checkRepro },
+  { key: "fix", label: "Fix", check: checkFix },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 2) },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
+  { key: "files", label: "Files", check: checkFiles },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+];
+
+const HOTFIX_SECTIONS: SectionDef[] = BUG_SECTIONS;
+
+const SPEC_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentStrict },
+  { key: "decision_tree", label: "Decision Tree", check: checkDecisionTree },
+  { key: "rules_or_content", label: "Rules or Content", check: checkRulesOrContent },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
+  { key: "files_schema", label: "Files / Schema", check: checkFilesOrSchema },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+];
+
+const CHORE_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentChore },
+  { key: "action", label: "Action", check: checkAction },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 1) },
+  { key: "files", label: "Files", check: checkFiles },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+];
+
+const REFACTOR_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentStrict },
+  { key: "decision_tree", label: "Decision Tree", check: checkDecisionTree },
+  { key: "final_spec", label: "Final Spec", check: checkFinalSpec },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 3) },
+  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
+  { key: "files_list", label: "Files created / updated", check: checkFilesList },
+  { key: "models_applied", label: "Models Applied", check: checkModelsApplied },
+  { key: "migration_plan", label: "Migration Plan", check: checkMigrationPlan },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
 ];
 
 const RESEARCH_SECTIONS: SectionDef[] = [
@@ -258,47 +405,75 @@ const RESEARCH_SECTIONS: SectionDef[] = [
   { key: "acceptance_criteria", label: "Acceptance Criteria", check: checkAcceptanceCriteriaResearch },
   { key: "report_format", label: "Report Format", check: checkReportFormat },
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
-  { key: "files_list", label: "Files list", check: checkFilesList },
+  { key: "files", label: "Files", check: checkFiles },
 ];
 
-const BUG_SECTIONS: SectionDef[] = [
-  { key: "intent", label: "Intent", check: checkIntentLoose },
-  { key: "reproduction_steps", label: "Reproduction Steps", check: checkReproSteps },
-  { key: "fix", label: "Fix", check: checkBugFixSection },
-  { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummaryBug },
-  { key: "files_list", label: "Files list", check: checkFilesList },
+const UX_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: checkIntentStrict },
+  { key: "jobs_to_be_done", label: "Jobs To Be Done", check: checkJobsToBeDone },
+  { key: "design_rationale", label: "Design Rationale", check: checkDesignRationale },
+  { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 2) },
+  { key: "assets_files", label: "Assets / Files", check: checkFilesOrSchema },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
 ];
 
-const CHORE_SECTIONS: SectionDef[] = [
-  { key: "intent", label: "Intent", check: checkIntentLoose },
-  { key: "files_list", label: "Files list", check: checkFilesList },
-];
+const BRAND_SECTIONS: SectionDef[] = UX_SECTIONS;
 
-const HOTFIX_SECTIONS: SectionDef[] = [
-  { key: "intent", label: "Intent", check: checkIntentLoose },
-  { key: "fix", label: "Fix", check: checkBugFixSection },
-  { key: "files_list", label: "Files list", check: checkFilesList },
-];
-
-const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {
+export const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {
   feat: FEAT_SECTIONS,
-  research: RESEARCH_SECTIONS,
   bug: BUG_SECTIONS,
-  chore: CHORE_SECTIONS,
   hotfix: HOTFIX_SECTIONS,
+  spec: SPEC_SECTIONS,
+  chore: CHORE_SECTIONS,
+  refactor: REFACTOR_SECTIONS,
+  research: RESEARCH_SECTIONS,
+  ux: UX_SECTIONS,
+  brand: BRAND_SECTIONS,
+};
+
+// Ordered canonical section keys per type. Exported for the drift-detection
+// test so it can compare against ZAI_SYSTEM_INSTRUCTIONS.md §Appendix.
+export const RUBRIC_SECTION_KEYS: Record<SpecType, string[]> = {
+  feat: FEAT_SECTIONS.map((s) => s.key),
+  bug: BUG_SECTIONS.map((s) => s.key),
+  hotfix: HOTFIX_SECTIONS.map((s) => s.key),
+  spec: SPEC_SECTIONS.map((s) => s.key),
+  chore: CHORE_SECTIONS.map((s) => s.key),
+  refactor: REFACTOR_SECTIONS.map((s) => s.key),
+  research: RESEARCH_SECTIONS.map((s) => s.key),
+  ux: UX_SECTIONS.map((s) => s.key),
+  brand: BRAND_SECTIONS.map((s) => s.key),
 };
 
 // ─── type detection ───────────────────────────────────────────────────────
 
-const KNOWN_TYPES: SpecType[] = ["feat", "research", "bug", "chore", "hotfix"];
+export const KNOWN_TYPES: readonly SpecType[] = [
+  "feat",
+  "bug",
+  "hotfix",
+  "spec",
+  "chore",
+  "refactor",
+  "research",
+  "ux",
+  "brand",
+];
 
 export function detectSpecType(filename: string): SpecType {
   const basename = filename.split(/[\\/]/).pop() || filename;
   const match = basename.match(/^\d{4}-\d{2}-\d{2}__(\w+)__/);
-  const raw = match?.[1]?.toLowerCase() ?? "feat";
+  if (!match) {
+    throw new SpecTypeError(
+      `(no type prefix in filename "${basename}")`,
+      KNOWN_TYPES,
+    );
+  }
+  const raw = match[1].toLowerCase();
   if (raw === "feature") return "feat";
-  if (raw === "refactor") return "chore";
-  return (KNOWN_TYPES as string[]).includes(raw) ? (raw as SpecType) : "feat";
+  if ((KNOWN_TYPES as readonly string[]).includes(raw)) {
+    return raw as SpecType;
+  }
+  throw new SpecTypeError(raw, KNOWN_TYPES);
 }
 
 // ─── gate extraction ──────────────────────────────────────────────────────
@@ -334,7 +509,7 @@ export function scoreSpec(markdown: string, filename: string = ""): ScoreResult 
 
   const required_count = defs.length;
   const passOrSkip = Object.values(sections).filter(
-    (s) => s === "PASS" || s === "SKIP"
+    (s) => s === "PASS" || s === "SKIP",
   ).length;
   const passed = Object.values(sections).every((s) => s !== "FAIL");
   const gates = extractGates(markdown);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,5 +17,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Closes #46.

## Summary

- Fixes the `refactor → chore` silent downgrade in `src/lib/scoreSpec.ts`. REFACTOR is now a first-class `SpecType` with its own 9-check rubric.
- Authors `docs/ZAI_SYSTEM_INSTRUCTIONS.md` v1.2 — previously lived only in project knowledge and hero copy; now the file exists and is the canonical source of truth.
- Aligns every rubric to v1.2 counts. Drift-detection test in CI catches future divergence.

## Scope (widened vs. original spec)

Original BUG spec scoped the fix narrowly to `scoreSpec.ts:231`. Author widened scope 2026-04-20 after it became clear the root cause was the missing canonical doc and that the same drift class affected every building-type rubric, not just REFACTOR. Single PR closes the class.

- **FEAT:** 7 → 9 checks (adds Acceptance Criteria, Models Applied, Legal triggers; removes `draft_of_thoughts` from required — it's optional per v1.2 §2)
- **BUG:** 5 → 7 checks (adds Acceptance Criteria, Legal triggers; renames `reproduction_steps` → `repro`, `files_list` → `files` per canonical section IDs)
- **HOTFIX:** aliased to BUG (7 checks)
- **CHORE:** 2 → 5 checks (adds Action, Acceptance Criteria, Legal triggers; Intent word limit tightened to ≤100)
- **SPEC:** NEW, 6 checks (`intent, decision_tree, rules_or_content, migration_summary, files_schema, legal_triggers`)
- **REFACTOR:** NEW, 9 checks (`intent, decision_tree, final_spec, acceptance_criteria, migration_summary, files_list, models_applied, migration_plan, legal_triggers`)
- **RESEARCH:** unchanged, 6 checks. Exempt from Legal triggers per v1.2 §2 (reports are non-building by definition).
- **UX / BRAND:** NEW, 6 checks each (`intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers`)

## Layers delivered (per spec §Fix)

**Layer 1 — Remove downgrade + add REFACTOR.** `detectSpecType()` no longer returns `"chore"` for `refactor`. A new `REFACTOR_SECTIONS` array + `refactor` entry in `SECTIONS_BY_TYPE` + `SpecType` union.

**Layer 2 — Strict unknown-type handling.** `SpecTypeError` class exported. `detectSpecType()` throws on both missing-prefix and unknown-prefix inputs (was: silent fallback to `"feat"`).

**Layer 3 — Drift-detection test.** `src/lib/scoreSpec.test.ts` reads `docs/ZAI_SYSTEM_INSTRUCTIONS.md` §Appendix, parses the rubric-count table, asserts every documented type has matching implementation count + ordered section IDs. Fails CI on divergence.

## Code-layout deviation

The original spec's §Fix pseudocode showed a `src/lib/rubrics/*.ts` modular layout (`refactor.ts`, `registry.ts`, etc.). The current codebase uses a single flat `scoreSpec.ts`. This PR preserves the flat structure. Modularization to per-rubric files is a **future REFACTOR, not this PR's scope** — it would touch many surface areas without behavior change and is better tracked separately.

## Acceptance Criteria (from spec)

- [x] `src/lib/scoreSpec.ts` no longer contains `if (raw === "refactor") return "chore";` or any equivalent downgrade
- [x] REFACTOR rubric exists with 9 checks matching v1.2 §2
- [x] Uploading a REFACTOR spec now returns `refactor` classification with per-check score (manual verify pending dev deploy)
- [x] Uploading an incomplete REFACTOR spec (missing Migration Plan) fails the `migration_plan` check (unit-tested)
- [x] Unknown spec types throw `SpecTypeError` (unit-tested)
- [x] Drift-detection test runs in CI and fails if any documented type lacks implementation with matching count (unit-tested — 6 assertions)
- [x] Existing FEAT / BUG / CHORE / RESEARCH / HOTFIX rubrics pass their updated test suites (no regression — test counts moved per v1.2, all passing)
- [x] Re-scoring the ZiLin brand migration spec will now produce `refactor 9/9` (or failure with named checks) rather than `chore 2/2` — **unblocks the brand migration REFACTOR**

## New acceptance criteria (added 2026-04-20)

- [x] RESEARCH documented in v1.2 at 6 checks, exempt from Legal triggers (explicit "non-building" carve-out in §2)
- [x] HOTFIX documented as a BUG alias at 7 checks

## Breaking changes

- Specs with unrecognized `spec_type` prefixes now throw `SpecTypeError` instead of silently scoring against the wrong rubric. Known impact: none internally; external integrations (if any existed) get a clear error instead of a bad pass.
- Historical REFACTOR specs scored as `chore` retain their `.scored.md` artifacts as-generated. Re-upload to receive v1.2 scoring. No retroactive re-scoring planned (per spec §Subject Migration Summary open question (2): default is re-score on next upload, no retro sweep).

## Follow-ups (out of scope for this PR)

- Hero copy sweep on validator landing — copy says "deterministic 7-section score" but rubric counts are now per-type variable (5–9). Covered under brand migration Phase 1.
- Full Models Applied structural cross-check (Pass B + Pass C from v1.2 §3). This PR's `checkModelsApplied` is Layer-1 minimum (heading present + at least one declaration). Full cross-check is a separate SPEC.
- Per-rubric modularization to `src/lib/rubrics/*.ts` (see "Code-layout deviation" above).

## Test + build

- 54 tests pass (up from 32). Coverage: all 9 types + 6 drift-test assertions.
- `npm test`: green.
- `npm run build` (`tsc -b && vite build`): green.
- `npm run lint`: eslint binary not installed in repo (pre-existing — present in scripts but missing from node_modules). Flagged; out of scope for this PR.

## Reviewer: daniel-silvers

Approval audit trail: this non-trivial `bug` spec was approved by ZiLin in the active Claude Code session 2026-04-20 per CLAUDE.md §Gate 1 solo-operator path. PR review at merge remains the enforceable governance gate.