### PR TITLE
fix: update router allow-list and env-var names for v2 repo naming

### DIFF
--- a/.github/workflows/zilin-queue.yml
+++ b/.github/workflows/zilin-queue.yml
@@ -12,11 +12,17 @@ jobs:
       # Per-repo dispatch-mode flags. Unset -> legacy (existing in-place behavior).
       # Source of truth: repository variables on zi007lin/zai.
       # See docs/router-dispatch-contract.md#mode-resolution.
-      ZAI_DISPATCH_MODE_STREETTT: ${{ vars.ZAI_DISPATCH_MODE_STREETTT }}
+      # Slug derivation: TARGET_REPO basename, uppercased, dots and hyphens -> underscores.
+      # streettt.com -> STREETTT_COM ; nyqex.io -> NYQEX_IO ; sixpass.app -> SIXPASS_APP.
+      ZAI_DISPATCH_MODE_STREETTT_COM: ${{ vars.ZAI_DISPATCH_MODE_STREETTT_COM }}
       ZAI_DISPATCH_MODE_HTU_IO: ${{ vars.ZAI_DISPATCH_MODE_HTU_IO }}
       ZAI_DISPATCH_MODE_HTU_FOUNDATION: ${{ vars.ZAI_DISPATCH_MODE_HTU_FOUNDATION }}
-      ZAI_DISPATCH_MODE_NYQEX: ${{ vars.ZAI_DISPATCH_MODE_NYQEX }}
+      ZAI_DISPATCH_MODE_NYQEX_IO: ${{ vars.ZAI_DISPATCH_MODE_NYQEX_IO }}
       ZAI_DISPATCH_MODE_ZAI: ${{ vars.ZAI_DISPATCH_MODE_ZAI }}
+      ZAI_DISPATCH_MODE_SIXPASS_APP: ${{ vars.ZAI_DISPATCH_MODE_SIXPASS_APP }}
+      ZAI_DISPATCH_MODE_THEICTE_COM: ${{ vars.ZAI_DISPATCH_MODE_THEICTE_COM }}
+      ZAI_DISPATCH_MODE_MEDICSHARE_COM: ${{ vars.ZAI_DISPATCH_MODE_MEDICSHARE_COM }}
+      ZAI_DISPATCH_MODE_SHOPLEMENT_COM: ${{ vars.ZAI_DISPATCH_MODE_SHOPLEMENT_COM }}
     steps:
       - name: Ensure Claude Code CLI on PATH
         run: |
@@ -70,8 +76,28 @@ jobs:
 
           # Allow-list. Edits to this case statement require a dual-PR merge on
           # zi007lin/zai (daniel-silvers approves). See docs/router-dispatch-contract.md#allow-list.
+          # Repo names follow htu-foundation CLAUDE.md Hard Rule: registered domains use full
+          # domain (with TLD); non-domain repos use bare slug. See htu-foundation#33.
           case "$TARGET_REPO" in
-            zi007lin/streettt|zi007lin/htu.io|zi007lin/nyqex|zi007lin/htu-foundation|zi007lin/zai)
+            zi007lin/streettt.com | \
+            zi007lin/streettt-private | \
+            zi007lin/htu.io | \
+            zi007lin/nyqex.io | \
+            zi007lin/zzv.io | \
+            zi007lin/theicte.com | \
+            zi007lin/sixpass.app | \
+            zi007lin/medicshare.com | \
+            zi007lin/shoplement.com | \
+            zi007lin/htu-foundation | \
+            zi007lin/htu-governance | \
+            zi007lin/zai | \
+            zi007lin/htu-legal | \
+            zi007lin/httc-framework | \
+            zi007lin/zzvchain | \
+            zi007lin/zzv-engine-net8 | \
+            zi007lin/zzv-engine-py | \
+            zi007lin/zzv-mid-layer | \
+            zi007lin/zzv-win-sentinel)
               ;;
             *)
               echo "::error::target_repo $TARGET_REPO not in allow-list"


### PR DESCRIPTION
## Summary

Updates the ZAI router workflow (`.github/workflows/zilin-queue.yml`) to reflect the post-rename HTU repo state codified in [zi007lin/htu-foundation#33](https://github.com/zi007lin/htu-foundation/issues/33) (repo naming standardization v2).

- Replaces the 5-entry allow-list with the canonical 19-entry list of active HTU repos
- Renames env-var declarations to match the slug-derivation rule for the renamed repos
- Adds env-var declarations for the four new/renamed product repos

## Why

The dispatcher previously rejected `zi007lin/streettt.com` (the new URL after step 4 rename) because the allow-list still listed the bare slug `streettt`. This PR is the unblocking change for issue #33's smoke test (step 11) — the rename in step 4 is already done; without this allow-list update, dispatches to `streettt.com` get `target_repo not in allow-list`.

The `NYQEX` env var was a separate latent bug — see Scope notes below.

## Changes

```
.github/workflows/zilin-queue.yml | 32 +++++++++++++++++++++++++-------
1 file changed, 29 insertions(+), 3 deletions(-)
```

### Allow-list (19 entries)

```
zi007lin/streettt.com         zi007lin/htu-foundation
zi007lin/streettt-private     zi007lin/htu-governance
zi007lin/htu.io               zi007lin/zai
zi007lin/nyqex.io             zi007lin/htu-legal
zi007lin/zzv.io               zi007lin/httc-framework
zi007lin/theicte.com          zi007lin/zzvchain
zi007lin/sixpass.app          zi007lin/zzv-engine-net8
zi007lin/medicshare.com       zi007lin/zzv-engine-py
zi007lin/shoplement.com       zi007lin/zzv-mid-layer
                              zi007lin/zzv-win-sentinel
```

### Env-var declarations

| Before | After | Reason |
|---|---|---|
| `ZAI_DISPATCH_MODE_STREETTT` | `ZAI_DISPATCH_MODE_STREETTT_COM` | Repo renamed; slug rederives |
| `ZAI_DISPATCH_MODE_HTU_IO` | (unchanged) | Already correct |
| `ZAI_DISPATCH_MODE_HTU_FOUNDATION` | (unchanged) | Already correct |
| `ZAI_DISPATCH_MODE_NYQEX` | `ZAI_DISPATCH_MODE_NYQEX_IO` | **Drive-by fix** — see Scope notes |
| `ZAI_DISPATCH_MODE_ZAI` | (unchanged) | Already correct |
| (new) | `ZAI_DISPATCH_MODE_SIXPASS_APP` | sixpass renamed |
| (new) | `ZAI_DISPATCH_MODE_THEICTE_COM` | new repo |
| (new) | `ZAI_DISPATCH_MODE_MEDICSHARE_COM` | new repo |
| (new) | `ZAI_DISPATCH_MODE_SHOPLEMENT_COM` | new repo |

## Scope notes

The spec's acceptance criteria (htu-foundation#33) explicitly mentions only `STREETTT_COM` and `SIXPASS_APP` env vars. This PR additionally fixes `NYQEX → NYQEX_IO` as an opportunistic drive-by:

- The repo is `zi007lin/nyqex.io` (and has been since long before v2)
- The slug derivation script computes `nyqex.io → NYQEX_IO`
- The env var was declared as `NYQEX`, which never matched
- Result: dispatch-mode resolution for `nyqex.io` silently fell back to legacy mode regardless of the configured `vars.ZAI_DISPATCH_MODE_NYQEX`

This is the same class of bug as `STREETTT → STREETTT_COM` (slug mismatch). Bundling it here keeps the fix-classes together. If you'd prefer it landed separately, I can split into two PRs — let me know.

## Verification

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/zilin-queue.yml'))"
(no output — parse OK)

$ bash -n  # case statement syntax check
(no output — syntax OK)

$ for repo in streettt.com sixpass.app zzv.io htu-foundation zzv-win-sentinel some-other-repo; do
    case "zi007lin/$repo" in <19-entry list>) echo "$repo ALLOWED" ;; *) echo "$repo REJECTED" ;; esac
  done
streettt.com ALLOWED
sixpass.app ALLOWED
zzv.io ALLOWED
htu-foundation ALLOWED
zzv-win-sentinel ALLOWED
some-other-repo REJECTED
```

## Test plan

- [ ] daniel-silvers reviews diff
- [ ] After merge, dispatch a trivial read-only chore to `zi007lin/streettt.com` and confirm logs show `Resolved: target_repo=zi007lin/streettt.com slug=STREETTT_COM mode=legacy` (this is htu-foundation#33 step 11)
- [ ] If desired, set `vars.ZAI_DISPATCH_MODE_STREETTT_COM = dispatch` on zi007lin/zai to flip streettt.com to dispatch mode (formerly governed by the broken `STREETTT` var)

## Related

- Parent: [zi007lin/htu-foundation#33](https://github.com/zi007lin/htu-foundation/issues/33)
- Sibling PR (htu-foundation): pending — will reference this PR's URL