### PR TITLE
chore: align Gate 1 threshold doc references with rubric v1.3.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ verification (Option A) once `SCORE_SIGNING_KEY` is live on the runner. See
 
 Before impl runs, every spec is classified:
 
-- **Trivial** (`chore` 2/2, `hotfix` 3/3, no gates listed in the score block):
+- **Trivial** (`chore` 5/5, `hotfix` 3/3, no gates listed in the score block):
   AUTO — proceeds immediately
 - **Non-trivial** (`feat`, `bug`, `research`, or any spec with one or more items
   in `gates[]`, or any spec referencing a force-push / history rewrite /

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each stage has a command: `spec`, `eval`, `impl`, `review`, `deploy`, `autopilot
 
 ## Try the scorer
 
-The first piece of the SDD pipeline is live as a web scorer at **[demo.zai.htu.io/app](https://demo.zai.htu.io/app)**. Drop any `.md` spec file into the upload zone and you'll get a deterministic, type-aware score — `feat` 7/7, `research` 6/6, `bug` 5/5, `chore` 2/2, or `hotfix` 3/3 — with a per-section breakdown and any pre-deploy gates the spec declares. Pure structural analysis, no LLM judgment; human review still required.
+The first piece of the SDD pipeline is live as a web scorer at **[demo.zai.htu.io/app](https://demo.zai.htu.io/app)**. Drop any `.md` spec file into the upload zone and you'll get a deterministic, type-aware score — `feat` 7/7, `research` 6/6, `bug` 5/5, `chore` 5/5, or `hotfix` 3/3 — with a per-section breakdown and any pre-deploy gates the spec declares. Pure structural analysis, no LLM judgment; human review still required.
 
 ---
 


### PR DESCRIPTION
Closes #75

## Summary

Updates `CLAUDE.md` line 42 and `README.md` line 37 from `chore 2/2` to `chore 5/5` so the public Gate 1 / scorer descriptions match the live `scoreSpec.ts` emission under rubric v1.3.1. Doc-only — no code or tests touched.

## Acceptance criteria

- [x] `CLAUDE.md` line 42 references `chore 5/5`, not `chore 2/2`
- [x] `README.md` line 37 uses matching threshold language
- [x] `grep -rn 'chore 2/2' --include='*.md' .` returns hits only in `issues/` files dated 2026-04-13 through 2026-04-19 (frozen historical artifacts)
- [x] No code files modified — doc-only
- [x] No local paths, command inventories, or internal module paths in the spec body or PR
- [x] daniel-silvers requested as reviewer

## Score

- Rubric: v1.3.1
- Type: chore
- Score: 5/5 — Passed: YES
- Sections: intent, action, acceptance_criteria, files, legal_triggers — all PASS