### PR TITLE
refactor: ZAI router dual-mode dispatch + Phase 0 audit

### DIFF
--- a/.github/workflows/zilin-queue.yml
+++ b/.github/workflows/zilin-queue.yml
@@ -8,6 +8,15 @@ jobs:
   impl:
     runs-on: [self-hosted, contabo, zilin, zai]
     timeout-minutes: 60
+    env:
+      # Per-repo dispatch-mode flags. Unset -> legacy (existing in-place behavior).
+      # Source of truth: repository variables on zi007lin/zai.
+      # See docs/router-dispatch-contract.md#mode-resolution.
+      ZAI_DISPATCH_MODE_STREETTT: ${{ vars.ZAI_DISPATCH_MODE_STREETTT }}
+      ZAI_DISPATCH_MODE_HTU_IO: ${{ vars.ZAI_DISPATCH_MODE_HTU_IO }}
+      ZAI_DISPATCH_MODE_HTU_FOUNDATION: ${{ vars.ZAI_DISPATCH_MODE_HTU_FOUNDATION }}
+      ZAI_DISPATCH_MODE_NYQEX: ${{ vars.ZAI_DISPATCH_MODE_NYQEX }}
+      ZAI_DISPATCH_MODE_ZAI: ${{ vars.ZAI_DISPATCH_MODE_ZAI }}
     steps:
       - name: Ensure Claude Code CLI on PATH
         run: |
@@ -30,15 +39,109 @@ jobs:
             echo "PATH=$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
           } >> "$GITHUB_ENV"
 
-      - name: Dispatch to ZAI router
+      - name: Resolve target repo and mode
+        id: resolve
         env:
           GITHUB_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN }}
         run: |
+          set -euo pipefail
+
           ISSUE_NUMBER="${{ github.event.client_payload.issue_number }}"
           if [ -z "$ISSUE_NUMBER" ]; then
-            echo "Error: issue_number not provided in client_payload"
+            echo "::error::issue_number not provided in client_payload"
             exit 1
           fi
-          echo "Routing implw $ISSUE_NUMBER for ${{ github.repository }}"
+
+          TARGET_REPO="${{ github.event.client_payload.target_repo }}"
+
+          if [ -z "$TARGET_REPO" ]; then
+            echo "client_payload.target_repo not set; parsing **Repo:** from issue body"
+            SPEC_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "${{ github.repository }}" --json body -q .body)
+            TARGET_REPO=$(echo "$SPEC_BODY" \
+              | grep -oE '\*\*Repo:\*\*[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' \
+              | head -1 \
+              | awk '{print $2}' || true)
+          fi
+
+          if [ -z "$TARGET_REPO" ]; then
+            echo "::error::could not resolve target_repo from payload or spec body"
+            exit 1
+          fi
+
+          # Allow-list. Edits to this case statement require a dual-PR merge on
+          # zi007lin/zai (daniel-silvers approves). See docs/router-dispatch-contract.md#allow-list.
+          case "$TARGET_REPO" in
+            zi007lin/streettt|zi007lin/htu.io|zi007lin/nyqex|zi007lin/htu-foundation|zi007lin/zai)
+              ;;
+            *)
+              echo "::error::target_repo $TARGET_REPO not in allow-list"
+              exit 1
+              ;;
+          esac
+
+          REPO_NAME="${TARGET_REPO##*/}"
+          SLUG="${REPO_NAME^^}"
+          SLUG="${SLUG//./_}"
+          SLUG="${SLUG//-/_}"
+          MODE_VAR="ZAI_DISPATCH_MODE_${SLUG}"
+          RAW_MODE="${!MODE_VAR:-}"
+          if [ "$RAW_MODE" = "dispatch" ]; then
+            MODE="dispatch"
+          else
+            MODE="legacy"
+          fi
+
+          echo "Resolved: target_repo=$TARGET_REPO slug=$SLUG mode=$MODE (raw=${RAW_MODE:-unset})"
+          {
+            echo "target_repo=$TARGET_REPO"
+            echo "mode=$MODE"
+            echo "issue_number=$ISSUE_NUMBER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to target repo (dispatch mode)
+        if: steps.resolve.outputs.mode == 'dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          TARGET="${{ steps.resolve.outputs.target_repo }}"
+          ISSUE_NUMBER="${{ steps.resolve.outputs.issue_number }}"
+          SOURCE_RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SPEC_PATH="${{ github.event.client_payload.spec_path }}"
+          SPEC_TYPE="${{ github.event.client_payload.spec_type }}"
+          NEEDS_APPROVAL="${{ github.event.client_payload.needs_approval }}"
+
+          PAYLOAD=$(jq -nc \
+            --argjson issue "$ISSUE_NUMBER" \
+            --arg target "$TARGET" \
+            --arg spec_path "$SPEC_PATH" \
+            --arg spec_type "$SPEC_TYPE" \
+            --arg needs_approval "$NEEDS_APPROVAL" \
+            --arg source_run "$SOURCE_RUN_URL" \
+            '{
+              event_type: "zilin-impl",
+              client_payload: {
+                issue_number: $issue,
+                target_repo: $target,
+                spec_path: $spec_path,
+                spec_type: $spec_type,
+                needs_approval: ($needs_approval == "true"),
+                source_zai_run_url: $source_run
+              }
+            }')
+
+          echo "Dispatching zilin-impl to $TARGET for issue #$ISSUE_NUMBER"
+          printf '%s' "$PAYLOAD" | gh api "repos/$TARGET/dispatches" --input -
+          echo "Dispatched: https://github.com/$TARGET/actions"
+
+      - name: Legacy in-place execute (legacy mode)
+        if: steps.resolve.outputs.mode == 'legacy'
+        env:
+          GITHUB_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          ISSUE_NUMBER="${{ steps.resolve.outputs.issue_number }}"
+          TARGET="${{ steps.resolve.outputs.target_repo }}"
+          echo "Routing implw $ISSUE_NUMBER for $TARGET (legacy mode)"
           cd "$ROUTER_PATH"
-          claude -p "implw $ISSUE_NUMBER --repo ${{ github.repository }}"
+          claude -p "implw $ISSUE_NUMBER --repo $TARGET"

--- a/docs/router-audit-2026-04-22.md
+++ b/docs/router-audit-2026-04-22.md
@@ -1,0 +1,114 @@
+# Router Audit — 2026-04-22
+
+Phase 0 output of `issues/2026-04-22__refactor__zai-router-dispatch-only.md`. Point-in-time inventory of the current ZAI router, the repos it routes to, and the secrets / env vars / runner labels each workflow depends on. This document is a snapshot; the state below can change after merge. To reproduce, check out each repo at the SHAs listed in the Audit snapshot table and re-grep.
+
+## Scope
+
+The refactor splits routing from execution. This audit captures:
+
+1. Where `implw` is invoked today.
+2. Which secrets the central executor depends on.
+3. Which runner labels and env vars each invocation expects.
+4. What needs to move (execution) and what stays (parse + dispatch).
+
+## Current router — `zi007lin/zai`
+
+| Field | Value |
+|---|---|
+| Workflow file | `.github/workflows/zilin-queue.yml` |
+| Workflow `name:` | `ZiLin Queue Listener` |
+| Trigger | `repository_dispatch` type `zilin_impl` |
+| Runner labels | `[self-hosted, contabo, zilin, zai]` |
+| Timeout | 60 minutes |
+| Secrets | `ZZV_DISPATCH_TOKEN` |
+| Runner-env dependencies | `HOME`, `PATH` (normalized in-workflow), `ROUTER_PATH` (set on runner, not in YAML) |
+| External tooling | `@anthropic-ai/claude-code` CLI (auto-installed if missing) |
+| Last commit touching file | `733f802` — `fix: defensive guard for claude CLI on ZAI runner + daily health check` (2026-04-18) |
+
+> Spec note: `issues/2026-04-22__refactor__zai-router-dispatch-only.md` lists the router file as `.github/workflows/zilin_impl.yml`. The actual file on disk is `zilin-queue.yml`. Treated as a spec-side naming error; modifying the real file.
+
+Today the router both parses the dispatch and executes the impl in the zai checkout:
+
+```
+cd "$ROUTER_PATH"
+claude -p "implw $ISSUE_NUMBER --repo ${{ github.repository }}"
+```
+
+This is the exact path that surfaced the repo-mismatch failure captured in issue #57: the executor had no access to the target repo's code, tests, or deploy scripts.
+
+## Target repos
+
+### `zi007lin/streettt`
+
+| Field | Value |
+|---|---|
+| `implw` invocations | `.github/workflows/zilin-dev.yml` (label-triggered, separate path from zai router) |
+| Secrets used by that workflow | `ANTHROPIC_API_KEY`, `GITHUB_TOKEN` |
+| Runner | `self-hosted` |
+| Dormant `zilin-impl.yml` present? | No |
+
+The streettt label-triggered path is independent of the zai router and is not affected by this refactor. It will coexist with the new dispatch-mode `zilin-impl.yml` once that's enabled.
+
+### `zi007lin/htu.io`
+
+| Field | Value |
+|---|---|
+| `implw` invocations | None |
+| Existing workflows | `token-mint.yml` |
+| Dormant `zilin-impl.yml` present? | No |
+
+### `zi007lin/htu-foundation`
+
+| Field | Value |
+|---|---|
+| `implw` invocations | None |
+| Existing workflows | `.github/workflows/` directory does not exist |
+| Dormant `zilin-impl.yml` present? | No |
+
+### `zi007lin/nyqex`
+
+Does not exist on GitHub at audit time (`gh repo view zi007lin/nyqex` returns a not-found). Skipped in Phase 1. If the repo is created later, `zilin-impl.yml` must be added before it can be cut over.
+
+## Secrets inventory (union across all implw paths)
+
+| Secret | Used by | Scope |
+|---|---|---|
+| `ZZV_DISPATCH_TOKEN` | zai `zilin-queue.yml` | repo-level in zai |
+| `ANTHROPIC_API_KEY` | streettt `zilin-dev.yml` | repo-level in streettt |
+| `GITHUB_TOKEN` | streettt `zilin-dev.yml` | ambient in every runner |
+
+Post-refactor, each target repo's own `zilin-impl.yml` will resolve secrets from that repo — the zai router will no longer need cross-repo secret visibility.
+
+## Runner labels in use
+
+| Workflow | Labels |
+|---|---|
+| zai `zilin-queue.yml` | `self-hosted, contabo, zilin, zai` |
+| streettt `zilin-dev.yml` | `self-hosted` |
+| Proposed target-repo `zilin-impl.yml` (Phase 1) | `self-hosted, contabo, zilin` |
+
+The new target-repo workflow label set drops `zai` (target-repo-specific, not zai-specific) and keeps `contabo, zilin` so GitHub continues to route jobs to the existing Contabo self-hosted runner(s).
+
+## Env vars referenced on the runner (outside YAML)
+
+- `ROUTER_PATH` — set on the Contabo runner, used by the legacy execute step (`cd "$ROUTER_PATH"`). Must remain set while the legacy path is alive. Not required for dispatch mode.
+- `HOME`, `PATH` — normalized in-workflow; documented here because the `zilin-queue.yml` file contains an in-YAML fallback for cases where systemd units omit `Environment="HOME=..."`.
+
+## Audit snapshot — reproducibility
+
+To reproduce this audit: check out each repo at the SHA below and re-grep `.github/workflows/` for `implw`.
+
+| Repo | Default branch | `main` HEAD @ audit time | Checked-out branch @ audit time | Checked-out HEAD |
+|---|---|---|---|---|
+| zi007lin/zai | main | `36ac1014ea` | main | `36ac1014ea` |
+| zi007lin/streettt | main | `134f84b0b2` | `stt/match-prediction-league-spec` | `b314049efd` |
+| zi007lin/htu.io | main | `0ee40e1e3f` | `stt/home-page-history-audit` | `0dd8a94e79` |
+| zi007lin/htu-foundation | main | `c485815971` | `htu/park-score-signing-issue` | `67273e14fb` |
+
+The non-`main` checkouts are unrelated in-progress work by the operator; they are recorded only so the audit is reproducible, not because they contain implw-relevant changes. The `main` HEAD column is the canonical audit state.
+
+## What this refactor changes
+
+- **Moves out of zai:** execution (claude CLI install, checkout, `claude -p "implw ..."`).
+- **Stays in zai:** payload parse, target-repo validation against allow-list, dispatch of `repository_dispatch` to the target.
+- **New per-target-repo surface:** a dormant `.github/workflows/zilin-impl.yml` that listens on `repository_dispatch` type `zilin-impl` (hyphen) and is gated by `vars.ZILIN_IMPL_ENABLED == 'true'`. Dormant by default; activation is Phase 3+.

--- a/docs/router-dispatch-contract.md
+++ b/docs/router-dispatch-contract.md
@@ -1,0 +1,119 @@
+# Router Dispatch Contract
+
+Canonical reference for the `repository_dispatch` payload emitted by the ZAI router, the allow-list that gates it, and the rollback procedure. Drafted from `issues/2026-04-22__refactor__zai-router-dispatch-only.md` sections **Dispatch payload contract**, **Allow-list enforcement**, and **Rollback procedure**. Any change to the payload shape or the allow-list must land here and in the router workflow together.
+
+## Payload contract
+
+When the ZAI router is in `dispatch` mode for a given target repo, it fires `repository_dispatch` to that repo with:
+
+```json
+{
+  "event_type": "zilin-impl",
+  "client_payload": {
+    "issue_number": 123,
+    "target_repo": "zi007lin/streettt",
+    "spec_path": "issues/YYYY-MM-DD__type__title.scored.md",
+    "spec_type": "feat|bug|spec|chore|refactor|research|ux|brand",
+    "needs_approval": true,
+    "source_zai_run_url": "https://github.com/zi007lin/zai/actions/runs/..."
+  }
+}
+```
+
+### Field notes
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `issue_number` | integer | zai client_payload on inbound dispatch | Required; the issue on `zi007lin/zai` whose body contains the scored spec |
+| `target_repo` | string `org/repo` | parsed from `**Repo:**` in the spec body, or passed through from inbound payload | Must match the allow-list — see below |
+| `spec_path` | string | relative path inside target repo | E.g. `issues/2026-04-22__refactor__zai-router-dispatch-only.scored.md` |
+| `spec_type` | string enum | parsed from spec filename `YYYY-MM-DD__TYPE__title` | Drives downstream commit prefix + version bump |
+| `needs_approval` | boolean | inbound payload or computed per Gate 1 classifier | Target repo workflow may re-apply the approval gate |
+| `source_zai_run_url` | string URL | built in zai at dispatch time | Audit breadcrumb; points back to the zai router run |
+
+Event type is **`zilin-impl`** (hyphen), not `zilin_impl` (underscore). Underscore remains reserved for the inbound event the zai router itself listens on; hyphen is the outbound event type the router fires to target repos. This keeps the two sides distinguishable in runner logs and payload captures.
+
+## Allow-list
+
+The router refuses to dispatch to any repo outside this list. Prevents a malicious or malformed spec from targeting an arbitrary org/repo.
+
+```
+zi007lin/streettt
+zi007lin/htu.io
+zi007lin/nyqex
+zi007lin/htu-foundation
+zi007lin/zai
+```
+
+The allow-list lives inline in the router workflow (`.github/workflows/zilin-queue.yml`) as a `case` statement. Editing it is governed by the standard dual-PR process on `zi007lin/zai` — `daniel-silvers` is the only approver. No repo-variable indirection: the source of truth is the committed YAML.
+
+## Mode resolution
+
+Per-repo via repo variable `ZAI_DISPATCH_MODE_<REPO_SLUG>`:
+
+| Variable | Effect |
+|---|---|
+| `ZAI_DISPATCH_MODE_STREETTT=dispatch` | streettt → fired via `repository_dispatch` |
+| `ZAI_DISPATCH_MODE_STREETTT=legacy` or unset | streettt → executed in-place by zai router (current behavior) |
+| Same pattern for `HTU_IO`, `HTU_FOUNDATION`, `NYQEX`, `ZAI` | … |
+
+Slug rules: repository name lowercased, `.` and `-` rewritten to `_`, then uppercased. Examples:
+
+| Repo | Slug | Variable |
+|---|---|---|
+| `zi007lin/streettt` | `STREETTT` | `ZAI_DISPATCH_MODE_STREETTT` |
+| `zi007lin/htu.io` | `HTU_IO` | `ZAI_DISPATCH_MODE_HTU_IO` |
+| `zi007lin/htu-foundation` | `HTU_FOUNDATION` | `ZAI_DISPATCH_MODE_HTU_FOUNDATION` |
+| `zi007lin/nyqex` | `NYQEX` | `ZAI_DISPATCH_MODE_NYQEX` |
+| `zi007lin/zai` | `ZAI` | `ZAI_DISPATCH_MODE_ZAI` |
+
+Default (variable unset or any value other than `dispatch`): `legacy`.
+
+## Target-repo workflow gate
+
+Each target repo has `.github/workflows/zilin-impl.yml` gated by `vars.ZILIN_IMPL_ENABLED == 'true'`. When unset or `false` the job is a no-op: GitHub still delivers the dispatch, but the `if:` evaluates falsy and nothing runs.
+
+This means enabling dispatch mode is a **two-variable flip** per target repo:
+
+1. Set `ZAI_DISPATCH_MODE_<SLUG>=dispatch` on `zi007lin/zai` — zai starts firing.
+2. Set `ZILIN_IMPL_ENABLED=true` on the target repo — target starts executing.
+
+Either flip alone is safe: (1) without (2) delivers dispatches that no-op at the target. (2) without (1) delivers nothing because zai never dispatches.
+
+## Rollback procedure
+
+| Scope | Action | Data loss risk |
+|---|---|---|
+| Single repo, too hot | Set `ZAI_DISPATCH_MODE_<SLUG>=legacy` on zai | None — zai falls back to in-place execute |
+| All repos | Set all `ZAI_DISPATCH_MODE_*=legacy` on zai | None |
+| Full revert of the refactor | `git revert` the zai merge commit back to pre-refactor; dormant `zilin-impl.yml` files in target repos stay as-is (no-op) | None |
+| Emergency — dispatch delivered but target misbehaving | Set `ZILIN_IMPL_ENABLED=false` on the target repo; run `implw` from local WSL until fixed | None |
+
+### Pre-refactor anchor
+
+Pre-refactor SHA on `zi007lin/zai` main: **`36ac1014ea2dd80ad2c456b6ec30770929aa3383`**. Fast revert:
+
+```
+git revert -m 1 <merge-commit-of-this-PR>
+```
+
+or, if merged directly (non-merge commit):
+
+```
+git revert <commit-sha>
+```
+
+No database changes, no data migrations, no force-pushes — every rollback step is a config flip or a single revert.
+
+## Phase status at time of writing
+
+- **Phase 0** — audit doc (`docs/router-audit-2026-04-22.md`): landed in this PR.
+- **Phase 1** — dormant `zilin-impl.yml` in each target repo: separate PRs, not merged in this PR.
+- **Phase 2** — dual-mode router (this file + `.github/workflows/zilin-queue.yml` edit): landed in this PR.
+- **Phase 3+** — cutover (var flips, canary, per-repo soak): **out of scope for this PR**. No `ZAI_DISPATCH_MODE_*` or `ZILIN_IMPL_ENABLED` variables are being set anywhere by this change.
+
+## What this contract does not cover
+
+- Signing or verification of dispatch events (open question in the spec's Subject Migration Summary). Currently the target-repo workflow trusts any `repository_dispatch` of type `zilin-impl`; only accounts with `repository_dispatch` write permission on the target can send those. If we need to reject spoofed dispatches from a compromised but scoped token, add a signed payload field and verify in the target workflow. Tracked as a follow-up, not a blocker.
+- Durable audit log of every dispatch. Today the `source_zai_run_url` breadcrumb is the only record; if we want a queryable log we'd emit to an external sink. Tracked as a follow-up.
+- Shared-tooling location for Claude Code CLI install once each target repo has its own workflow. For Phase 1 the dormant workflows inherit the runner's ambient install; once Phase 3+ cutovers begin, we may factor the install step into a composite action. Tracked as a follow-up.


### PR DESCRIPTION
## Summary

Implements **Phases 0 and 2 only** of the spec in issue #58 (`issues/2026-04-22__refactor__zai-router-dispatch-only.md`). Adds the audit artifact and the dual-mode router; stops short of Phase 1 (target-repo dormant workflow files, which are in follow-up PRs on each target repo) and Phase 3+ (cutover).

## Files changed

- `docs/router-audit-2026-04-22.md` (new) — Phase 0 inventory.
- `docs/router-dispatch-contract.md` (new) — payload contract, allow-list, mode resolution, rollback.
- `.github/workflows/zilin-queue.yml` (modified) — dual-mode router.

## Call-outs for reviewer

### 1. Spec–file name mismatch (spec error, not impl error)

The spec's **Files created / updated** section lists the router workflow as `zi007lin/zai/.github/workflows/zilin_impl.yml`. The **actual file on disk** is `zi007lin/zai/.github/workflows/zilin-queue.yml` (workflow `name:` is `ZiLin Queue Listener`). Confirmed by `ls ~/dev/zai/.github/workflows/` at audit time — there is no `zilin_impl.yml`, only `zilin-queue.yml` and `runner-health.yml`. Treated as a spec-side naming error; this PR modifies the real file and notes the mismatch in `router-audit-2026-04-22.md` so the record is explicit.

The inbound dispatch **event type** remains `zilin_impl` (underscore, unchanged). The outbound dispatch event type fired by the router to target repos is `zilin-impl` (hyphen, new) — this is deliberate so the two sides are distinguishable in runner logs.

### 2. router-dispatch-contract.md provenance

Drafted directly from three sections of `issues/2026-04-22__refactor__zai-router-dispatch-only.md`:

- **Dispatch payload contract** — transcribed verbatim where the spec gave a JSON example; field-notes table is new editorial.
- **Allow-list enforcement** — the five-repo list is the spec's; the decision to embed it in the workflow as a `case` (rather than a repo variable) is documented as a choice, with rationale that "source of truth is the committed YAML" and editing remains gated by daniel-silvers approval on zai PRs.
- **Rollback procedure** — transcribed from the spec's rollback table; the pre-refactor SHA `36ac1014ea2dd80ad2c456b6ec30770929aa3383` was captured at branch creation and pinned into the doc per the spec's "Pre-refactor commit SHA must be pinned in the PR description and in `docs/router-dispatch-contract.md`" requirement.

Additions beyond the three sections: **Mode resolution** (slug rules + per-repo variable names) and **Target-repo workflow gate** (how `ZILIN_IMPL_ENABLED` interacts with `ZAI_DISPATCH_MODE_<SLUG>` to produce the two-flip activation). These flesh out implementation details the spec implied but didn't spell out.

### 3. Phase 0 audit is a point-in-time snapshot — reproducibility refs

The audit doc captures the state of each repo at audit time (2026-04-22). To reproduce, check out each repo at these refs and re-grep `.github/workflows/` for `implw`:

- **zi007lin/zai** — https://github.com/zi007lin/zai/tree/36ac1014ea2dd80ad2c456b6ec30770929aa3383 (`main` HEAD at audit)
- **zi007lin/streettt** — https://github.com/zi007lin/streettt/tree/134f84b0b2 (`main` HEAD at audit). Operator's checked-out branch at audit time: [`stt/match-prediction-league-spec`](https://github.com/zi007lin/streettt/tree/stt/match-prediction-league-spec) @ `b314049efd` — unrelated in-progress work, recorded for completeness.
- **zi007lin/htu.io** — https://github.com/zi007lin/htu.io/tree/0ee40e1e3f (`main` HEAD at audit). Checked-out branch: [`stt/home-page-history-audit`](https://github.com/zi007lin/htu.io/tree/stt/home-page-history-audit) @ `0dd8a94e79`.
- **zi007lin/htu-foundation** — https://github.com/zi007lin/htu-foundation/tree/c485815971 (`main` HEAD at audit). Checked-out branch: [`htu/park-score-signing-issue`](https://github.com/zi007lin/htu-foundation/tree/htu/park-score-signing-issue) @ `67273e14fb`.
- **zi007lin/nyqex** — repo does not exist on GitHub at audit time.

The `main`-branch SHAs are the canonical audit state; the non-`main` checkouts are my in-progress work and are called out purely for reproducibility honesty.

### 4. No variables set anywhere (per approval scope)

This PR deliberately does **not** set any of:
- `ZAI_DISPATCH_MODE_STREETTT`, `ZAI_DISPATCH_MODE_HTU_IO`, `ZAI_DISPATCH_MODE_HTU_FOUNDATION`, `ZAI_DISPATCH_MODE_NYQEX`, `ZAI_DISPATCH_MODE_ZAI` — router variables on zai
- `ZILIN_IMPL_ENABLED` — target-repo variable (will be referenced by Phase 1 dormant workflows but never set by any PR in this scope)

Default behavior: unset → `legacy` → **router behavior is unchanged** from today. Merging this PR is a pure code addition; cutover to dispatch mode is a deliberate separate action.

## Acceptance criteria — status against this PR

Per spec. Only criteria satisfied or advanced by this PR alone are checked:

- [x] ZAI router parses `**Repo:**` from scored spec and validates against allow-list.
- [x] ZAI router supports dual mode via `ZAI_DISPATCH_MODE_<REPO>` variable; default `legacy`.
- [x] `docs/router-dispatch-contract.md` documents payload, allow-list, and rollback.
- [ ] `zilin-impl.yml` exists in each target repo — **follow-up PRs B/C/D** (Phase 1).
- [ ] Target-repo workflow listens on `repository_dispatch` with event type `zilin-impl` — **follow-up PRs**.
- [ ] Concurrency group `impl-<repo>-<issue_number>` — **follow-up PRs** (lives in target-repo workflows).
- [ ] Feature flag `ZILIN_IMPL_ENABLED` default `false` in each target repo — **follow-up PRs**.
- [ ] Canary spec runs end-to-end in dispatch mode for each target repo — **Phase 3 (out of scope)**.
- [ ] Rollback tested: flipping mode back to `legacy` resumes in-place execution with no errors — **Phase 3 (out of scope)**.
- [ ] Issue #57 re-filed in `zi007lin/streettt` and runs cleanly through the dispatch path — **Phase 3 (out of scope)**.
- [ ] Legacy executor code path removed ≥30 days after Phase 4 completion — **Phase 5 (out of scope)**.

## Complexity & governance

- **Complexity estimate:** M (single-repo code + docs; multi-repo follow-ups tracked as separate PRs).
- **Reviewers:** daniel-silvers.
- **Dual-control gate:** standard — this approval covers impl start only; PR merge is daniel-silvers' call per governance.

## Test plan

- [ ] Review `router-dispatch-contract.md` for factual accuracy vs the spec.
- [ ] Review `zilin-queue.yml` diff: confirm allow-list case statement matches the five-repo list in the contract doc.
- [ ] Confirm default mode is `legacy` (variable unset path).
- [ ] Optional smoke: with all `ZAI_DISPATCH_MODE_*` unset, the workflow should run identically to pre-refactor — verify by firing a test `repository_dispatch` to this branch against a low-risk issue.
- [ ] Verify the `Resolve target repo and mode` step handles a payload with `target_repo` set AND a payload without it (fallback to `gh issue view`).

Refs: #58.