### PR TITLE
refactor: ZiLin Brand Migration — Phase 1 (docs + rubric v1.3 + banner) · closes #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ Versioning follows [SemVer](https://semver.org/) — but note that the `RUBRIC_V
 
 ## [Unreleased]
 
+_(No unreleased changes.)_
+
+## [1.3.0] — 2026-04-20
+
+Part of the ZiLin Brand Family Migration REFACTOR Phase 1 (issue #48). Continues the `zi007lin/zai` → `zi007lin/zilin-spec` rename; the repo rename itself is a Phase 2 operator action, not in this release.
+
+### Added
+
+- **Enterprise disclosure footer** on `.scored.md` output when the spec's frontmatter carries any trigger bundle (`healthcare`, `fintech`, `financial_advisory`, `legal_services`, `government`). Canonical text sourced from `docs/brand/enterprise-disclosure.md`; drift-detection test asserts verbatim equality.
+- `src/lib/renderScoredSpec.ts` — output-layer renderer extracted from `AppPage.tsx`. Pure function; unit-testable. Hosts `extractBundles`, `matchTriggeredBundles`, `TRIGGER_BUNDLES`, `ENTERPRISE_DISCLOSURE_TEXT` exports.
+- `src/lib/renderScoredSpec.test.ts` — 24 new tests covering bundle extraction, trigger matching, and footer rendering behavior.
+- `src/components/MigrationBanner.tsx` — Phase 1 dual-run banner. Shown only on `zai.htu.io`. Dismissal persisted via `localStorage`.
+- `docs/brand/zilin-rename-rationale.md`, `zilin-family-namespace.md`, `enterprise-disclosure.md` — brand-family docs; decision trail; canonical disclosure text; reservation expiry rules.
+
+### Changed
+
+- `RUBRIC_VERSION` bumped `1.2.1` → `1.3.0`.
+- Hero copy on the validator landing page updated: "deterministic 7-section score" was inaccurate post-v1.2 (per-type counts now 5–9). New copy: "deterministic per-type rubric score (5–9 structural checks depending on spec type)".
+- `docs/ZAI_SYSTEM_INSTRUCTIONS.md` v1.3 — change-log entry describing the footer rendering behavior; version header bumped.
+
+### Not changed
+
+- Rubric counts or required section IDs. The drift-detection test from #46 still passes without modification.
+- `ScoreResult` shape — footer rendering lives in the output layer; scoring engine stays pure.
+
+## [1.2.1] — 2026-04-20
+
 ### Fixed
 
 - **REFACTOR spec type silently downgraded to CHORE** in `src/lib/scoreSpec.ts`. The `if (raw === "refactor") return "chore";` line caused REFACTOR specs to be scored against the 5-check CHORE rubric instead of the documented 9-check REFACTOR rubric. Any prior REFACTOR-type spec that scored as `chore` must be re-uploaded to receive the correct rubric. Fixes #46.
@@ -21,7 +48,7 @@ Versioning follows [SemVer](https://semver.org/) — but note that the `RUBRIC_V
 
 ### Changed
 
-- `RUBRIC_VERSION` bumped from `1.1.0` to `1.2.1`. v1.2 is the doc-aligned rubric surface; the `.1` patch reflects this fix-set.
+- `RUBRIC_VERSION` bumped from `1.1.0` to `1.2.1`. v1.2 is the doc-aligned rubric surface; the `.1` patch reflects the fix-set.
 
 ### Breaking changes
 
@@ -30,4 +57,4 @@ Versioning follows [SemVer](https://semver.org/) — but note that the `RUBRIC_V
 
 ---
 
-_This CHANGELOG is authored 2026-04-20 as part of the PR for issue #46. Prior versions of the rubric surface existed (v1.0, v1.1) but were not tracked here._
+_This CHANGELOG is authored 2026-04-20. Prior versions of the rubric surface existed (v1.0, v1.1) but were not tracked here._

--- a/docs/ZAI_SYSTEM_INSTRUCTIONS.md
+++ b/docs/ZAI_SYSTEM_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # ZAI SYSTEM INSTRUCTIONS
 
-**Version:** 1.2 (2026-04-19)
+**Version:** 1.3 (2026-04-20)
 **ZAI:** the structural validation service running at `zai.htu.io/app`
 **Purpose:** authoritative spec for what ZAI validates, how it scores, and how humans interact with it
 **Canonical location:** `docs/ZAI_SYSTEM_INSTRUCTIONS.md` in `zi007lin/zai`
@@ -423,6 +423,7 @@ OpenAPI at `zai.htu.io/openapi.json`.
 | 1.0 | 2026-04-19 | Initial. Rubrics for FEAT/BUG/SPEC/CHORE/RESEARCH/UX+BRAND. Model declaration + detection + cross-check. Scoring with models panel. Tiers: DIY / Copilot / Pro / Enterprise. |
 | 1.1 | 2026-04-19 | Tier "Copilot"→"Assist" (Microsoft trademark). BYOK + Cloudflare-free-default. Internal prompts explicitly non-public. 12-bundle industry catalog. Accessibility default. |
 | 1.2 | 2026-04-19 | Added `legal_trigger_declaration` check to every building-type rubric (RESEARCH exempt; reports are non-building). Added `contract_law_signals` bundle (structural only, mandatory disclaimer banner, jurisdiction-agnostic, explicitly not legal advice). Added future `legal_services` bundle slot for 2027+ partner firm use. Rubric counts: FEAT 8→9, BUG 6→7, SPEC 5→6, CHORE 4→5, REFACTOR introduced as first-class type at 9 checks (was previously silently folded into CHORE in implementation — see BUG 2026-04-19), RESEARCH unchanged at 6 (non-building), UX/BRAND 5→6. |
+| 1.3 | 2026-04-20 | Enterprise disclosure footer rendered on `.scored.md` output for specs carrying any trigger bundle (`healthcare`, `fintech`, `financial_advisory`, `legal_services`, `government`). Canonical text sourced from `docs/brand/enterprise-disclosure.md`; drift-detection test asserts verbatim equality. Rendering lives in the output layer (`src/lib/renderScoredSpec.ts`), not the scoring engine — `ScoreResult` shape unchanged. No rubric count changes. Part of the ZiLin Brand Migration REFACTOR Phase 1 (2026-04-19). |
 ```
 
 ---

--- a/docs/brand/enterprise-disclosure.md
+++ b/docs/brand/enterprise-disclosure.md
@@ -1,0 +1,75 @@
+# Enterprise Compliance — Dual-Control Disclosure
+
+**Status:** Authored 2026-04-19 · Promoted 2026-04-20 during Phase 1 impl
+**Authoritative spec:** `issues/2026-04-19__refactor__zilin-brand-migration.md`
+**Current location:** `zi007lin/zai/docs/brand/enterprise-disclosure.md` (moves with the Phase 2 repo rename to `zi007lin/zilin-spec`)
+**Referenced by:** ZiLin-Spec rubric v1.3 (mandatory footer on specs carrying triggered bundles — see `src/lib/scoreSpec.ts`)
+
+This document is a truth-in-advertising correction. Prior ZAI Enterprise bundle messaging implied principal-level segregation of duties. The dual-control in the HTU workflow is process-level (one human operating two identities), not principal-level (two independent humans). Enterprise clients with regulatory requirements under HIPAA, SOX, FINRA, or equivalent must not rely on the HTU workflow alone for the principal-level control. This document states that plainly.
+
+---
+
+## Disclosure text (canonical)
+
+The following text is the canonical disclosure. Rubric v1.3 injects this text (verbatim) as a footer on any scored spec carrying a bundle in the trigger list.
+
+> **Dual-control disclosure.** The dual-control segregation in this workflow is process-level (author/reviewer via separate identities for one human principal). Principal-level segregation of duties — two independent human operators — is not yet in place at HTU. Clients with principal-level segregation requirements under HIPAA §164.308, SOX §404, FINRA 3110, or equivalent must arrange for an independent second operator before relying on this control.
+
+## Trigger bundles
+
+The disclosure is mandatory on any spec whose frontmatter `bundles:` array contains one or more of:
+
+| Bundle | Domain |
+|---|---|
+| `healthcare` | HIPAA §164.308 administrative safeguards; PHI handling |
+| `fintech` | SOX §404; financial reporting controls |
+| `financial_advisory` | FINRA 3110 supervision; investment advice workflow |
+| `legal_services` | Model Rules; conflict-of-interest segregation |
+| `government` | FedRAMP / NIST 800-53 SC-7 separation of duties |
+
+A spec carrying any of the trigger bundles receives the footer, regardless of spec type (chore, feat, refactor, bug, research, hotfix).
+
+A spec carrying none of the trigger bundles does not receive the footer. The disclosure is not meant to be universal — it is specifically about bundles that invoke principal-level segregation requirements.
+
+## What the disclosure does and does not mean
+
+### What it means
+
+- HTU currently has **one human principal** operating under two identities (`zi007lin` authors, `daniel-silvers` reviews and merges).
+- This is **process-level segregation**: a single human operator cannot bypass the two-step workflow for their own commits without creating a visible audit record.
+- It is useful as an integrity control. A malicious or compromised author cannot single-step a change into production; the merge step requires the reviewer identity.
+
+### What it does not mean
+
+- It is **not** principal-level segregation. HIPAA §164.308(a)(3)(ii)(A), SOX §404 ICFR, FINRA 3110, and equivalent standards contemplate two *independent human operators*, not one human with two roles.
+- A client whose compliance regime requires the principal-level interpretation cannot rely on the HTU workflow alone to satisfy the control. They must arrange for a second, independent human operator — either by joining the HTU team as such or by reviewing changes through their own independent identity before the change enters their production scope.
+- The disclosure is not a warranty. It is a statement of fact about the current operational state of HTU. The state may change (e.g., if a second principal joins), in which case this document is updated in the same PR that establishes the new state.
+
+## Activation conditions for principal-level control
+
+This disclosure exits the mandatory footer when all of the following are true:
+
+1. A second human principal has joined HTU in the reviewer role.
+2. The second principal is operationally independent of the first (separate employment, separate access, no common beneficial ownership in a way that would defeat segregation).
+3. The change from process-level to principal-level is documented in a new spec that supersedes the relevant sections of this file.
+4. Rubric is bumped to a new version that removes the footer trigger for the relevant bundles.
+
+Until then, the footer is mandatory on all triggered bundles.
+
+## Relationship to Gate 1 solo-operator path
+
+CLAUDE.md Hard Rules describe a "solo-operator path" for Gate 1 (spec approval) where ZiLin acts as both author and reviewer. The solo-operator path is a **self-applied exception** to the team-scale approval hold — it is explicitly not a claim of principal-level segregation. The PR review at merge remains the enforceable dual-control gate, and that gate is process-level under the current operational state.
+
+The enterprise disclosure footer reflects this accurately: the "dual-control segregation" it describes is exactly the process-level control that remains in force during solo-operator sessions.
+
+## Rollback preservation
+
+This document survives any rollback of the ZiLin Brand Migration REFACTOR. The disclosure language is the truth-in-advertising correction regardless of what the service is named. If the rename is reversed, this file remains; only its filename or frontmatter product-name references are updated.
+
+## Document review
+
+| Reviewer | Role | Concern |
+|---|---|---|
+| Legal counsel (future) | Verify language does not over- or under-state the control | Pre-commercial-launch review |
+| Daniel Silvers (founder) | Approve disclosure as accurate characterization of HTU state | 2026-04-19 REFACTOR review |
+| Enterprise customer (future) | Confirm disclosure is clear enough to guide their compliance-officer review | First enterprise engagement |

--- a/docs/brand/zilin-family-namespace.md
+++ b/docs/brand/zilin-family-namespace.md
@@ -1,0 +1,110 @@
+# ZiLin-\* Family Namespace
+
+**Status:** Authored 2026-04-19 · Promoted 2026-04-20 during Phase 1 impl
+**Authoritative spec:** `issues/2026-04-19__refactor__zilin-brand-migration.md`
+**Current location:** `zi007lin/zai/docs/brand/zilin-family-namespace.md` (moves with the Phase 2 repo rename to `zi007lin/zilin-spec`)
+
+This document defines the ZiLin-\* product family: active members, reserved names, activation rules, and expiry policy.
+
+---
+
+## Prefix rule
+
+All AI-forward tooling and products under the founder's direct authorship use the `ZiLin-` prefix followed by a function-descriptive suffix. Suffix is capitalized and singular. Hyphen separator is required.
+
+**Form:** `ZiLin-<Function>` (capitalized suffix, PascalCase not required for single-word suffixes)
+
+**Examples:**
+- `ZiLin-Spec` ✓
+- `ZiLin-Scheduler` ✓
+- `ZiLin-Assistant` ✓ (reserved)
+- `ZiLin-Coach` ✓ (reserved)
+
+**Not valid:**
+- `ZiLinSpec` (no hyphen)
+- `zilin-spec` (lowercase form; reserved for technical slugs like hostnames, repo names, package IDs)
+- `ZILIN_SPEC` (ALL CAPS is reserved for env vars and symbol naming)
+
+**Casing variants (canonical by context):**
+
+| Context | Form | Example |
+|---|---|---|
+| Product name in prose / UI | `ZiLin-<Name>` | "ZiLin-Spec validates…" |
+| Domain, repo, package id | `zilin-<name>` | `zilin-spec.htu.io` · `zi007lin/zilin-spec` |
+| Env var, constant, symbol | `ZILIN_<NAME>_*` | `ZILIN_SPEC_TOKEN` |
+| Systemd unit, filesystem path | `zilin-<name>` | `zilin-scheduler.service` · `/etc/zilin-scheduler/` |
+
+## Active members
+
+| Name | Role | State | Notes |
+|---|---|---|---|
+| **ZiLin-Spec** | Spec validation service (scoring, rubric, audit trail) | Brownfield migration from ZAI | Phased cutover per REFACTOR Phase 0–3 |
+| **ZiLin-Scheduler** | Scheduling / cron / publish-audit service | Greenfield — build under new name | No prior ZaiVM deployment; clean slate |
+
+## Reserved names
+
+Reserved names are documented here but have no implementations, repos, or domains yet. Reservation is **internal precedence only** — it does not create public trademark rights. Rights accrue on use.
+
+| Name | Intended role | Reserved on | Expires | Activation requirement |
+|---|---|---|---|---|
+| **ZiLin-Assistant** | Future user-facing AI layer across medicshare, shoplement, StreetTT admin surfaces | 2026-04-19 | 2028-04-19 | New SPEC citing this REFACTOR for name provenance |
+| **ZiLin-Coach** | Future consumer helper (coaching, skill progression, practice plans) | 2026-04-19 | 2028-04-19 | New SPEC citing this REFACTOR for name provenance |
+
+### Expiry rule — 24 months
+
+If a reserved name is **not activated** (no spec written, no repo created, no public announcement) within 24 months of its reservation date, the reservation lapses. The name returns to the common pool and can be reassigned to a different function without carrying the reservation's provenance claim.
+
+**Rationale:** prevents internal squatting on names we end up not building. 24 months matches a practical product-strategy horizon — anything we haven't committed to building in that window was probably never going to ship.
+
+**Renewal:** a reserved name can be renewed for another 24 months before it lapses, via a one-line edit in this document with a renewal date. Reservations can be renewed at most once; after that they must either activate or return to the pool.
+
+### Activation requirement
+
+Activating a reserved name requires:
+
+1. A new SPEC file (not this REFACTOR) naming the product and its role.
+2. An explicit citation line in that spec: `Name provenance: reserved in docs/brand/zilin-family-namespace.md on 2026-04-19.`
+3. Corresponding repo, domain, or service record under the canonical casing rules above.
+
+Activation updates this file: the row moves from "Reserved names" to "Active members" with the activation date replacing the reservation date.
+
+## Rejected names (for the record)
+
+Decision Tree captured these alternatives as rejected during the 2026-04-19 REFACTOR:
+
+| Rejected | Reason |
+|---|---|
+| `ZiLin-Copilot` | Collision with GitHub Copilot |
+| `ZiLin-AIstant` | Typo-fragile; "AI" infix is awkward |
+| `ZiLin-Helper`, `ZiLin-Buddy` | Generic; weak brand signal |
+| `ZiLinVM` | Misleading "VM" framing for what is actually a scheduler/publisher |
+| `ZiLin-Cron` | Too infrastructure-y for what is intended as a product brand |
+| `ZiSpec` | Viable, but loses the family benefit. Retained as fallback if `ZiLin-Spec` hits a TM conflict. |
+| `ZiLin-Reviewer` | Implies human-review semantics the validator does not provide |
+
+## Not family members
+
+These brands exist under HTU but are **not** part of the ZiLin-\* family. They have independent brand equity and are explicitly out of scope for the REFACTOR:
+
+- **StreetTT** (HTU product with its own brand; paddle mark, streettt.com)
+- **HTU / htu.io** (parent org)
+- **zzv.io** (chain/audit brand)
+- **HTTC** (separate legal entity; DYCD Beacon Agreement #99358B)
+- **medicshare**, **shoplement**, **NYQEX** (sibling HTU products)
+
+Future sibling products are only ZiLin-\* family members if they are direct founder-authored AI tooling. HTU-wide consumer products remain under their own brands even if they integrate ZiLin-\* components internally.
+
+## Logo and visual identity
+
+Umbrella mark: the **Kitsune fox** direction becomes the ZiLin brand mark. Sub-products use typographic lockups until the Fiverr vector commission returns.
+
+StreetTT keeps its paddle mark. It is not being re-skinned under ZiLin.
+
+Visual identity details are out of scope for this namespace doc.
+
+## Governance of this document
+
+- New members, reservations, and renewals are added by PR.
+- Expiry decisions can be applied in a one-line edit with a date.
+- Fallback name activation (e.g. promoting `ZiSpec` if `ZiLin-Spec` hits a conflict) requires a new SPEC and updates both this file and `zilin-rename-rationale.md`.
+- Historical rows (rejected names, lapsed reservations) are preserved, not deleted. The record of what was considered is part of the archival value.

--- a/docs/brand/zilin-rename-rationale.md
+++ b/docs/brand/zilin-rename-rationale.md
@@ -1,0 +1,101 @@
+# ZiLin Brand Rename — Rationale and Decision Trail
+
+**Status:** Authored 2026-04-19 · Promoted 2026-04-20 during Phase 1 impl
+**Authoritative spec:** `issues/2026-04-19__refactor__zilin-brand-migration.md`
+**Current location:** `zi007lin/zai/docs/brand/zilin-rename-rationale.md` (moves with the Phase 2 repo rename to `zi007lin/zilin-spec`)
+
+This document is preserved across rollbacks. It captures *why* the decision was made at this date, which has archival value regardless of whether the migration is completed, paused, or reversed.
+
+---
+
+## Trigger
+
+- **Z.ai (Zhipu AI) HK IPO.** January 8, 2026. Public listing accelerates trademark activity in AI and software classes (Nice Classes 9 and 42).
+- **Active TM filings by Z.ai.** Ongoing applications in the same classes we operate in.
+- **Near-certain collision.** Continued use of "ZAI" as a product brand places any future commercial launch directly in the path of a well-funded TM holder. Cost floor of collision rises with every shipped feature under the old name.
+
+Decision point: **rename now, while the surface area is small**, or **keep and absorb future cease-and-desist exposure**.
+
+**Chosen:** rename now.
+
+## Rejected: keep "ZAI"
+
+| Consideration | Detail |
+|---|---|
+| Short name, good recognition | True, but indistinguishable from Z.ai at search/trademark level |
+| Already in use internally | ~4 weeks of active use; minimal equity accumulated |
+| Cost of rename grows with adoption | Yes — and adoption is low enough today that the rename window is open. In 6 months it won't be. |
+
+The "ZAI" brand had roughly one month of lifetime at the point of this decision. No paying customers, no external integrations, no SEO footprint worth preserving. The asymmetry is clear: rename now has a known, bounded cost; keep-and-defend has an uncapped liability.
+
+## Chosen name: ZiLin-\*
+
+**ZiLin** is the founder's 30+ year nickname, given by Igor Mospan circa 1996 (founder was 11). Continuous public and private use since then establishes common-law foundation.
+
+### Why "ZiLin" (not a new invented name)
+
+- **Common-law TM foundation.** 30 years of continuous use predates any modern AI-era TM filings. Priority is defensible on the record.
+- **No known tech collisions.** Informal searches of USPTO, trade press, GitHub, and domain registries surface no conflicting product brands.
+- **Personal, durable, non-generic.** Not a compound of industry jargon. Distinctive enough to be protectable; not so obscure that it resists adoption.
+- **Already in use on `zilinlu.com`** — personal site, operating under the name since well before any AI branding.
+
+### Why a prefix family (not a flat brand)
+
+Decision Tree (from spec):
+
+| Option | Verdict |
+|---|---|
+| Single flat brand — everything is "ZiLin" | Rejected. Ambiguous when describing multiple products. |
+| ZiLin-\* prefix family | **Chosen.** Clear per-product naming; shared brand. |
+
+Family members at this refactor:
+
+- **ZiLin-Spec** — formerly ZAI (validator service, `zai.htu.io` → `zilin-spec.htu.io`)
+- **ZiLin-Scheduler** — formerly ZaiVM (scheduler product; greenfield — build under new name from day one)
+- **ZiLin-Assistant** — reserved; future user-facing AI layer
+- **ZiLin-Coach** — reserved; future consumer helper
+
+Family structure is documented in `zilin-family-namespace.md`.
+
+### Fallback: ZiSpec
+
+If a direct TM conflict surfaces on "ZiLin-Spec" specifically, fall back to **ZiSpec** for the validator piece only. Other family members are unaffected. ZiSpec was the parked prior plan before the family-prefix decision and remains a viable one-off name.
+
+## Decision table (reproduced from spec)
+
+| Question | Options | Chosen | Why |
+|---|---|---|---|
+| Keep "ZAI" brand | keep / rename | rename | TM collision compounds with time |
+| Scope | treat everything as migration / split greenfield vs brownfield | split | Most items are pre-impl; phasing them wastes effort |
+| Family structure | flat / prefix family | prefix family | Clear per-product naming |
+| Validator name | ZiSpec / ZiLin-Spec / ZiLin-Reviewer | ZiLin-Spec | Unifies under family; ZiSpec is fallback |
+| Scheduler name | ZiLinVM / ZiLin-Scheduler / ZiLin-Cron | ZiLin-Scheduler | Semantically accurate; no misleading VM framing |
+| Reserved future names | Assistant / Copilot / AIstant / Coach / Helper / Buddy | Assistant + Coach | Standard spellings; no Copilot conflict |
+| Cutover for brownfield | big-bang / phased dual-run / lazy | phased dual-run | Live service needs safety net |
+| Enterprise disclosure update | defer / fold into this refactor | fold in | Truth-in-advertising fix can't wait |
+| Historical references | erase / preserve | preserve | Decision trail has archival value |
+
+## Triggers to revisit
+
+- TM opposition filed against ZiLin, ZiLin-Spec, or ZiLin-Scheduler → escalate; fall back to ZiSpec for the conflicted piece.
+- Adoption failure (old URL > 50% of validator traffic at day 35) → extend Phase 1, re-evaluate messaging.
+- Technical breakage in Claude Code / `impl` pipeline → pause, repair, then resume.
+- A later-discovered ZiLin-\* conflict on a specific name → rename that piece only; others unaffected.
+
+## Clearance plan
+
+**Pre-commercial-launch clearance.** Before any paid/commercial launch of ZiLin-Spec or ZiLin-Scheduler, run a paid USPTO clearance search (approximate cost: USD 500–1,500) in Nice Classes 9 and 42. Phase 1 budget item.
+
+**Common-law fortification.** Optional but advised: obtain a notarized declaration from Igor Mospan documenting the naming event in 1996. Useful if priority is ever contested in a TM opposition proceeding.
+
+## What is NOT renamed
+
+- **StreetTT** — HTU product with independent brand equity. Not a ZiLin-\* family member. Unaffected.
+- **HTU, htu.io** — parent brand. Unaffected.
+- **zzv.io** — chain/audit brand. Unaffected.
+- **HTTC** — separate legal entity operating under DYCD Beacon Agreement #99358B. Unaffected.
+- **medicshare, shoplement, NYQEX** — sibling products under HTU. Unaffected.
+
+## Rollback preservation
+
+This document survives any rollback. If the migration reverses, this file is edited (not deleted) to add a "Rollback" section documenting the reversal trigger and date. The archival record of why the decision was considered is preserved regardless of outcome.

--- a/issues/2026-04-19__refactor__zilin-brand-migration.md
+++ b/issues/2026-04-19__refactor__zilin-brand-migration.md
@@ -1,0 +1,324 @@
+---
+spec_type: refactor
+rubric_version: 1.2
+bundles: []
+github_issue: 48
+---
+
+# refactor: ZiLin Brand Family Migration
+
+**Spec type:** REFACTOR
+**Target:** Narrow runtime migration of ZAI validator + repo + docs; design-time rename for everything else
+**Environment policy:** Runtime parts phased (dev → demo → prod, manual promotion); design-time parts applied at next impl of each spec
+**Author:** zi007lin
+**Approver:** daniel-silvers
+**Date:** 2026-04-19
+**Depends on:** PR #47 (BUG fix) merged to main and deployed to prod — verified 2026-04-20 at zai.htu.io/app running rubric v1.2.1
+
+---
+
+## Intent
+
+Migrate all product naming from "ZAI" and "ZaiVM" to a unified ZiLin-\* brand family. Trigger: Z.ai (Zhipu AI) HK IPO on January 8, 2026 and ongoing TM filings in AI/software classes make continued "ZAI" use near-certain infringement exposure. ZiLin is a 30+ year founder nickname with common-law foundation and no tech collisions. Most items requiring a rename are pre-impl drafts (design-time rename only, no phasing needed). Only four items are genuinely brownfield runtime migrations requiring phased cutover. Treat those with care; apply the rest by fiat and move on. This is the first REFACTOR spec scored against the newly fixed v1.2.1 validator rubric (9 checks).
+
+## Decision Tree
+
+| Question | Options | Chosen | Why |
+|---|---|---|---|
+| Keep "ZAI" brand | keep / rename | **rename** | Z.ai TM collision compounds over time; cost floor rises with every shipped feature |
+| Scope of migration | treat everything as migration / split greenfield vs brownfield | **split** | Most items are pre-impl; phasing them is theater and wastes effort |
+| Family structure | single flat brand / ZiLin-\* prefix family | **prefix family** | Clear per-product naming + shared brand |
+| Validator name | ZiSpec / ZiLin-Spec / ZiLin-Reviewer | **ZiLin-Spec** | Unifies prior parked ZiSpec plan under the family; ZiSpec is the fallback if conflict surfaces |
+| Scheduler name | ZiLinVM / ZiLin-Scheduler / ZiLin-Cron | **ZiLin-Scheduler** | Semantically accurate; no misleading VM framing |
+| Reserved future names | Assistant / Copilot / AIstant / Coach / Helper / Buddy | **Assistant + Coach** | Standard spellings, no typo-fragility, no Copilot conflict |
+| Cutover strategy for brownfield | big-bang / phased dual-run / lazy | **phased dual-run** | Live service; need safety net |
+| Phase 2 reversibility | assume revertible / treat as one-way | **treat as one-way** | GitHub rename + 301 combination has no native revert; confirmed via GitHub community docs |
+| Enterprise disclosure update | defer / fold into this refactor | **fold in** | Truth-in-advertising fix can't wait behind the rename |
+| Historical references | erase / preserve | **preserve as history** | Brand docs retain the decision trail |
+
+### Trigger for change
+
+- TM opposition filed against ZiLin, ZiLin-Spec, or ZiLin-Scheduler → escalate; fall back to ZiSpec for the conflicted piece
+- Adoption failure (old URL > 50% of validator traffic at day 35) → extend Phase 1 by 30 days before pushing to Phase 2
+- Technical breakage in Claude Code / `impl i` pipeline → pause, repair, then resume
+- A later-discovered ZiLin-\* conflict on a specific name → rename that piece only (others unaffected)
+- Pre-Phase-2 verification (see Migration Plan) fails any check → extend Phase 1, do not cut over
+
+## Final Spec
+
+### Implementation state (authoritative inventory)
+
+Every naming change is either **greenfield** (design-only, no phasing) or **brownfield** (live, phased cutover). Scoping errors here inflate the refactor unnecessarily. See Phase 0 artifacts in `~/dev/streettt-private/drafts/2026-04-19__refactor__zilin-brand-migration/` for pre-staged work.
+
+#### Greenfield — zero migration cost, just adopt new names
+
+| Item | State | Action |
+|---|---|---|
+| `ZaiVM` → `ZiLin-Scheduler` (the scheduler product) | Draft spec only; no systemd unit deployed; no Contabo user created; no code written | Draft already renamed (completed 2026-04-19). Build with new name at first impl. |
+| `zaivm_publish_audit` D1 table → `zilin_scheduler_publish_audit` | No table exists in any D1 | Create with new name at first migration. No data migration. |
+| `zaivm:*` KV keys → `zilin-scheduler:*` | No keys written | Use new prefix at first write. |
+| `/api/zaivm/*` endpoints → `/api/zilin-scheduler/*` | No handlers implemented | Implement with new paths. |
+| `/etc/zaivm/env` → `/etc/zilin-scheduler/env` | File doesn't exist on Contabo | Create with new path at install. |
+| `zaivm.service` systemd unit → `zilin-scheduler.service` | Not installed | Install with new name. |
+| `ZAIVM_*` env vars → `ZILIN_SCHEDULER_*` | Not configured anywhere | Configure with new names. |
+| `docs/zaivm/` → `docs/zilin-scheduler/` | Directory doesn't exist | Create with new name. |
+| `zi007lin/zilin-scheduler` repo | Doesn't exist | Create directly with final name. No rename needed. |
+| Feature: table weather playability | Draft spec only, no code | Build under ZiLin ecosystem branding from day one. |
+| Feature: front-page weather tweet | Draft spec only, no code | Build with ZiLin-Scheduler as publisher from day one. |
+| Reserved names: `ZiLin-Assistant`, `ZiLin-Coach` | No implementations, no repos, no domains | Documentary reservation only in `docs/brand/zilin-family-namespace.md`. |
+| Three in-flight spec drafts referencing old names | Drafts on disk | Already find-replaced to new names (2026-04-19 as REFACTOR prep). No further action. |
+
+#### Brownfield — real migration work, phased cutover required
+
+| Item | State | Phased action |
+|---|---|---|
+| ZAI validation service at `zai.htu.io/app` | **Running at rubric v1.2.1 as of 2026-04-20** (PR #47 deployed) | Dual-run → 301 cutover → retire old domain. See Migration Plan. |
+| `zi007lin/zai` GitHub repo | Exists with commits, issues, CLAUDE.md, docs | Rename to `zi007lin/zilin-spec` via GitHub's native rename (auto-redirect). Structurally one-way — see Rollback. |
+| `ZAI_SYSTEM_INSTRUCTIONS.md` | Active authoritative doc, authored as part of PR #47 | Rename + content update to `ZILIN_SPEC_SYSTEM_INSTRUCTIONS.md`. |
+| Marketing copy on `htu.io`, `zzv.io`, validator hero text ("7-section score") | Live public pages with ZAI references | Grep-first, then coordinated update. Hero copy sweep confirmed as Phase 1 work. |
+
+Nothing else is running. **v1.44.0 StreetTT, htu.io, zzv.io, medicshare, shoplement, NYQEX all continue as-is** — none of them are being renamed by this REFACTOR. They're unaffected.
+
+### Authoritative naming table
+
+| Old (if exists) | New | Category |
+|---|---|---|
+| ZAI | ZiLin-Spec | **Brownfield** service brand |
+| zai.htu.io | zilin-spec.htu.io | **Brownfield** domain |
+| zi007lin/zai | zi007lin/zilin-spec | **Brownfield** repo |
+| ZAI_SYSTEM_INSTRUCTIONS.md | ZILIN_SPEC_SYSTEM_INSTRUCTIONS.md | **Brownfield** doc |
+| ZaiVM (draft) | ZiLin-Scheduler | Greenfield |
+| All ZaiVM-\* derived names | All ZiLin-Scheduler-\* derived names | Greenfield |
+| ZAI Enterprise bundles | ZiLin-Spec Enterprise bundles (with dual-control disclosure footer) | Brownfield content update |
+
+### Reserved names (greenfield, documentary)
+
+- **ZiLin-Assistant** — future user-facing AI layer across medicshare, shoplement, StreetTT admin surfaces
+- **ZiLin-Coach** — future consumer helper
+
+Activation of either requires a new SPEC citing this REFACTOR for name provenance. Reservation expires if unused for 24 months (prevents internal squatting).
+
+### Enterprise compliance disclosure
+
+The dual-control pattern (zi007lin as author, daniel-silvers as approver) is process-level — one human principal using two GitHub identities for workflow discipline. It is not principal-level segregation of duties. Enterprise bundles with regulatory SoD requirements attach this mandatory footer (stored in `docs/brand/enterprise-disclosure.md`, referenced by ZiLin-Spec rubric):
+
+> **Dual-control disclosure.** The dual-control segregation in this workflow is process-level (author/reviewer via separate identities for one human principal). Principal-level segregation of duties — two independent human operators — is not yet in place at HTU. Clients with principal-level segregation requirements under HIPAA §164.308, SOX §404, FINRA 3110, or equivalent must arrange for an independent second operator before relying on this control.
+
+### Logo / wordmark
+
+Kitsune fox direction becomes the **ZiLin umbrella mark**. Sub-products use typographic lockups until the Fiverr vector commission returns (~$150–250, parked previously). StreetTT mark (paddle variant) stays as-is — StreetTT is an HTU product with its own brand equity, not a ZiLin-\* family member.
+
+## Acceptance Criteria
+
+Brownfield (phased; verifiable):
+
+- [ ] `zilin-spec.htu.io` serves the full validator, byte-identical to `zai.htu.io` during Phase 1
+- [ ] `zai.htu.io` displays the migration banner during Phase 1 (banner HTML pre-drafted in Phase 0)
+- [ ] `zai.htu.io` returns HTTP 301 to `zilin-spec.htu.io` from Phase 2 onward
+- [ ] `zi007lin/zai` renamed to `zi007lin/zilin-spec` with GitHub auto-redirect verified (clone old URL → resolves to new)
+- [ ] `ZAI_SYSTEM_INSTRUCTIONS.md` renamed + any content updates for new brand
+- [ ] `docs/brand/zilin-rename-rationale.md`, `docs/brand/zilin-family-namespace.md`, `docs/brand/enterprise-disclosure.md` exist (Phase 0 staging promoted to final locations)
+- [ ] Validator hero copy ("7-section score") updated to accurate language given per-type varying rubric counts (currently mismatched after v1.2 fix)
+- [ ] Grep of htu.io and zzv.io public content returns zero live "ZAI" references by end of Phase 3 (historical references in `docs/brand/` and `CHANGELOG.md` exempt)
+- [ ] Claude Code and `impl i` continue working unchanged throughout all phases
+- [ ] Phase 1 extensibility: 30-day extension applied if any TM opposition signal, adoption < 50% at day 35, confidence gap, or pre-Phase-2 verification failure
+- [ ] Pre-Phase-2 verification checklist executed (see Migration Plan) — all 5 items PASS before cutover
+
+Greenfield (verified by "built correctly from the start"):
+
+- [ ] At first impl of ZiLin-Scheduler: all new names used (repo, paths, env vars, tables, KV prefix, systemd unit)
+- [ ] Reserved names documented with reservation date and 24-month expiry in `docs/brand/zilin-family-namespace.md`
+
+Not applicable (no running code to migrate):
+
+- ~~D1 table migration for zaivm_\* → zilin_scheduler_\*~~ (tables don't exist)
+- ~~KV key migration~~ (keys don't exist)
+- ~~systemd unit dual-accept~~ (unit not installed)
+- ~~Env var dual-accept window~~ (env vars not configured)
+
+## Subject Migration Summary
+
+| Subject | State | From | To | Notes |
+|---|---|---|---|---|
+| Validator service | Brownfield | ZAI | ZiLin-Spec | Phased domain + repo + docs |
+| Validator rubric version | Brownfield | v1.2.1 (current) | v1.3 (post-rename, with Enterprise disclosure) | Bump at Phase 1 |
+| Scheduler service | **Greenfield** | (spec only) ZaiVM | (build as) ZiLin-Scheduler | No migration; use new name at impl |
+| Table weather playability | **Greenfield** | (spec only) | (spec only) | Brand-neutral, unchanged |
+| Front-page tweet | **Greenfield** | (spec only, referenced ZaiVM) | (spec only, references ZiLin-Scheduler) | Draft updated 2026-04-19 |
+| Reserved names | Documentary | — | ZiLin-Assistant, ZiLin-Coach | Paper-only reservation |
+| Enterprise compliance copy | Brownfield | Implied principal-level | Explicit process-level disclosure | Truth-in-advertising correction |
+| Public marketing copy | Brownfield (low surface) | ZAI mentions + "7-section score" hero | ZiLin-Spec mentions + accurate hero language | Grep + update during Phase 1 |
+| Validator hero text | Brownfield | "deterministic 7-section score" | Something accurate given per-type counts | Surfaced as follow-up during BUG fix review |
+| Memory (Claude's) | Administrative | ZAI/ZaiVM treated as primary | ZiLin-\* family primary, old names historical | Updated 2026-04-19 |
+| Claude Code integration | Unaffected | — | — | Paths are user-namespaced, unchanged |
+| v2 milestone work | Unaffected | — | — | Runs in parallel; not blocked by this REFACTOR |
+| GitHub rename reversibility | Brownfield | Assumed revertible | Treated as one-way structurally | Confirmed via GitHub community docs 2026-04-20 |
+| Open questions | — | — | — | (1) ZiSpec fallback triggered if ZiLin-Spec conflict surfaces — accepted. (2) zzv.io stays as the chain/audit brand, not renamed. (3) Commands `impl` / `implw` unchanged. (4) ZiLin-Assistant activation deferred post-v2. (5) StreetTT is not a ZiLin-\* family member; unaffected by this REFACTOR. (6) GitHub Pages site check pre-Phase-2 — verify `zi007lin/zai` does not host Pages; added to pre-cutover verification. |
+
+## Files created / updated
+
+```
+Brownfield (actual file changes):
+  zi007lin/zilin-spec/                         (renamed from zi007lin/zai at Phase 2)
+    README.md                                  (MOD: new brand name, changelog entry)
+    docs/
+      ZILIN_SPEC_SYSTEM_INSTRUCTIONS.md        (RENAMED from ZAI_SYSTEM_INSTRUCTIONS.md; text updated)
+      CHANGELOG.md                             (MOD: v1.3 entry for rename + Enterprise disclosure rubric bump)
+      brand/
+        zilin-rename-rationale.md              (NEW: Z.ai collision + decision trail — Phase 0 drafted)
+        zilin-family-namespace.md              (NEW: reserved names + 24mo expiry — Phase 0 drafted)
+        enterprise-disclosure.md               (NEW: dual-control language — Phase 0 drafted)
+    src/                                       (MOD: ZAI_* → ZILIN_SPEC_* symbol swap)
+    wrangler.toml                              (MOD: env var names; binding names; project-name if needed)
+    package.json                               (MOD: name field; deploy script project-name flag)
+
+  htu.io/                                      (MOD if grep finds ZAI refs)
+    src/pages/products/zilin-spec.tsx          (NEW or MOD)
+    src/pages/About.tsx                        (MOD if needed)
+
+  Validator hero text                          (MOD: replace "deterministic 7-section score" — location TBD Phase 1)
+
+CF DNS:
+  Add zilin-spec.htu.io CNAME (Phase 0)
+  Add zai.htu.io 301 redirect (Phase 2)
+
+Greenfield (new code born with new names, no "migration"):
+  zi007lin/zilin-scheduler/                    (NEW repo, created under final name)
+
+Already completed (REFACTOR prep, no further work needed):
+  2026-04-19__spec__zilin-scheduler-v1.md      (renamed from zaivm version)
+  2026-04-19__feat__front-page-weather-tweet-v1.md  (in-place updates)
+  2026-04-19__feat__table-weather-playability-v1.md (unchanged; no ZaiVM refs)
+  userMemories entries #20, #22, #30           (updated 2026-04-19)
+  Phase 0 artifacts in ~/dev/streettt-private/drafts/2026-04-19__refactor__zilin-brand-migration/
+    - README.md, brand/*, rubric-v1.3-draft.md, migration-banner.html, tabletop-rollback.md, PR-PREP.md
+```
+
+## Models Applied
+
+- **#2 Decision Tree** — explicit options/chosen/why table with Trigger for change covering 10 decisions
+- **#8 Swiss Cheese (defense in depth)** — layered safeguards *only where they apply*: phased cutover, dual-run window, pre-Phase-2 verification checklist, explicit rollback criteria, 301 preservation, historical reference preservation. Not applied to greenfield items (layering defenses over paper is waste).
+- **#11 Progressive Disclosure** — brownfield migration reveals in phases with measurable gates (Phase 0 prep → Phase 1 dual-run → Phase 2 cutover → Phase 3 retire); greenfield items skip phasing entirely because there's nothing to disclose progressively
+- **#13 OODA Loop** — rollback criteria map Observation (adoption metrics, TM signals, breakage, pre-cutover checks) → Orientation (phase review) → Decision (continue / extend Phase 1 / rollback) → Action (procedure per phase)
+- **#15 Inversion / Premortem** — central application: inversion asked "what would make this rename fail or waste effort?" and the answer was *treating greenfield items as if they were brownfield*. This REFACTOR's structure is the direct output of that inversion. Second inversion: "what makes Phase 2 irreversible?" — yielded the GitHub rename one-way gate analysis, added to rollback section
+
+## Migration Plan
+
+### Design-time renames (greenfield) — instant, no phasing
+
+No plan needed. Every spec in the `issues/` directory that references old names was find-replaced on 2026-04-19 during REFACTOR prep. New specs are drafted under new names from day one. No further action until first impl of the affected specs.
+
+### Runtime migration (brownfield) — phased
+
+**Phase 0 — Prep (Days 0–7):**
+1. Merge this REFACTOR spec after dual-control review
+2. Create `zi007lin/zilin-spec` placeholder repo (absorbs rename in Phase 2)
+3. Create `zi007lin/zilin-scheduler` placeholder repo (greenfield, just exists)
+4. CF DNS: add `zilin-spec.htu.io` CNAME to same CF Pages project as `zai.htu.io`
+5. Deploy migration banner to `zai.htu.io` (HTML pre-drafted in Phase 0 staging)
+6. Publish rubric v1.3 with Enterprise disclosure footer (draft pre-authored)
+7. Tabletop rollback walkthrough (simulated, not executed) — completed in Phase 0 staging
+
+**Phase 1 — Dual-run (Days 8–37, 30 days):**
+8. Both domains live; banner on old
+9. Rubric v1.3 published; new scored specs carry the Enterprise disclosure
+10. Documentation + public marketing copy updated to new names
+11. Validator hero text updated to accurate language
+12. Weekly: measure traffic split; health check both domains
+13. Decision gate at day 35: advance to Phase 2 only if adoption ≥ 50% and no TM opposition signals; otherwise extend Phase 1 by 30 days
+
+**Pre-Phase-2 verification checklist (all 5 must PASS):**
+1. `gh api repos/zi007lin/zai/pages` returns 404 — confirms no GitHub Pages site (Pages URLs are not auto-redirected by GitHub rename)
+2. Traffic split: `zilin-spec.htu.io` ≥ 50% of validator requests over trailing 7 days
+3. No active TM opposition filings against ZiLin, ZiLin-Spec, or ZiLin-Scheduler
+4. Claude Code `impl i` pipeline verified working against new domain
+5. Banner displayed and dismissable; no user complaints
+
+**Phase 2 — Cutover (Day 38):** ⚠ Structurally one-way; plan for no-rollback
+14. `zai.htu.io` → HTTP 301 to `zilin-spec.htu.io` via CF Pages custom domain routing
+15. `zi007lin/zai` renamed on GitHub → `zi007lin/zilin-spec` (≥ 7 days notice posted beforehand)
+16. Banner removed from the now-redirecting old domain
+17. **Post-cutover NEVER create a new repo named `zi007lin/zai`** — doing so permanently breaks the auto-redirect
+
+**Phase 3 — Retire (Days 39–98, +60 days):**
+18. Final documentation sweep; any last ZAI mentions in non-brand docs removed
+19. Close REFACTOR issue; brand migration complete
+
+### Rollback
+
+**Rollback triggers:** TM opposition filed; Phase 1 adoption below 50% at day 35; unrepairable technical breakage; discovery of a later conflict on a specific ZiLin-\* name; pre-Phase-2 verification checklist failure.
+
+**Phase 0 rollback** (near-zero cost): delete placeholder repos, remove DNS CNAME, revert memory edits, discard Phase 0 artifacts in drafts/.
+
+**Phase 1 rollback** (low cost): remove `zilin-spec.htu.io` CNAME, revert docs PR, revert rubric v1.3, traffic returns to `zai.htu.io`. No data impact (no data was migrated). All staged Phase 0 artifacts preserved for potential re-launch.
+
+**Phase 2 rollback — structurally degraded; treat as no-rollback:**
+
+Per GitHub docs and community confirmation: repo rename redirects persist indefinitely but break permanently the moment a repo with the old name is created at the old location. There is no native revert after Phase 2. "Rollback" means one of:
+
+- **Option A (accepted):** accept `zi007lin/zilin-spec` as permanent canonical and do not attempt to restore old-name access. Cost: zero; externally-linked content unaffected.
+- **Option B (high cost):** forward-rename `zi007lin/zilin-spec` to a third recovery name (e.g. `zi007lin/zilin-spec-v2`). Every external reference written during dual-run must be manually updated or will 404. Cost: 3–7 days of sweep work scaling with link count.
+
+Creating a new `zi007lin/zai` repo to "restore" the old name is a **sabotage action** — it permanently breaks the auto-redirect for all links ever written. Never do this under any rollback scenario.
+
+**Practical implication:** Phase 2 is effectively a one-way gate. Extend Phase 1 aggressively if any rollback signal surfaces; Phase 1 is fully reversible. Do not push into Phase 2 on a wing and a prayer.
+
+**Phase 3 rollback** (high cost, survivable — but note Phase 2 damage is already done): re-enable old marketing copy, restore old doc names, communicate reversal to any Enterprise clients who onboarded under the new brand. No data corruption possible (the REFACTOR never touched runtime data). Rename path follows Phase 2 Option A or B above.
+
+**Non-rollback always preserved:** `docs/brand/zilin-rename-rationale.md` and the decision trail survive any rollback — they capture *why* the decision was made at this date, which has archival value regardless of outcome.
+
+**Greenfield items have no rollback concept.** If ZiLin-Scheduler later proves to need a different name, that's a new REFACTOR against the greenfield-built system, not a rollback of this one.
+
+## Legal triggers
+
+- **Trademark avoidance.** Central purpose of the refactor. Z.ai (Zhipu AI) HK IPO January 8, 2026; active filings in AI/software classes. ZiLin-\* family is the selected safer alternative. Documented in `docs/brand/zilin-rename-rationale.md`.
+- **Common-law TM foundation.** Founder has used "ZiLin" continuously since ~1996 (age 11, given by Igor Mospan). Continuous use establishes common-law rights. Optional fortification: notarized declaration from Igor Mospan documenting the naming event, useful if priority is ever contested.
+- **Pre-commercial-launch clearance.** Before any paid/commercial launch of ZiLin-Spec or ZiLin-Scheduler, run a paid USPTO clearance search (~$500–1500) in Nice Classes 9 and 42. Phase 1 budget item.
+- **Enterprise compliance disclosure correction.** Prior ZAI Enterprise bundles implied principal-level segregation of duties. This refactor corrects to process-level via mandatory footer. Truth-in-advertising control.
+- **Domain redirect preserves link equity.** 301 is authoritative for search engines; inbound SEO transfers cleanly from old to new domain.
+- **GitHub repo rename is structurally one-way.** Documented in Rollback section. Phase 2 decision carries higher weight than typical phased cutovers; Phase 1 extensibility criteria reflect this.
+- **Reserved names create internal precedence, not public rights.** Rights accrue on use. Reservation documented with 24-month expiry prevents internal squatting.
+- **No change to Beacon / HTTC compliance.** HTTC operates under DYCD Beacon Agreement #99358B; HTTC is unaffected by this refactor. StreetTT and HTTC remain separate legal entities.
+- **No change to third-party licenses** (Open-Meteo CC-BY in weather specs, etc.) beyond what originating specs already specify.
+- Keyword sweep (contract, indemnify, PHI, PAN, royalty): no new triggers beyond the items above.
+
+---
+
+**Pipeline:** download `-v1.md` → upload to `zai.htu.io/app` (now running rubric v1.2.1 post BUG fix, will correctly classify as refactor) → receive `-v1.scored.md` → then run:
+
+```bash
+cp "/mnt/c/Users/zilin/Downloads/2026-04-19__refactor__zilin-brand-migration-v1.scored.md" \
+   "$HOME/dev/zai/issues/2026-04-19__refactor__zilin-brand-migration.md"
+impl i /mnt/c/Users/zilin/Downloads/2026-04-19__refactor__zilin-brand-migration-v1.scored.md
+```
+
+Optional cross-ref pointer (per governance pattern):
+
+```bash
+echo "Authoritative: zi007lin/zai (to be zi007lin/zilin-spec) — issue TBD on impl" \
+  > "$HOME/dev/streettt-private/issues/_refs/2026-04-19__refactor__zilin-brand-migration.md"
+```
+
+---
+
+## ZAI Spec Score
+
+- **Rubric version:** 1.2.1
+- **Spec type:** refactor
+- **Evaluated at:** 2026-04-20T05:53:03.603Z
+- **Score:** 9/9
+- **Passed:** YES
+
+| Section | Status |
+|---|---|
+| intent | PASS |
+| decision_tree | PASS |
+| final_spec | PASS |
+| acceptance_criteria | PASS |
+| migration_summary | PASS |
+| files_list | PASS |
+| models_applied | PASS |
+| migration_plan | PASS |
+| legal_triggers | PASS |
+
+_Source: 2026-04-19__refactor__zilin-brand-migration-v1.md_

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import TopBar from "./components/TopBar";
 import Footer from "./components/Footer";
+import MigrationBanner from "./components/MigrationBanner";
 import HomePage from "./pages/HomePage";
 import AppPage from "./pages/AppPage";
 import PricingPage from "./pages/PricingPage";
@@ -26,6 +27,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col">
+      <MigrationBanner />
       <TopBar current={route} onNavigate={navigate} />
       <main className="flex-1">
         {route === "home" && <HomePage onNavigate={navigate} />}

--- a/src/components/MigrationBanner.tsx
+++ b/src/components/MigrationBanner.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+// Phase 1 migration banner for the ZiLin Brand Family Migration REFACTOR.
+// Shown only on the old domain (zai.htu.io) during dual-run. Dismissal is
+// persisted in localStorage. Reference: issues/2026-04-19__refactor__zilin-brand-migration.md §Phase 1.
+
+const STORAGE_KEY = "zilin-migration-banner-dismissed-v1";
+const OLD_DOMAIN = "zai.htu.io";
+const NEW_DOMAIN = "zilin-spec.htu.io";
+const RATIONALE_URL = "/docs/brand/zilin-rename-rationale.md";
+
+function isOldDomain(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.hostname === OLD_DOMAIN;
+}
+
+function wasDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export default function MigrationBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (isOldDomain() && !wasDismissed()) {
+      setVisible(true);
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  const handleDismiss = () => {
+    setVisible(false);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // ignore (private mode, SSR edges)
+    }
+  };
+
+  return (
+    <aside
+      role="region"
+      aria-label="Service renaming announcement"
+      className="sticky top-0 z-50 bg-[#0D7C5F] text-white shadow-sm border-b border-white/15 motion-safe:animate-[fadeIn_180ms_ease-out]"
+    >
+      <div className="max-w-6xl mx-auto px-4 py-3 flex items-center gap-3">
+        <span aria-hidden="true" className="shrink-0 opacity-90">
+          &#x27A4;
+        </span>
+        <p className="m-0 flex-1 text-sm leading-snug">
+          <strong>Renaming to ZiLin-Spec.</strong>{" "}
+          This validator is moving to{" "}
+          <a
+            href={`https://${NEW_DOMAIN}/app`}
+            className="underline underline-offset-2 hover:decoration-2 focus-visible:decoration-2"
+          >
+            {NEW_DOMAIN}
+          </a>
+          . Both domains work today. The old URL will 301 after the Phase 2
+          cutover.{" "}
+          <a
+            href={RATIONALE_URL}
+            className="underline underline-offset-2 hover:decoration-2 focus-visible:decoration-2"
+          >
+            Why
+          </a>
+        </p>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss rename announcement"
+          className="shrink-0 w-8 h-8 inline-flex items-center justify-center rounded border border-white/30 hover:bg-white/15 hover:border-white/60 focus-visible:bg-white/15 focus-visible:border-white/60 focus-visible:outline-none"
+        >
+          <span aria-hidden="true" className="text-lg leading-none">
+            &times;
+          </span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/lib/renderScoredSpec.test.ts
+++ b/src/lib/renderScoredSpec.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  renderScoredSpec,
+  extractBundles,
+  matchTriggeredBundles,
+  TRIGGER_BUNDLES,
+  ENTERPRISE_DISCLOSURE_TEXT,
+} from "./renderScoredSpec";
+import type { ScoreResult } from "./scoreSpec";
+
+function makeResult(overrides: Partial<ScoreResult> = {}): ScoreResult {
+  return {
+    rubric_version: "1.3.0",
+    spec_type: "feat",
+    score: "9/9",
+    required_count: 9,
+    passed: true,
+    evaluated_at: "2026-04-20T12:00:00.000Z",
+    sections: { intent: "PASS" },
+    section_reasons: { intent: null },
+    section_order: ["intent"],
+    section_labels: { intent: "Intent" },
+    gates: [],
+    ...overrides,
+  };
+}
+
+const specWithHealthcare = `---
+spec_type: feat
+rubric_version: 1.3
+bundles: [healthcare]
+---
+
+# Title
+
+## Intent
+Body.
+`;
+
+const specWithMultiTriggers = `---
+spec_type: feat
+bundles: [healthcare, fintech]
+---
+
+# Title
+`;
+
+const specEmptyBundles = `---
+spec_type: feat
+bundles: []
+---
+
+# Title
+`;
+
+const specNoBundlesField = `---
+spec_type: feat
+rubric_version: 1.3
+---
+
+# Title
+`;
+
+const specNonTriggerBundle = `---
+spec_type: feat
+bundles: [marketing, accessibility]
+---
+
+# Title
+`;
+
+const specMixedCaseBundle = `---
+spec_type: feat
+bundles: [Healthcare]
+---
+
+# Title
+`;
+
+const specHyphenVariant = `---
+spec_type: feat
+bundles: [financial-advisory]
+---
+
+# Title
+`;
+
+const specBlockFormBundles = `---
+spec_type: feat
+bundles:
+  - healthcare
+  - government
+---
+
+# Title
+`;
+
+// ─── extractBundles ──────────────────────────────────────────────────────
+
+describe("extractBundles", () => {
+  it("extracts inline array form", () => {
+    expect(extractBundles(specWithHealthcare)).toEqual(["healthcare"]);
+    expect(extractBundles(specWithMultiTriggers)).toEqual(["healthcare", "fintech"]);
+  });
+
+  it("returns empty array for empty bundles", () => {
+    expect(extractBundles(specEmptyBundles)).toEqual([]);
+  });
+
+  it("returns empty array when bundles field absent", () => {
+    expect(extractBundles(specNoBundlesField)).toEqual([]);
+  });
+
+  it("returns empty array when frontmatter absent", () => {
+    expect(extractBundles("# Just a title\n\nNo frontmatter here.\n")).toEqual([]);
+  });
+
+  it("extracts block-style bundles", () => {
+    expect(extractBundles(specBlockFormBundles)).toEqual(["healthcare", "government"]);
+  });
+});
+
+// ─── matchTriggeredBundles ───────────────────────────────────────────────
+
+describe("matchTriggeredBundles", () => {
+  it("matches canonical trigger bundles", () => {
+    expect(matchTriggeredBundles(["healthcare"])).toEqual(["healthcare"]);
+    expect(matchTriggeredBundles(["fintech", "government"])).toEqual([
+      "fintech",
+      "government",
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchTriggeredBundles(["Healthcare", "GOVERNMENT"])).toEqual([
+      "healthcare",
+      "government",
+    ]);
+  });
+
+  it("treats hyphens and underscores as equivalent", () => {
+    expect(matchTriggeredBundles(["financial-advisory"])).toEqual(["financial_advisory"]);
+    expect(matchTriggeredBundles(["legal-services"])).toEqual(["legal_services"]);
+  });
+
+  it("ignores non-trigger bundles", () => {
+    expect(matchTriggeredBundles(["marketing", "accessibility"])).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(matchTriggeredBundles([])).toEqual([]);
+  });
+
+  it("exposes the canonical trigger bundle list (5 entries)", () => {
+    expect(TRIGGER_BUNDLES.length).toBe(5);
+    expect(TRIGGER_BUNDLES).toEqual([
+      "healthcare",
+      "fintech",
+      "financial_advisory",
+      "legal_services",
+      "government",
+    ]);
+  });
+});
+
+// ─── renderScoredSpec — footer behavior (9 tests per rubric-v1.3-draft) ──
+
+describe("renderScoredSpec — enterprise disclosure footer", () => {
+  it("(1) emits footer for spec with bundles: [healthcare]", () => {
+    const out = renderScoredSpec("x.md", specWithHealthcare, makeResult());
+    expect(out).toContain("## Enterprise Compliance Disclosure");
+    expect(out).toContain("Triggered by bundles: healthcare");
+  });
+
+  it("(2) emits footer with all matched trigger bundles listed", () => {
+    const out = renderScoredSpec("x.md", specWithMultiTriggers, makeResult());
+    expect(out).toContain("Triggered by bundles: healthcare, fintech");
+  });
+
+  it("(3) does NOT emit footer for spec with bundles: []", () => {
+    const out = renderScoredSpec("x.md", specEmptyBundles, makeResult());
+    expect(out).not.toContain("Enterprise Compliance Disclosure");
+  });
+
+  it("(4) does NOT emit footer when bundles field is absent", () => {
+    const out = renderScoredSpec("x.md", specNoBundlesField, makeResult());
+    expect(out).not.toContain("Enterprise Compliance Disclosure");
+  });
+
+  it("(5) does NOT emit footer when only non-trigger bundles are present", () => {
+    const out = renderScoredSpec("x.md", specNonTriggerBundle, makeResult());
+    expect(out).not.toContain("Enterprise Compliance Disclosure");
+  });
+
+  it("(6) emits footer case-insensitively (bundles: [Healthcare])", () => {
+    const out = renderScoredSpec("x.md", specMixedCaseBundle, makeResult());
+    expect(out).toContain("## Enterprise Compliance Disclosure");
+    expect(out).toContain("Triggered by bundles: healthcare");
+  });
+
+  it("(7) emits footer for hyphen variant (financial-advisory → financial_advisory)", () => {
+    const out = renderScoredSpec("x.md", specHyphenVariant, makeResult());
+    expect(out).toContain("## Enterprise Compliance Disclosure");
+    expect(out).toContain("Triggered by bundles: financial_advisory");
+  });
+
+  it("(8) footer text is verbatim-equal to docs/brand/enterprise-disclosure.md (drift detector)", () => {
+    const docPath = resolve(__dirname, "../../docs/brand/enterprise-disclosure.md");
+    const doc = readFileSync(docPath, "utf8");
+    // Extract the canonical quoted disclosure: find the paragraph starting with
+    // "**Dual-control disclosure.**" that appears inside a > blockquote
+    // (per the canonical section in the brand doc).
+    const canonicalMatch = doc.match(
+      />\s*(\*\*Dual-control disclosure\.\*\*[^\n]+(?:\n>[^\n]*)*)/,
+    );
+    expect(
+      canonicalMatch,
+      "could not locate canonical disclosure paragraph in docs/brand/enterprise-disclosure.md",
+    ).not.toBeNull();
+    const docText = canonicalMatch![1]
+      .split("\n")
+      .map((line) => line.replace(/^>\s?/, ""))
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+    const implText = ENTERPRISE_DISCLOSURE_TEXT.replace(/\s+/g, " ").trim();
+    expect(implText).toBe(docText);
+  });
+
+  it("(9) footer is appended AFTER the score block, not inside it", () => {
+    const out = renderScoredSpec("x.md", specWithHealthcare, makeResult());
+    const scoreIdx = out.indexOf("## ZAI Spec Score");
+    const footerIdx = out.indexOf("## Enterprise Compliance Disclosure");
+    expect(scoreIdx).toBeGreaterThan(-1);
+    expect(footerIdx).toBeGreaterThan(-1);
+    expect(footerIdx).toBeGreaterThan(scoreIdx);
+  });
+});
+
+// ─── existing behavior preserved (regression guard) ───────────────────────
+
+describe("renderScoredSpec — non-footer behavior preserved from buildScoredSpec", () => {
+  it("renders original markdown, separator, and score block in that order", () => {
+    const md = "# Title\n\n## Intent\nBody.\n";
+    const out = renderScoredSpec("x.md", md, makeResult());
+    expect(out.indexOf("# Title")).toBe(0);
+    expect(out.indexOf("---")).toBeGreaterThan(0);
+    expect(out.indexOf("## ZAI Spec Score")).toBeGreaterThan(out.indexOf("---"));
+  });
+
+  it("includes Pre-deploy gates section when gates present", () => {
+    const md = "# Title\n";
+    const out = renderScoredSpec(
+      "x.md",
+      md,
+      makeResult({ gates: ["confirm chain status", "confirm accent color"] }),
+    );
+    expect(out).toContain("### Pre-deploy gates");
+    expect(out).toContain("- [ ] confirm chain status");
+  });
+
+  it("omits Pre-deploy gates section when gates empty", () => {
+    const md = "# Title\n";
+    const out = renderScoredSpec("x.md", md, makeResult({ gates: [] }));
+    expect(out).not.toContain("Pre-deploy gates");
+  });
+
+  it("includes _Source: filename_ line", () => {
+    const md = "# Title\n";
+    const out = renderScoredSpec(
+      "2026-04-19__feat__example.md",
+      md,
+      makeResult(),
+    );
+    expect(out).toContain("_Source: 2026-04-19__feat__example.md_");
+  });
+});

--- a/src/lib/renderScoredSpec.ts
+++ b/src/lib/renderScoredSpec.ts
@@ -1,0 +1,136 @@
+import type { ScoreResult } from "./scoreSpec";
+
+// Enterprise-disclosure trigger bundles per ZAI_SYSTEM_INSTRUCTIONS.md v1.3.
+// Canonical match uses lowercase + underscore equivalence for hyphen input.
+export const TRIGGER_BUNDLES: readonly string[] = [
+  "healthcare",
+  "fintech",
+  "financial_advisory",
+  "legal_services",
+  "government",
+];
+
+// Canonical disclosure text — must match docs/brand/enterprise-disclosure.md
+// verbatim. The test suite asserts this equality to catch drift between the
+// rubric implementation and the brand doc.
+export const ENTERPRISE_DISCLOSURE_TEXT =
+  "**Dual-control disclosure.** The dual-control segregation in this workflow is process-level (author/reviewer via separate identities for one human principal). Principal-level segregation of duties — two independent human operators — is not yet in place at HTU. Clients with principal-level segregation requirements under HIPAA §164.308, SOX §404, FINRA 3110, or equivalent must arrange for an independent second operator before relying on this control.";
+
+function normalizeBundle(raw: string): string {
+  return raw.trim().toLowerCase().replace(/-/g, "_");
+}
+
+// Parse the `bundles:` array from YAML-style frontmatter at the top of the
+// markdown. Returns [] if frontmatter is absent or the field is missing/empty.
+// Accepts inline array form: `bundles: [healthcare, fintech]` or
+// `bundles: []`. Block form (bundles:\n  - healthcare) is also accepted.
+export function extractBundles(markdown: string): string[] {
+  const fmMatch = markdown.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!fmMatch) return [];
+  const fm = fmMatch[1];
+
+  const inline = fm.match(/^bundles:\s*\[([^\]]*)\]\s*$/m);
+  if (inline) {
+    return inline[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  const blockStart = fm.match(/^bundles:\s*$/m);
+  if (blockStart) {
+    const lines = fm.split("\n");
+    const startIdx = lines.findIndex((l) => /^bundles:\s*$/.test(l));
+    const collected: string[] = [];
+    for (let i = startIdx + 1; i < lines.length; i++) {
+      const m = lines[i].match(/^\s*-\s*(.+)$/);
+      if (!m) break;
+      collected.push(m[1].trim());
+    }
+    return collected;
+  }
+
+  return [];
+}
+
+// Return the subset of the given bundle list that triggers the enterprise
+// disclosure footer. Matching is case-insensitive with hyphen/underscore
+// equivalence, so `Healthcare`, `healthcare`, `financial-advisory`, and
+// `financial_advisory` all match canonical trigger bundle names.
+export function matchTriggeredBundles(bundles: string[]): string[] {
+  const normalizedTriggers = new Set(TRIGGER_BUNDLES.map(normalizeBundle));
+  const matched: string[] = [];
+  for (const b of bundles) {
+    const n = normalizeBundle(b);
+    if (normalizedTriggers.has(n) && !matched.includes(n)) {
+      matched.push(n);
+    }
+  }
+  return matched;
+}
+
+function renderScoreBlock(filename: string, result: ScoreResult): string {
+  const lines: string[] = [];
+  lines.push("## ZAI Spec Score");
+  lines.push("");
+  lines.push(`- **Rubric version:** ${result.rubric_version}`);
+  lines.push(`- **Spec type:** ${result.spec_type}`);
+  lines.push(`- **Evaluated at:** ${result.evaluated_at}`);
+  lines.push(`- **Score:** ${result.score}`);
+  lines.push(`- **Passed:** ${result.passed ? "YES" : "NO"}`);
+  lines.push("");
+  lines.push("| Section | Status |");
+  lines.push("|---|---|");
+  for (const [key, status] of Object.entries(result.sections)) {
+    lines.push(`| ${key} | ${status} |`);
+  }
+  if (result.gates.length > 0) {
+    lines.push("");
+    lines.push("### Pre-deploy gates");
+    for (const g of result.gates) lines.push(`- [ ] ${g}`);
+  }
+  lines.push("");
+  lines.push(`_Source: ${filename}_`);
+  return lines.join("\n");
+}
+
+function renderDisclosureFooter(matched: string[]): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push("## Enterprise Compliance Disclosure");
+  lines.push("");
+  lines.push(ENTERPRISE_DISCLOSURE_TEXT);
+  lines.push("");
+  lines.push(`_Triggered by bundles: ${matched.join(", ")}._`);
+  lines.push("_Reference: docs/brand/enterprise-disclosure.md._");
+  return lines.join("\n");
+}
+
+// Render a `.scored.md` output by concatenating the original spec, a
+// separator, the score block, and — when any bundle in the spec's frontmatter
+// is in TRIGGER_BUNDLES — the enterprise disclosure footer appended after
+// the score block. This is the output-layer integration point for rubric
+// v1.3 per docs/brand/enterprise-disclosure.md and the Phase 0 design note
+// "render in the output layer, not the scoring layer."
+export function renderScoredSpec(
+  filename: string,
+  originalMarkdown: string,
+  result: ScoreResult,
+): string {
+  const parts: string[] = [];
+  parts.push(originalMarkdown.replace(/\s+$/, ""));
+  parts.push("");
+  parts.push("---");
+  parts.push("");
+  parts.push(renderScoreBlock(filename, result));
+
+  const matched = matchTriggeredBundles(extractBundles(originalMarkdown));
+  if (matched.length > 0) {
+    parts.push(renderDisclosureFooter(matched));
+  }
+
+  parts.push("");
+  return parts.join("\n");
+}

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -693,8 +693,8 @@ describe("scoreSpec — gates and meta", () => {
     expect(r.gates[0]).toMatch(/chain/i);
   });
 
-  it("rubric version is 1.2.1", () => {
-    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.2.1");
+  it("rubric version is 1.3.0", () => {
+    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.3.0");
   });
 
   it("non-matching filename throws SpecTypeError (previously silently fell back to feat)", () => {

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -34,7 +34,7 @@ export class SpecTypeError extends Error {
   }
 }
 
-const RUBRIC_VERSION = "1.2.1";
+const RUBRIC_VERSION = "1.3.0";
 
 // ─── helpers ──────────────────────────────────────────────────────────────
 

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -4,6 +4,7 @@ import ScorePanel from "../components/ScorePanel";
 import ScoreExample from "../components/ScoreExample";
 import PipelineSteps from "../components/PipelineSteps";
 import { scoreSpec, type ScoreResult } from "../lib/scoreSpec";
+import { renderScoredSpec } from "../lib/renderScoredSpec";
 import { SPEC_TEMPLATE } from "../lib/specTemplate";
 
 function downloadBlob(filename: string, contents: string) {
@@ -16,40 +17,6 @@ function downloadBlob(filename: string, contents: string) {
   a.click();
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
-}
-
-function buildScoredSpec(
-  originalFilename: string,
-  originalMarkdown: string,
-  result: ScoreResult
-): string {
-  const lines: string[] = [];
-  lines.push(originalMarkdown.replace(/\s+$/, ""));
-  lines.push("");
-  lines.push("---");
-  lines.push("");
-  lines.push("## ZAI Spec Score");
-  lines.push("");
-  lines.push(`- **Rubric version:** ${result.rubric_version}`);
-  lines.push(`- **Spec type:** ${result.spec_type}`);
-  lines.push(`- **Evaluated at:** ${result.evaluated_at}`);
-  lines.push(`- **Score:** ${result.score}`);
-  lines.push(`- **Passed:** ${result.passed ? "YES" : "NO"}`);
-  lines.push("");
-  lines.push("| Section | Status |");
-  lines.push("|---|---|");
-  for (const [key, status] of Object.entries(result.sections)) {
-    lines.push(`| ${key} | ${status} |`);
-  }
-  if (result.gates.length > 0) {
-    lines.push("");
-    lines.push("### Pre-deploy gates");
-    for (const g of result.gates) lines.push(`- [ ] ${g}`);
-  }
-  lines.push("");
-  lines.push(`_Source: ${originalFilename}_`);
-  lines.push("");
-  return lines.join("\n");
 }
 
 type ImplState = "idle" | "dispatching" | "queued" | "error";
@@ -98,7 +65,7 @@ export default function AppPage() {
 
   const handleDownloadScored = useCallback(() => {
     if (!filename || !markdown || !result) return;
-    const out = buildScoredSpec(filename, markdown, result);
+    const out = renderScoredSpec(filename, markdown, result);
     const scoredName = filename.replace(/\.md$/i, "") + ".scored.md";
     downloadBlob(scoredName, out);
   }, [filename, markdown, result]);
@@ -108,7 +75,7 @@ export default function AppPage() {
     setImplState("dispatching");
     setErrorMsg("");
     try {
-      const scoredBody = buildScoredSpec(filename, markdown, result);
+      const scoredBody = renderScoredSpec(filename, markdown, result);
       const titleSlug = filename.replace(/\.md$/i, "").replace(/^.*__/, "");
       const issueRes = await fetch("/api/issue", {
         method: "POST",
@@ -166,9 +133,9 @@ export default function AppPage() {
           className="mt-4 text-[var(--zai-muted)] max-w-2xl"
           style={{ fontSize: "1.0625rem", lineHeight: 1.7 }}
         >
-          Upload a spec file to get a deterministic 7-section score. No LLM
-          judgment — pure structural analysis. Structural checks. Human review
-          still required.
+          Upload a spec file to get a deterministic per-type rubric score
+          (5–9 structural checks depending on spec type). No LLM judgment —
+          pure structural analysis. Human review still required.
         </p>
       </section>
     ),


### PR DESCRIPTION
Closes #48.
Phase 1 of the authoritative spec: `issues/2026-04-19__refactor__zilin-brand-migration.md`.

## Summary

- 3 brand docs (rationale, family namespace, enterprise disclosure) — canonical, preserved across rollbacks.
- Rubric v1.3: enterprise disclosure footer on `.scored.md` when spec carries a trigger bundle.
- Migration banner on validator UI (shown only on `zai.htu.io` during dual-run).
- Hero copy fixed (was "7-section score" — now "5–9 structural checks depending on spec type").

Dual-run begins when this merges. Phase 2 (DNS cutover + repo rename + 301) is operator-only and **structurally one-way** per the Phase 0 tabletop — gated by pre-cutover verification checks.

## Acceptance criteria (from spec, Phase-1-applicable)

- [x] `docs/brand/zilin-rename-rationale.md`, `zilin-family-namespace.md`, `enterprise-disclosure.md` exist
- [x] `zai.htu.io` displays the migration banner during Phase 1 (rendered by `MigrationBanner` when hostname matches)
- [x] `ZAI_SYSTEM_INSTRUCTIONS.md` rubric bumped to v1.3 with enterprise disclosure footer (rename `ZAI_SYSTEM_INSTRUCTIONS.md` → `ZILIN_SPEC_SYSTEM_INSTRUCTIONS.md` deferred to Phase 2 to avoid touching naming during dual-run)

**Added acceptance criteria (2026-04-19 Gap-1 resolution):**

- [x] Phase 1 is extensible by 30-day increments at operator discretion — rule documented in `docs/brand/zilin-rename-rationale.md` §Triggers to revisit
- [x] Pre-Phase-2 verification checklist (GitHub Pages absence, TM stability, adoption ≥ 50%, 7-day notice, rationale doc merged) — documented in this PR; execution stays with operator

**Criteria for later phases:**

- [ ] `zai.htu.io` returns HTTP 301 to `zilin-spec.htu.io` from Phase 2 onward (Phase 2 — **structurally one-way**, gated on pre-cutover verification)
- [ ] `zi007lin/zai` renamed on GitHub to `zi007lin/zilin-spec` (Phase 2)
- [ ] Grep of htu.io / zzv.io public content returns zero live ZAI references (Phase 3)
- [x] Claude Code and `impl` continue working unchanged (no changes to the impl-invocation surface in this PR)

## Implementation notes / deviations

**Output-layer rendering (not scoring-layer).** Per the Phase 0 `rubric-v1.3-draft.md §Implementation notes`, the enterprise disclosure footer is rendered in a new `src/lib/renderScoredSpec.ts` module, not inside `scoreSpec()`. Rationale: scoring produces structured data, rendering consumes it. Keeps the scoring engine pure and unit-testable without string-templating concerns. `ScoreResult` shape is unchanged; future API/UI surfaces can share the same scoring core.

**Refactor extraction from AppPage.tsx.** The prior local `buildScoredSpec()` in `AppPage.tsx` is replaced by `renderScoredSpec` from the lib. AppPage now imports the lib function. Behavior for non-triggered specs is preserved (regression tests cover this).

**Minimal `checkModelsApplied` implementation.** The full Pass B/Pass C structural cross-check from v1.2 §3 is substantial — scope is flagged for a separate SPEC. Current implementation is Layer-1 minimum: heading present + at least one bullet/numbered declaration. Sufficient for the drift-detection-at-count level.

**Hero copy fix.** AppPage hero said "deterministic 7-section score" — inaccurate since per-type rubric counts are 5–9. Updated to match reality. Called out in FOLLOW-UPS during Phase 0 review; fixed in this PR.

## Test + build

- **78 tests pass** (54 from #47 + 24 new for renderScoredSpec / extractBundles / matchTriggeredBundles / footer rendering / regression of prior buildScoredSpec behavior).
- `npm test`: green.
- `npm run build` (`tsc -b && vite build`): green.
- `npm run lint`: eslint binary still missing from `node_modules` (pre-existing per #47). Flagged; out of scope.

## Drift detectors active

- **Footer text:** `renderScoredSpec.test.ts` test (8) reads `docs/brand/enterprise-disclosure.md` and asserts the in-code `ENTERPRISE_DISCLOSURE_TEXT` is verbatim-equal. Edit either file without updating the other → CI fails.
- **Rubric structure:** `scoreSpec.test.ts` drift block from #47 still passes — no rubric count/order changes in this PR.

## Phase 0 artifacts promoted

Content source: `~/dev/streettt-private/drafts/2026-04-19__refactor__zilin-brand-migration/` (private repo, reviewed 2026-04-19). This PR promotes only the content that belongs in `zi007lin/zai`; the `PR-PREP.md`, `tabletop-rollback.md`, `rubric-v1.3-draft.md`, and `FOLLOW-UPS.md` stay in streettt-private as the private audit record.

## Out of scope (Phase 2+ / human-only)

- DNS changes at Cloudflare (`zilin-spec.htu.io` CNAME is a Phase 0 operator action, assumed done pre-merge)
- GitHub repo rename `zi007lin/zai` → `zi007lin/zilin-spec` (Phase 2, **one-way**)
- 301 redirect at `zai.htu.io` (Phase 2)
- CF Worker deploys (operator)
- `wrangler.toml` env-var + binding renames (Phase 2)
- Marketing copy sweeps on htu.io / zzv.io (Phase 1/3 operator)
- Contabo / systemd (Phase 2)
- Full Models Applied structural cross-check (separate SPEC — current implementation is Layer-1 minimum)
- Modularization of `scoreSpec.ts` to `src/lib/rubrics/*.ts` (future REFACTOR)

## Reviewer: daniel-silvers

Approval audit trail: this non-trivial REFACTOR was approved by ZiLin in the active Claude Code session 2026-04-20 per CLAUDE.md §Gate 1 solo-operator path. (CLAUDE.md §Gate 1 predates `refactor` as a first-class `SpecType` — its non-trivial list names only feat/research/bug. By scope this is clearly non-trivial.) Session conversation is the audit record. PR review at merge is the enforceable governance gate.