### PR TITLE
feat: ZAI MCP server (demo subset, score_spec only) (#80)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,76 @@
+name: Publish @htu/zai-mcp
+
+# Manual-trigger only. Does NOT auto-publish on merge or tag — the npm
+# scope @htu must be registered manually first, and a wrong publish leaves
+# a permanent shadow on the registry. The PR-time job below validates that
+# the package builds and packs cleanly so this workflow is ready when
+# called.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.0). Must match packages/zai-mcp/package.json."
+        required: true
+        type: string
+      dry_run:
+        description: "Skip the actual npm publish — only run the build + pack."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write  # for npm provenance, when enabled
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/zai-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install (root, with workspaces)
+        working-directory: .
+        run: npm ci
+
+      - name: Verify version matches input
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ inputs.version }}" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match dispatch input (${{ inputs.version }})"
+            exit 1
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Pack (always — verifies the tarball)
+        run: npm pack --dry-run
+
+      - name: Publish
+        if: ${{ inputs.dry_run == false }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Publish summary"
+            echo ""
+            echo "- Package: \`@htu/zai-mcp\`"
+            echo "- Version: \`${{ inputs.version }}\`"
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+            echo "- Outcome: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zai-mcp-pack-check.yml
+++ b/.github/workflows/zai-mcp-pack-check.yml
@@ -1,0 +1,47 @@
+name: zai-mcp pack check
+
+# PR-time validation: build + test + pack-dry-run for the zai-mcp package
+# only when its files change. Catches packaging issues (missing bin entry,
+# wrong files glob, broken tsup output) before merge, not at publish time.
+on:
+  pull_request:
+    paths:
+      - "packages/zai-mcp/**"
+      - "src/lib/scoreSpec.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/zai-mcp-pack-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/zai-mcp/**"
+      - "src/lib/scoreSpec.ts"
+
+permissions:
+  contents: read
+
+jobs:
+  pack-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/zai-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install (root, with workspaces)
+        working-directory: .
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Pack dry-run
+        run: npm pack --dry-run

--- a/issues/2026-04-28__feat__zai-mcp-demo-score-spec.md
+++ b/issues/2026-04-28__feat__zai-mcp-demo-score-spec.md
@@ -1,0 +1,276 @@
+# 2026-04-28 · feat · ZAI MCP server (demo subset, score_spec only) — v1
+
+## Intent
+
+Build a minimum-viable MCP server for ZAI that exposes a single tool, `score_spec`, callable via stdio transport from Claude Desktop, Cursor, Cline, and other MCP-capable LLM agents. The tool accepts a markdown spec body and a spec type, runs ZAI's existing rubric scoring engine in-process, and returns the structured score (per-check pass/fail with error messages). No authentication. No state mutation. Anonymous-only with per-IP rate limiting via existing ZAI infrastructure. Goal: enable live demonstrations of AI-driven spec-first development to prospective C2C clients within days, not weeks. Subset of the parent SPEC `2026-04-28__spec__zai-mcp-server-v1` (to be drafted separately); other tools deferred until a buyer asks for them.
+
+## Decision Tree
+
+| Question | Options | Chosen | Why |
+|---|---|---|---|
+| Transport | stdio only / streamable-HTTP / both | stdio only | Claude Desktop, Cursor, Cline all support stdio first; no remote deployment complexity; ships fastest |
+| Tools exposed | many / a few / one | one (`score_spec`) | Minimum demoable surface; matches the existing "drop a spec, see it scored" magic moment |
+| Authentication | passkey / API token / anonymous | anonymous | Caller identity is the LLM client (Claude Desktop user); no need for separate auth in v1 |
+| Rate limiting | per-IP / per-process / none | per-IP via existing ZAI rate limiter | Reuses existing infra; prevents abuse; no new code path |
+| Implementation language | Python / TypeScript / Go | TypeScript | zai repo is TS; reuse the existing rubric scoring code unchanged |
+| MCP SDK | official Anthropic / community | `@modelcontextprotocol/sdk` (official) | Stable, well-documented, owned by Anthropic, reduces drift risk |
+| State storage | none / D1 / KV | none | Stateless function call; no persistence needed in v1 |
+| Distribution | npm package / Docker image / both | npm package only for v1 | Stdio is process-spawn; Claude Desktop launches `npx zai-mcp`; Docker can be added later if Streamable-HTTP becomes needed |
+| Versioning of returned scores | numeric only / structured / structured + raw | structured: `{score, max, type, checks[{name, pass, error?}], rubric_version}` | Enables LLM agents to reason about specific failures; future-compatible with rubric updates |
+| Error model | throw on bad input / return error in payload | return error in payload | MCP protocol prefers tool errors as data, not exceptions; agent can handle gracefully |
+
+### Trigger for change
+
+Bump to v2 when any of the following becomes true:
+- A buyer asks for `file_issue`, `draft_spec`, or `trigger_implw` during a demo (file `feat__zai-mcp-write-tools-v1` per the parent SPEC)
+- Streamable-HTTP transport becomes needed (remote deployment, server-side hosted MCP)
+- ZAI rubric versioning changes shape (rare, per the parent SPEC)
+- More than one buyer reports the score JSON shape doesn't fit their LLM's tool-use parser
+
+## Draft-of-thoughts
+
+The temptation is to build a "real" MCP server with auth, multiple tools, and persistence. That's a 5-7 week investment that doesn't pay off until weeks 5-7. Wrong tradeoff for a hungry-consultant timeline.
+
+The minimum demoable subset is exactly one tool: `score_spec`. With that one tool, a buyer in a 15-minute demo sees: (a) the methodology has structure (rubric exists, scores are deterministic), (b) AI agents can drive it programmatically (Claude Desktop calls the MCP tool, watches the score come back), (c) integration is a one-line config in any MCP-capable client. Everything else the buyer cares about — file creation, PR opening, pipeline triggering — can be discussed verbally ("we can wire that next, here's the architecture"), not demonstrated.
+
+Stateless + anonymous + stdio reduces this to: one TypeScript file (~200 lines), one npm package, one README, one Claude Desktop config snippet. Implementable in hours, not weeks. ZiLin-Dev can ship this today.
+
+The risk of starting narrow is that v1 looks toy-like to a sophisticated buyer. Mitigation: the demo flow ends with verbal walkthrough of the parent SPEC architecture (showing this is intentionally a demo subset, not the limit of the offering). Buyers who want production-grade get pointed at the parent SPEC's roadmap.
+
+## Final Spec
+
+### Package
+
+- npm package name: `@htu/zai-mcp` (scope reserved or registered as part of this work)
+- Binary entry: `zai-mcp` (stdio MCP server)
+- Public installation: `npx -y @htu/zai-mcp` (no install step required for end users)
+
+### Tool: `score_spec`
+
+Input schema:
+
+```typescript
+{
+  content: string,          // raw markdown spec body, ≤200KB
+  type: 'feat' | 'bug' | 'spec' | 'chore' | 'refactor' | 'ux' | 'brand',
+  bundles?: string[]        // optional: ['healthcare', 'fintech', etc.] per existing ZAI bundle catalog
+}
+```
+
+Output schema:
+
+```typescript
+{
+  score: number,            // count of passing checks
+  max: number,              // total checks for this type+bundles
+  passed: boolean,          // score === max
+  type: string,             // echo of input type
+  rubric_version: string,   // e.g., "v1.3.1"
+  checks: Array<{
+    name: string,           // e.g., "Intent", "Game Theory Cooperative"
+    pass: boolean,
+    error?: string          // present when pass=false
+  }>,
+  models_applied?: Array<{  // optional, per FEAT/REFACTOR rubric items
+    id: number,
+    name: string,
+    declared: boolean,
+    detected: boolean,
+    status: 'green' | 'yellow' | 'red'
+  }>,
+  warnings?: string[]       // e.g., from Legal triggers keyword scan
+}
+```
+
+### Rate limit
+
+Per remote-IP (extracted from MCP client connection metadata when available; falls back to per-process limit when stdio with no IP):
+
+- 30 calls per minute per IP
+- 200 calls per hour per IP
+- 1000 calls per day per IP
+
+Exceeded → tool returns `{ error: "rate_limited", retry_after_seconds: N }` as a normal MCP tool response (not a transport error).
+
+### No persistence
+
+The MCP server retains no state between calls. No logging of spec content. No caching of results. Reuses the existing ZAI scoring code path which is already pure-function.
+
+### Claude Desktop config snippet (delivered in README)
+
+```json
+{
+  "mcpServers": {
+    "zai": {
+      "command": "npx",
+      "args": ["-y", "@htu/zai-mcp"]
+    }
+  }
+}
+```
+
+User adds to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent. Restart Claude Desktop. Tool appears.
+
+## Acceptance Criteria
+
+- [ ] `npx -y @htu/zai-mcp` starts an MCP server that responds to `initialize`, `tools/list`, and `tools/call` per MCP protocol spec
+- [ ] `tools/list` returns exactly one tool, `score_spec`, with the input schema above
+- [ ] `tools/call score_spec` with valid input returns a structured response matching the output schema above
+- [ ] Score values for a given input are byte-identical to scores returned by the existing `zai.htu.io/app` web UI (parity test)
+- [ ] Rate limits enforced per the spec; over-limit returns structured error, not exception
+- [ ] Empty `content` returns structured validation error (not exception)
+- [ ] Invalid `type` returns structured validation error
+- [ ] Spec content >200KB returns structured size error
+- [ ] No spec content appears in any log output (server stderr is empty during normal operation)
+- [ ] Vitest unit tests cover: parity with web UI, rate limit enforcement, error responses, ≥85% line coverage
+- [ ] Integration test using `@modelcontextprotocol/sdk/client` confirms end-to-end protocol flow
+- [ ] README documents Claude Desktop install in <10 lines
+- [ ] README includes an example LLM transcript showing `score_spec` being called and the response interpreted
+- [ ] PR includes a 30-second screencast (gif or mp4) showing Claude Desktop calling the tool
+- [ ] All 9 ZAI FEAT rubric checks pass on the scored spec
+- [ ] daniel-silvers approval recorded on PR before merge
+
+## Game Theory Cooperative Model review
+
+Three parties: the consultant offering the methodology (HTU), the prospective buyer evaluating it, and the LLM platform vendor (Anthropic) hosting the agent that drives the MCP tool. Cooperative equilibrium: HTU exposes the methodology programmatically, buyers can verify it without commitment, Anthropic gets a showcase MCP integration. All three parties strictly prefer "tool exists and works" over "tool doesn't exist."
+
+Operationally enforced by:
+- Stateless tool — no buyer data is captured during the demo, removing trust friction
+- Open-source MCP server code (planned, license TBD; likely MIT or Apache-2.0) — buyers can audit before connecting their LLM
+- Returns same structured data the public web UI already exposes — no information asymmetry between demo and production
+
+### Who benefits
+
+Five cooperators, each strictly better off than under the alternative ("no MCP, manual scoring only"):
+
+1. The consultant (HTU operator) — gains a live demonstrable proof of methodology that converts buyer conversations to discovery calls faster than verbal claims alone. Time-to-revenue compresses from 60-120 days (build-everything-first) to 14-45 days (demo-now-build-as-needed).
+2. The prospective buyer — can validate the methodology in their own environment using their own LLM client in 5 minutes. Reduces evaluation cost from "schedule a deep technical review" to "drop a spec into Claude Desktop."
+3. The LLM vendor (Anthropic) — gains an additional production MCP integration, strengthens the MCP ecosystem story, no cost of integration to them.
+4. Future paid-tier customers — when authenticated MCP tools (`file_issue`, `trigger_implw`) ship, they inherit the proven foundation; no rebuild.
+5. The methodology itself — practicing what it preaches. ZiLin Methodology says spec-driven AI development; if HTU's own ZAI is driveable from AI agents via standard protocol, that's the strongest possible proof.
+
+No party in the game has a defection that improves their payoff. The consultant gains nothing by withholding the tool; the buyer gains nothing by paying without verification; the vendor gains nothing by blocking integration.
+
+### Abuse vector
+
+Hostile cases considered:
+
+1. Spammer floods `score_spec` calls to exhaust ZAI compute. Mitigation: per-IP rate limits enforced via existing ZAI infrastructure. Worst case: rate limit triggers, tool returns rate-limit response, attacker wastes their own time.
+2. Adversary submits 200KB of malformed markdown to crash parser. Mitigation: input size cap, content validation, structured error response on parse failure. Parser is the same code as the web UI, already battle-tested.
+3. Spec content extraction via timing side-channels. Mitigation: scoring is constant-time per check (rubric is structural pattern matching); no input-dependent branching that would leak content shape.
+4. Supply-chain attack on `@htu/zai-mcp` npm package. Mitigation: package published from a CI workflow with signed tags; daniel-silvers approval required for releases; lockfile committed; minimal dependencies (only `@modelcontextprotocol/sdk` and the existing ZAI rubric module from the zai repo).
+5. LLM agent uses the MCP tool to draft adversarial specs that pass ZAI but encode intent harmful to the operator's downstream systems. Mitigation: out of scope — `score_spec` only scores; it does not file issues or trigger pipelines. Downstream defense (auth + ZiLin-Dev validation) belongs to other FEATs.
+6. Rate-limit evasion via VPN/proxy rotation. Mitigation: bounded by per-day caps; high friction relative to value extracted (free score-only access is also publicly available via the web UI).
+
+The dominant strategy under all considered adversaries is for HTU to maintain stateless+rate-limited semantics; deviation provides no operator benefit and inflates breach surface.
+
+## Subject Migration Summary
+
+| Subject | From | To | Notes |
+|---|---|---|---|
+| ZAI scoring access surface | web UI only (`zai.htu.io/app`) + REST API (`POST /api/v1/validate`) | web UI + REST API + MCP stdio server | Additive, non-breaking |
+| MCP integration on the htu portfolio | none | `@htu/zai-mcp` published to npm | First MCP integration in the portfolio |
+| ZiLin Methodology demonstration | web UI screenshot during sales calls | live invocation from the buyer's own LLM client | Demonstrably real, not a brochure |
+| Buyer evaluation friction | "schedule a technical review" | "drop a spec into your Claude Desktop, see the score in 2 seconds" | Reduces evaluation activation energy |
+| Open questions | — | — | Should the MCP server expose `bundles` parameter or auto-detect from spec content? Should there be a `version` tool that reports rubric version separately from each call? Should the npm package be public or scoped private to invited buyers initially? Resolve at implementation time or first buyer feedback. |
+
+## Files created / updated
+
+```
+zai/                                                                 [existing repo]
+├── packages/
+│   └── zai-mcp/                                                    [new package]
+│       ├── package.json                                            [new]
+│       ├── tsconfig.json                                           [new]
+│       ├── src/
+│       │   ├── index.ts                                            [new] MCP server entry, stdio transport setup
+│       │   ├── tools/
+│       │   │   └── score-spec.ts                                   [new] tool definition + handler
+│       │   ├── rate-limit.ts                                       [new] per-IP rate limiter, in-memory
+│       │   └── score-engine.ts                                     [new] re-export of existing ZAI rubric scoring
+│       ├── tests/
+│       │   ├── unit/
+│       │   │   ├── score-spec.test.ts                              [new]
+│       │   │   ├── rate-limit.test.ts                              [new]
+│       │   │   └── parity-with-web-ui.test.ts                      [new] critical: same input → same output as web
+│       │   └── integration/
+│       │       └── mcp-protocol.test.ts                            [new] uses @modelcontextprotocol/sdk/client
+│       ├── README.md                                               [new] install + Claude Desktop config + transcript
+│       └── DEMO.md                                                 [new] sample transcripts for screencast capture
+├── src/scoring/                                                    [existing path, may differ]
+│   └── (existing files re-exported by score-engine.ts)             [no edits]
+├── package.json                                                    [edit] add workspaces or lerna config if not present
+├── pnpm-workspace.yaml or similar                                  [edit if monorepo tooling present]
+└── .github/workflows/
+    └── publish-mcp.yml                                             [new] CI workflow to publish on tag, requires daniel-silvers approval gate
+```
+
+## Models Applied
+
+The following models from the canonical 16-model catalog were applied; structural evidence noted for ZAI Pass B detection:
+
+- #1 Game Theory Cooperative — see `## Game Theory Cooperative Model review` (three-party game), `### Who benefits` (five cooperators), `### Abuse vector` (six adversary cases)
+- #2 Decision Tree — see `## Decision Tree` table with Options/Chosen/Why + `### Trigger for change`
+- #3 Draft-of-thoughts — see `## Draft-of-thoughts` section
+- #5 Flywheel — friction reduction in buyer evaluation: longer demos → shorter demos → instant verification → faster discovery calls → faster contracts
+- #11 Progressive Disclosure — single tool now, additional tools (file_issue, trigger_implw) deferred to subsequent FEATs based on buyer demand signals
+- #15 Inversion / Premortem — see `### Abuse vector` and `## Draft-of-thoughts` (the "what makes this fail" reasoning)
+- #16 Mechanism Design — anonymous + stateless + rate-limited makes defection structurally impossible to extract value from; cooperators retain full benefit
+
+## Legal triggers
+
+Trigger #4 — open source license declaration. The package will be published to npm; license must be declared. Recommend MIT or Apache-2.0 to maximize adoption (MCP ecosystem norm). Final license choice deferred to PR review; counsel touch unnecessary for permissive open-source licensing of a tool that wraps the operator's own scoring engine.
+
+Trigger #7 — npm package naming. The `@htu` scope must be available on npm or registered before publish. Verify availability before merge; if `@htu` is taken, fall back to `@htu-io` or `@hightechunited`. No legal risk in any of these names — none collides with known trademarks for similar developer tools.
+
+No PII, no third-party data, no contract clauses, no royalty obligations, no liability exposure beyond standard "as-is" disclaimer required by the npm license.
+
+## Run locally (optional)
+
+```bash
+# WSL
+cp /mnt/c/Users/zilin/Downloads/2026-04-28__feat__zai-mcp-demo-score-spec-v1.scored.md \
+   ~/dev/zai/issues/2026-04-28__feat__zai-mcp-demo-score-spec.md
+
+cd ~/dev/zai
+git fetch origin && git checkout $(gh repo view --json defaultBranchRef -q .defaultBranchRef.name) && git pull --ff-only
+
+# Verify required labels exist on zai (file label-prep micro-chore if missing, per the htu.io
+# governance rule that requires repo-state changes go through specs)
+gh label list --repo zi007lin/zai --json name -q '.[].name' | grep -ixE 'feat|mcp|demo'
+
+gh issue create \
+  --repo zi007lin/zai \
+  --title "feat: ZAI MCP server (demo subset, score_spec only)" \
+  --body-file issues/2026-04-28__feat__zai-mcp-demo-score-spec.md \
+  --label feat
+
+# Note the issue number, then:
+implw <number>
+```
+
+After merge, install in Claude Desktop and verify in <5 minutes. The demo is then live.
+
+---
+
+## ZAI Spec Score
+
+- **Rubric version:** 1.3.1
+- **Spec type:** feat
+- **Evaluated at:** 2026-04-29T05:20:14.306Z
+- **Score:** 9/9
+- **Passed:** YES
+
+| Section | Status |
+|---|---|
+| intent | PASS |
+| decision_tree | PASS |
+| final_spec | PASS |
+| acceptance_criteria | PASS |
+| game_theory | PASS |
+| migration_summary | PASS |
+| files_list | PASS |
+| models_applied | PASS |
+| legal_triggers | PASS |
+
+_Source: 2026-04-28__feat__zai-mcp-demo-score-spec-v1.md_

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "zai",
       "version": "0.1.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "hono": "^4.6.0",
         "i18next": "^23.15.0",
@@ -1189,6 +1192,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@htu/zai-mcp": {
+      "resolved": "packages/zai-mcp",
+      "link": true
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
@@ -1617,6 +1636,64 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2722,6 +2799,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2857,6 +2944,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2878,6 +2978,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2904,6 +3037,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2965,6 +3105,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -2999,6 +3163,70 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -3028,6 +3256,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/color": {
@@ -3079,6 +3323,55 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3090,10 +3383,49 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-tree": {
@@ -3149,7 +3481,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3176,6 +3507,15 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3205,12 +3545,41 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
       "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -3239,12 +3608,42 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3295,6 +3694,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3314,6 +3719,36 @@
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/exit-hook": {
       "version": "2.2.1",
@@ -3338,12 +3773,95 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3363,6 +3881,57 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3378,6 +3947,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3386,6 +3964,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-source": {
@@ -3406,12 +4021,48 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hono": {
       "version": "4.12.12",
@@ -3444,6 +4095,26 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/i18next": {
       "version": "23.16.8",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
@@ -3467,6 +4138,22 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3475,6 +4162,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
@@ -3492,6 +4203,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3500,6 +4223,25 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -3581,6 +4323,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3856,6 +4610,36 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3899,12 +4683,42 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -3917,6 +4731,31 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/min-indent": {
@@ -3955,11 +4794,36 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -3970,6 +4834,18 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -3991,12 +4867,42 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4016,6 +4922,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -4027,6 +4954,24 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -4061,6 +5006,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/playwright": {
@@ -4139,6 +5115,49 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -4162,6 +5181,19 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4170,6 +5202,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -4241,6 +5312,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4259,10 +5344,19 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rolldown": {
@@ -4394,6 +5488,38 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4425,6 +5551,57 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -4479,6 +5656,99 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4545,6 +5815,15 @@
         "get-source": "^2.0.12"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -4576,6 +5855,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4602,6 +5904,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -4668,6 +5993,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -4694,6 +6028,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4701,6 +6052,574 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -4736,6 +6655,13 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
@@ -4748,6 +6674,15 @@
         "ohash": "^2.0.10",
         "pathe": "^2.0.3",
         "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4779,6 +6714,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -5561,6 +7505,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6049,6 +8008,12 @@
         "@esbuild/win32-x64": "0.17.19"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -6115,6 +8080,26 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/zai-mcp": {
+      "name": "@htu/zai-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "zai-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.2",
+        "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/packages/zai-mcp/DEMO.md
+++ b/packages/zai-mcp/DEMO.md
@@ -1,0 +1,111 @@
+# Demo transcripts
+
+Sample exchanges between an LLM agent and the `score_spec` tool, useful for sales calls, onboarding, and screencast capture.
+
+## Transcript 1 — passing FEAT spec
+
+**Operator:** Claude, score the spec at `examples/sample-feat.md` as type `feat`.
+
+**Claude (tool call):**
+
+```json
+{
+  "tool": "score_spec",
+  "input": {
+    "content": "<contents of examples/sample-feat.md>",
+    "type": "feat"
+  }
+}
+```
+
+**Tool response:**
+
+```json
+{
+  "score": 9,
+  "max": 9,
+  "passed": true,
+  "type": "feat",
+  "rubric_version": "1.3.1",
+  "checks": [
+    { "name": "Intent", "pass": true },
+    { "name": "Decision Tree", "pass": true },
+    { "name": "Final Spec", "pass": true },
+    { "name": "Acceptance Criteria", "pass": true },
+    { "name": "Game Theory Cooperative review", "pass": true },
+    { "name": "Subject Migration Summary", "pass": true },
+    { "name": "Files created / updated", "pass": true },
+    { "name": "Models Applied", "pass": true },
+    { "name": "Legal triggers", "pass": true }
+  ]
+}
+```
+
+**Claude:** All 9 ZAI FEAT rubric checks passed. The spec is cleared to ship.
+
+## Transcript 2 — failing spec, agent reports per-check failures
+
+**Operator:** Score this draft as type `feat`. *(pastes a draft missing Models Applied and Legal triggers sections)*
+
+**Tool response (truncated):**
+
+```json
+{
+  "score": 7,
+  "max": 9,
+  "passed": false,
+  "type": "feat",
+  "rubric_version": "1.3.1",
+  "checks": [
+    { "name": "Intent", "pass": true },
+    { "name": "Decision Tree", "pass": true },
+    { "name": "Models Applied", "pass": false, "error": "Section heading '## Models Applied' not found" },
+    { "name": "Legal triggers", "pass": false, "error": "Section heading '## Legal triggers' not found" }
+  ]
+}
+```
+
+**Claude:** Two sections are missing: **Models Applied** and **Legal triggers**. Add `## Models Applied` listing the canonical models you applied, and `## Legal triggers` listing any compliance/contract triggers (or "None"). Re-score after.
+
+## Transcript 3 — invalid input
+
+**Operator:** Score this with type `urgent`.
+
+**Tool response:**
+
+```json
+{
+  "error": "invalid_input",
+  "message": "type must be one of: feat, bug, hotfix, spec, chore, refactor, research, ux, brand"
+}
+```
+
+**Claude:** `urgent` isn't a valid spec type. Did you mean `hotfix`?
+
+## Transcript 4 — rate-limited
+
+**Operator:** *(after 30 calls within a minute)* Score this one too.
+
+**Tool response:**
+
+```json
+{
+  "error": "rate_limited",
+  "retry_after_seconds": 47,
+  "remaining": { "minute": 0, "hour": 170, "day": 970 }
+}
+```
+
+**Claude:** Per-minute rate limit reached. Retry in ~47 seconds.
+
+## Recording a screencast
+
+For PR submissions and sales decks:
+
+1. Install the package locally: `cd packages/zai-mcp && npm run build && npm link`
+2. Add the Claude Desktop config snippet from README.md (use `command: "node"`, `args: ["/abs/path/to/dist/index.js"]` for the linked version)
+3. Restart Claude Desktop
+4. Open a chat and ask: *"Score the spec at `~/path/to/examples/sample-feat.md` as type feat using the score_spec tool"*
+5. Record the response (≈30 s)
+
+The exchange should show the tool call, the structured response, and Claude's interpretation. That's the demo.

--- a/packages/zai-mcp/README.md
+++ b/packages/zai-mcp/README.md
@@ -1,0 +1,95 @@
+# @htu/zai-mcp
+
+MCP server exposing ZAI's `score_spec` tool over stdio. Score markdown specs against the [ZAI rubric](https://zai.htu.io/) from any MCP-capable LLM client.
+
+## Install (Claude Desktop)
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "zai": {
+      "command": "npx",
+      "args": ["-y", "@htu/zai-mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The `score_spec` tool now appears in your tool palette.
+
+Cursor, Cline, and other MCP-capable clients accept the same shape — substitute their respective config locations.
+
+## What it does
+
+One tool: `score_spec`. Pass a markdown spec body and a spec type. Get back a structured score per the ZAI rubric: total score, per-check pass/fail, error messages on failures, rubric version. Identical scoring to the [zai.htu.io/app](https://zai.htu.io/app) web UI.
+
+Stateless. Anonymous. Per-process rate-limited (30/min, 200/hr, 1000/day).
+
+## Tool: `score_spec`
+
+**Input:**
+
+```typescript
+{
+  content: string,           // raw markdown spec body, ≤200KB
+  type: "feat" | "bug" | "hotfix" | "spec" | "chore" | "refactor" | "research" | "ux" | "brand",
+  bundles?: string[]         // reserved for future rubric bundles
+}
+```
+
+**Output (success):**
+
+```typescript
+{
+  score: number,             // count of passing checks
+  max: number,               // total checks for this type
+  passed: boolean,           // score === max
+  type: string,              // echo of input type
+  rubric_version: string,    // e.g., "1.3.1"
+  checks: Array<{
+    name: string,
+    pass: boolean,
+    error?: string           // present when pass=false
+  }>
+}
+```
+
+**Output (error):**
+
+```typescript
+// Bad input
+{ error: "invalid_input" | "content_too_large", message: string }
+
+// Rate-limited
+{ error: "rate_limited", retry_after_seconds: number, remaining: { ... } }
+```
+
+Errors come back as **MCP tool responses** (`isError: true`), not protocol exceptions. The agent can handle them as data.
+
+## Example transcript (Claude Desktop)
+
+> **You:** Use the score_spec tool to score this draft (paste the markdown of `examples/sample-feat.md`) as type `feat`.
+
+> **Claude:** *Calls `score_spec` with the markdown body. Receives:*
+> ```json
+> { "score": 9, "max": 9, "passed": true, "type": "feat", ... }
+> ```
+> The spec passes all 9 checks — Intent, Decision Tree, Final Spec, Acceptance Criteria, Game Theory Cooperative review, Subject Migration Summary, Files list, Models Applied, Legal triggers.
+
+See [DEMO.md](./DEMO.md) for more transcripts and [examples/](./examples) for reproducible sample inputs.
+
+## Development
+
+```bash
+npm install                  # at zai repo root (uses workspaces)
+cd packages/zai-mcp
+npm run build                # tsup -> dist/
+npm run test                 # vitest unit + integration
+npm pack --dry-run           # verify what would publish
+```
+
+## License
+
+MIT. See [LICENSE](../../LICENSE) at the zai repo root.

--- a/packages/zai-mcp/examples/sample-feat.md
+++ b/packages/zai-mcp/examples/sample-feat.md
@@ -1,0 +1,91 @@
+# feat: example feature for score_spec demo
+
+**Repo:** `zi007lin/zai`
+**Branch:** `feat/example-demo`
+**Reviewer:** daniel-silvers
+
+## Intent
+
+A worked example of a passing FEAT spec, used by `@htu/zai-mcp`'s README and DEMO transcripts. Adds a single new feature with all 9 FEAT rubric sections present and structurally valid. Not intended to be implemented — exists purely to demonstrate the scoring tool's behavior on a clean input.
+
+## Decision Tree
+
+| Question | Options | Chosen | Why |
+|---|---|---|---|
+| Where to host the example | repo / external gist / docs site | repo | Co-located with the README that references it; rebases survive the move |
+| Length | minimal / typical / exhaustive | minimal | Short enough to read in 30s during a demo; long enough that all 9 rubric sections are non-empty |
+| Real or fictional feature | real / fictional | fictional | Avoids implying a roadmap commitment; avoids stale references when real features ship |
+
+### Trigger for change
+
+Replace this example if:
+
+- The rubric introduces or removes a section — re-cut the example to match
+- A demo viewer asks "what does a passing FEAT actually look like" and this one doesn't make the structure obvious — rewrite for clarity
+
+## Draft-of-thoughts
+
+The temptation was to use a real in-flight FEAT as the example, since it would be more authentic. Rejected: real specs reference internal context (run numbers, branch names, prior decisions) that distracts a demo viewer. A fictional minimal spec keeps focus on the rubric structure itself.
+
+## Final Spec
+
+The example feature: a no-op `/api/echo` endpoint that returns the request body unchanged. Used solely as a structural demonstration. No implementation required by this spec.
+
+### Endpoint
+
+`POST /api/echo` — request body returned verbatim with content-type preserved. Public, anonymous, rate-limited per existing infra.
+
+## Acceptance Criteria
+
+- [ ] `/api/echo` returns 200 with the request body unchanged
+- [ ] Content-type header preserved on the response
+- [ ] Rate limits applied (per existing infra; no new code)
+- [ ] Vitest unit test confirms round-trip on JSON, text, and binary payloads
+- [ ] README links the endpoint under "Diagnostics"
+
+## Game Theory Cooperative Model review
+
+Three parties: the operator, the demo viewer, and the LLM agent driving the score_spec tool. All three benefit from a clean reference example. Operator gets a reliable demo asset; viewer sees the rubric concretely; agent gets a known-passing input for tool-use parser tuning.
+
+### Who benefits
+
+1. **Operator** — has a stable example that doesn't drift with real feature work.
+2. **Demo viewer** — sees the rubric's shape on a single screen.
+3. **LLM agent** — exercises the tool against known-good input during integration tests.
+
+### Abuse vector
+
+1. Adversary submits this exact file expecting different scores across versions. Mitigated by `rubric_version` in the output — caller sees when the rubric has shifted.
+2. Adversary modifies the file to drop sections and ships it as "passing". Mitigated by re-scoring at the gate; the tool is the source of truth, not the file's history.
+
+## Subject Migration Summary
+
+| Topic | State |
+|---|---|
+| What this establishes | A reference example of a passing FEAT spec for `@htu/zai-mcp` consumers |
+| Where it lives | `packages/zai-mcp/examples/sample-feat.md` |
+| Scope | Documentation only; no runtime code |
+| Dependencies | None |
+| Non-goals | Implementing `/api/echo`; this is a structural example only |
+| Open questions | None |
+
+## Files created / updated
+
+```
+packages/zai-mcp/examples/sample-feat.md    (new)
+packages/zai-mcp/README.md                  (link to this file)
+packages/zai-mcp/DEMO.md                    (reference in transcript 1)
+```
+
+## Models Applied
+
+- #1 Game Theory Cooperative — see `## Game Theory Cooperative Model review`
+- #2 Decision Tree — see `## Decision Tree`
+- #11 Progressive Disclosure — minimal example first; richer examples can be added on demand
+- #15 Inversion / Premortem — `### Abuse vector` enumerates failure modes
+
+## Legal triggers
+
+None.
+
+This is a documentation artifact. No PII, no contract clauses, no third-party data, no liability exposure.

--- a/packages/zai-mcp/package.json
+++ b/packages/zai-mcp/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@htu/zai-mcp",
+  "version": "0.1.0",
+  "description": "MCP server exposing ZAI's score_spec tool over stdio. Demo subset (#80).",
+  "license": "MIT",
+  "author": "ZiLin <noreply@zzv.io>",
+  "homepage": "https://github.com/zi007lin/zai/tree/main/packages/zai-mcp",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zi007lin/zai.git",
+    "directory": "packages/zai-mcp"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "bin": {
+    "zai-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "DEMO.md",
+    "examples"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run tests/integration",
+    "prepack": "npm run build",
+    "pack:dry": "npm pack --dry-run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.2",
+    "vitest": "^4.1.4"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "zai",
+    "spec-driven-development",
+    "anthropic",
+    "claude"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/zai-mcp/src/index.ts
+++ b/packages/zai-mcp/src/index.ts
@@ -1,0 +1,76 @@
+// MCP server entry — stdio transport only. Spawned by Claude Desktop /
+// Cursor / Cline / any MCP-capable client via `npx -y @htu/zai-mcp`.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { SCORE_SPEC_TOOL, handleScoreSpec } from "./tools/score-spec.js";
+
+const SERVER_NAME = "@htu/zai-mcp";
+const SERVER_VERSION = "0.1.0";
+
+export function createServer(): Server {
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [SCORE_SPEC_TOOL],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    if (name === SCORE_SPEC_TOOL.name) {
+      const result = handleScoreSpec(args ?? {});
+      const isError = "error" in result;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+        isError,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ error: "unknown_tool", name }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  });
+
+  return server;
+}
+
+async function main(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // The server now drives stdin/stdout. Do not write to stdout from here —
+  // the transport owns it. Any logging must go to stderr; we keep stderr
+  // silent during normal operation per acceptance criterion.
+}
+
+// Run only when invoked as the entry point (preserves importability for
+// tests that pull createServer directly).
+const isEntry =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url.endsWith(process.argv[1] ?? "");
+
+if (isEntry) {
+  main().catch((err) => {
+    process.stderr.write(`fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/zai-mcp/src/rate-limit.ts
+++ b/packages/zai-mcp/src/rate-limit.ts
@@ -1,0 +1,96 @@
+// In-memory sliding-window rate limiter, three caps per key.
+// Keyed per-IP when client metadata exposes one; falls back to a single
+// "stdio" key for stdio transport (per-process limit).
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retry_after_seconds?: number;
+  remaining: { minute: number; hour: number; day: number };
+}
+
+const LIMITS = {
+  minute: { count: 30, window_ms: 60_000 },
+  hour: { count: 200, window_ms: 3_600_000 },
+  day: { count: 1000, window_ms: 86_400_000 },
+} as const;
+
+interface Window {
+  per_minute: number[];
+  per_hour: number[];
+  per_day: number[];
+}
+
+const windows = new Map<string, Window>();
+
+function getWindow(key: string): Window {
+  let w = windows.get(key);
+  if (!w) {
+    w = { per_minute: [], per_hour: [], per_day: [] };
+    windows.set(key, w);
+  }
+  return w;
+}
+
+function prune(arr: number[], windowMs: number, now: number): number[] {
+  // Linear scan; keep timestamps within the window. Acceptable for our
+  // bounded counts (max 1000 entries per day per key).
+  const cutoff = now - windowMs;
+  const kept: number[] = [];
+  for (const t of arr) {
+    if (t > cutoff) kept.push(t);
+  }
+  return kept;
+}
+
+export function checkRateLimit(key: string, now: number = Date.now()): RateLimitResult {
+  const w = getWindow(key);
+  w.per_minute = prune(w.per_minute, LIMITS.minute.window_ms, now);
+  w.per_hour = prune(w.per_hour, LIMITS.hour.window_ms, now);
+  w.per_day = prune(w.per_day, LIMITS.day.window_ms, now);
+
+  const overMinute = w.per_minute.length >= LIMITS.minute.count;
+  const overHour = w.per_hour.length >= LIMITS.hour.count;
+  const overDay = w.per_day.length >= LIMITS.day.count;
+
+  if (overMinute || overHour || overDay) {
+    // Pick the tightest limit and compute retry_after from its oldest entry.
+    const tightest = overMinute
+      ? { arr: w.per_minute, window_ms: LIMITS.minute.window_ms }
+      : overHour
+      ? { arr: w.per_hour, window_ms: LIMITS.hour.window_ms }
+      : { arr: w.per_day, window_ms: LIMITS.day.window_ms };
+    const oldest = tightest.arr[0] ?? now;
+    const retry_after_seconds = Math.max(
+      1,
+      Math.ceil((tightest.window_ms - (now - oldest)) / 1000)
+    );
+    return {
+      allowed: false,
+      retry_after_seconds,
+      remaining: {
+        minute: Math.max(0, LIMITS.minute.count - w.per_minute.length),
+        hour: Math.max(0, LIMITS.hour.count - w.per_hour.length),
+        day: Math.max(0, LIMITS.day.count - w.per_day.length),
+      },
+    };
+  }
+
+  w.per_minute.push(now);
+  w.per_hour.push(now);
+  w.per_day.push(now);
+
+  return {
+    allowed: true,
+    remaining: {
+      minute: LIMITS.minute.count - w.per_minute.length,
+      hour: LIMITS.hour.count - w.per_hour.length,
+      day: LIMITS.day.count - w.per_day.length,
+    },
+  };
+}
+
+// Test seam: clear all keys. Not exported in the package's public surface,
+// but reachable for tests via direct import.
+export function _resetRateLimits(): void {
+  windows.clear();
+}

--- a/packages/zai-mcp/src/score-engine.ts
+++ b/packages/zai-mcp/src/score-engine.ts
@@ -1,0 +1,10 @@
+// Re-export of zai's rubric scoring engine. tsup resolves this relative
+// path and bundles the engine into the published package, so end users
+// never need the zai repo present at runtime.
+export {
+  scoreSpec,
+  KNOWN_TYPES,
+  type ScoreResult,
+  type SpecType,
+  type SectionStatus,
+} from "../../../src/lib/scoreSpec.js";

--- a/packages/zai-mcp/src/tools/score-spec.ts
+++ b/packages/zai-mcp/src/tools/score-spec.ts
@@ -1,0 +1,148 @@
+import { scoreSpec, KNOWN_TYPES, type SpecType } from "../score-engine.js";
+import { checkRateLimit, type RateLimitResult } from "../rate-limit.js";
+
+const MAX_CONTENT_BYTES = 200 * 1024;
+
+export const SCORE_SPEC_TOOL = {
+  name: "score_spec",
+  description:
+    "Score a markdown spec against ZAI's rubric. Returns structured per-check pass/fail with error messages on failures. Read-only, stateless. Scores match zai.htu.io/app exactly.",
+  inputSchema: {
+    type: "object" as const,
+    required: ["content", "type"],
+    properties: {
+      content: {
+        type: "string" as const,
+        description: "Raw markdown spec body. Must be ≤200KB.",
+      },
+      type: {
+        type: "string" as const,
+        enum: [...KNOWN_TYPES],
+        description:
+          "Spec type. One of: feat, bug, hotfix, spec, chore, refactor, research, ux, brand.",
+      },
+      bundles: {
+        type: "array" as const,
+        items: { type: "string" as const },
+        description:
+          "Optional bundle catalog tags (e.g., ['healthcare', 'fintech']). Reserved for future rubric bundles; ignored in v1.",
+      },
+    },
+  },
+} as const;
+
+// Inputs are typed as optional `unknown` because they arrive from MCP
+// callers as untrusted JSON. The handler validates each field at the top
+// of the function; downstream consumers see narrowed types only after
+// passing validation.
+export type ScoreSpecInput = {
+  content?: unknown;
+  type?: unknown;
+  bundles?: unknown;
+};
+
+export type ScoreSpecCheck = {
+  name: string;
+  pass: boolean;
+  error?: string;
+};
+
+export type ScoreSpecOutput =
+  | {
+      score: number;
+      max: number;
+      passed: boolean;
+      type: SpecType;
+      rubric_version: string;
+      checks: ScoreSpecCheck[];
+    }
+  | {
+      error: "rate_limited";
+      retry_after_seconds: number;
+      remaining: RateLimitResult["remaining"];
+    }
+  | {
+      error: "invalid_input" | "content_too_large" | "scoring_error";
+      message: string;
+    };
+
+function isKnownType(value: unknown): value is SpecType {
+  return typeof value === "string" && (KNOWN_TYPES as readonly string[]).includes(value);
+}
+
+function byteLength(s: string): number {
+  // TextEncoder gives an accurate UTF-8 byte count and works in any modern
+  // Node/runtime without requiring Buffer.
+  return new TextEncoder().encode(s).length;
+}
+
+export function handleScoreSpec(
+  input: ScoreSpecInput,
+  rateLimitKey: string = "stdio"
+): ScoreSpecOutput {
+  // Rate limit first — over-limit must not even parse input. Cheaper for
+  // hostile callers to be rejected before any work.
+  const rl = checkRateLimit(rateLimitKey);
+  if (!rl.allowed) {
+    return {
+      error: "rate_limited",
+      retry_after_seconds: rl.retry_after_seconds ?? 1,
+      remaining: rl.remaining,
+    };
+  }
+
+  if (typeof input.content !== "string" || input.content.length === 0) {
+    return { error: "invalid_input", message: "content must be a non-empty string" };
+  }
+  if (byteLength(input.content) > MAX_CONTENT_BYTES) {
+    return {
+      error: "content_too_large",
+      message: `content exceeds maximum of ${MAX_CONTENT_BYTES} bytes`,
+    };
+  }
+  if (!isKnownType(input.type)) {
+    return {
+      error: "invalid_input",
+      message: `type must be one of: ${KNOWN_TYPES.join(", ")}`,
+    };
+  }
+
+  // scoreSpec derives spec_type from filename. Synthesize a minimal valid
+  // filename so the engine routes to the requested type without modifying
+  // the existing zai/src/lib/scoreSpec.ts.
+  const synthFilename = `2026-01-01__${input.type}__mcp-call.md`;
+
+  let result;
+  try {
+    result = scoreSpec(input.content, synthFilename);
+  } catch (e) {
+    return {
+      error: "scoring_error",
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  const checks: ScoreSpecCheck[] = result.section_order.map((key) => {
+    const status = result.sections[key];
+    const reason = result.section_reasons[key];
+    return {
+      name: result.section_labels[key] ?? key,
+      pass: status === "PASS" || status === "SKIP",
+      error: status === "FAIL" && reason ? reason : undefined,
+    };
+  });
+
+  const score =
+    result.section_order.filter(
+      (k) => result.sections[k] === "PASS" || result.sections[k] === "SKIP"
+    ).length;
+
+  return {
+    score,
+    max: result.required_count,
+    passed: result.passed,
+    type: result.spec_type,
+    rubric_version: result.rubric_version,
+    checks,
+  };
+}

--- a/packages/zai-mcp/tests/integration/mcp-protocol.test.ts
+++ b/packages/zai-mcp/tests/integration/mcp-protocol.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createServer } from "../../src/index.js";
+import { _resetRateLimits } from "../../src/rate-limit.js";
+
+// End-to-end protocol test: pair an MCP Client to our Server via the
+// SDK's in-memory transport, exercise tools/list and tools/call.
+
+const SAMPLE_CHORE = `# chore: integration
+
+**Repo:** \`zi007lin/zai\`
+
+## Intent
+sample.
+
+## Action
+none.
+
+## Acceptance Criteria
+- [ ] passes
+
+## Files
+\`\`\`
+none (new)
+\`\`\`
+
+## Legal triggers
+None.
+`;
+
+describe("MCP protocol end-to-end", () => {
+  beforeEach(() => _resetRateLimits());
+
+  it("lists exactly one tool: score_spec", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createServer();
+    const client = new Client(
+      { name: "test-client", version: "0.0.0" },
+      { capabilities: {} }
+    );
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const list = await client.request({ method: "tools/list" }, ListToolsResultSchema);
+    expect(list.tools.length).toBe(1);
+    expect(list.tools[0].name).toBe("score_spec");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("calls score_spec and returns a JSON-encoded text result", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createServer();
+    const client = new Client(
+      { name: "test-client", version: "0.0.0" },
+      { capabilities: {} }
+    );
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "score_spec",
+          arguments: { content: SAMPLE_CHORE, type: "chore" },
+        },
+      },
+      CallToolResultSchema
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text
+    );
+    expect(parsed.type).toBe("chore");
+    expect(typeof parsed.passed).toBe("boolean");
+    expect(Array.isArray(parsed.checks)).toBe(true);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("returns isError=true for unknown tool", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createServer();
+    const client = new Client(
+      { name: "test-client", version: "0.0.0" },
+      { capabilities: {} }
+    );
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: { name: "nonexistent", arguments: {} },
+      },
+      CallToolResultSchema
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text
+    );
+    expect(parsed.error).toBe("unknown_tool");
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/zai-mcp/tests/unit/parity-with-web-ui.test.ts
+++ b/packages/zai-mcp/tests/unit/parity-with-web-ui.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleScoreSpec } from "../../src/tools/score-spec.js";
+import { scoreSpec } from "../../src/score-engine.js";
+import { _resetRateLimits } from "../../src/rate-limit.js";
+
+// Parity test: scores returned by the MCP tool match scoreSpec directly
+// (the function the web UI calls). Same input -> same passed bool, same
+// section pass/fail set, same rubric_version, same total counts.
+
+const FIXTURES: Array<{ name: string; type: string; markdown: string }> = [
+  {
+    name: "minimal feat",
+    type: "feat",
+    markdown: `# feat: minimal
+
+**Repo:** \`zi007lin/zai\`
+
+## Intent
+short.
+
+## Decision Tree
+| Q | Options | Chosen | Why |
+|---|---|---|---|
+| 1 | a / b | a | because |
+
+## Final Spec
+body
+
+## Acceptance Criteria
+- [ ] one
+
+## Game Theory Cooperative Model review
+cooperators win.
+
+## Subject Migration Summary
+| Topic | State |
+|---|---|
+| a | b |
+
+## Files created / updated
+\`\`\`
+x.ts (new)
+\`\`\`
+
+## Models Applied
+- #1 Game Theory Cooperative — applied
+
+## Legal triggers
+None.
+`,
+  },
+  {
+    name: "chore (smaller rubric)",
+    type: "chore",
+    markdown: `# chore: bump
+
+**Repo:** \`zi007lin/zai\`
+
+## Intent
+bump dep.
+
+## Action
+edit package.json.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+## Files
+\`\`\`
+package.json (edit)
+\`\`\`
+
+## Legal triggers
+None.
+`,
+  },
+];
+
+describe("parity with web UI scoring engine", () => {
+  beforeEach(() => _resetRateLimits());
+
+  for (const fx of FIXTURES) {
+    it(`matches scoreSpec direct call for ${fx.name}`, () => {
+      const synthFilename = `2026-01-01__${fx.type}__parity.md`;
+      const direct = scoreSpec(fx.markdown, synthFilename);
+      const viaTool = handleScoreSpec(
+        { content: fx.markdown, type: fx.type },
+        `parity-${fx.name}`
+      );
+      expect("error" in viaTool).toBe(false);
+      if ("error" in viaTool) return;
+
+      expect(viaTool.passed).toBe(direct.passed);
+      expect(viaTool.rubric_version).toBe(direct.rubric_version);
+      expect(viaTool.type).toBe(direct.spec_type);
+      expect(viaTool.max).toBe(direct.required_count);
+
+      // Per-section parity: each MCP "check" maps to a section in the
+      // direct result. Pass/fail status must agree.
+      const directPassMap = Object.fromEntries(
+        direct.section_order.map((k) => [
+          direct.section_labels[k] ?? k,
+          direct.sections[k] === "PASS" || direct.sections[k] === "SKIP",
+        ])
+      );
+      for (const c of viaTool.checks) {
+        expect(directPassMap[c.name]).toBe(c.pass);
+      }
+    });
+  }
+});

--- a/packages/zai-mcp/tests/unit/rate-limit.test.ts
+++ b/packages/zai-mcp/tests/unit/rate-limit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { checkRateLimit, _resetRateLimits } from "../../src/rate-limit.js";
+
+describe("rate-limit", () => {
+  beforeEach(() => {
+    _resetRateLimits();
+  });
+
+  it("first call is allowed and returns full remaining capacity", () => {
+    const r = checkRateLimit("k1");
+    expect(r.allowed).toBe(true);
+    expect(r.remaining.minute).toBe(29);
+    expect(r.remaining.hour).toBe(199);
+    expect(r.remaining.day).toBe(999);
+  });
+
+  it("blocks the 31st call within a minute", () => {
+    const t = 1_000_000;
+    for (let i = 0; i < 30; i++) {
+      const r = checkRateLimit("k1", t + i);
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = checkRateLimit("k1", t + 30);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retry_after_seconds).toBeGreaterThan(0);
+    expect(blocked.retry_after_seconds).toBeLessThanOrEqual(60);
+  });
+
+  it("recovers after the minute window passes", () => {
+    const t = 2_000_000;
+    for (let i = 0; i < 30; i++) {
+      checkRateLimit("k2", t + i);
+    }
+    expect(checkRateLimit("k2", t + 30).allowed).toBe(false);
+    // 60s later, the per-minute window has slid past all earlier entries.
+    expect(checkRateLimit("k2", t + 60_001).allowed).toBe(true);
+  });
+
+  it("isolates keys", () => {
+    const t = 3_000_000;
+    for (let i = 0; i < 30; i++) {
+      checkRateLimit("ka", t + i);
+    }
+    expect(checkRateLimit("ka", t + 30).allowed).toBe(false);
+    // Different key still has full capacity.
+    expect(checkRateLimit("kb", t + 30).allowed).toBe(true);
+  });
+
+  it("blocks when the hour cap is reached even if minute window allows", () => {
+    const t = 4_000_000;
+    // Spread 200 calls across the hour: 30 every 6 min + 20 in min 36.
+    let cur = t;
+    for (let i = 0; i < 200; i++) {
+      // 200 calls over 60 minutes -> ~18s apart -> never trips minute cap.
+      cur = t + i * 18_000;
+      const r = checkRateLimit("kh", cur);
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = checkRateLimit("kh", cur + 1_000);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retry_after_seconds).toBeGreaterThan(0);
+  });
+});

--- a/packages/zai-mcp/tests/unit/score-spec.test.ts
+++ b/packages/zai-mcp/tests/unit/score-spec.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleScoreSpec, SCORE_SPEC_TOOL } from "../../src/tools/score-spec.js";
+import { _resetRateLimits } from "../../src/rate-limit.js";
+
+const MINIMAL_FEAT = `# feat: example
+
+**Repo:** \`zi007lin/zai\`
+
+## Intent
+
+A short paragraph describing the feature.
+
+## Decision Tree
+
+| Q | Options | Chosen | Why |
+|---|---|---|---|
+| 1 | a / b | a | because |
+
+## Final Spec
+
+Body.
+
+## Acceptance Criteria
+
+- [ ] item one
+- [ ] item two
+
+## Game Theory Cooperative Model review
+
+Cooperators benefit. Adversary cases mitigated.
+
+## Subject Migration Summary
+
+| Topic | State |
+|---|---|
+| x | y |
+
+## Files created / updated
+
+\`\`\`
+file.ts (new)
+\`\`\`
+
+## Models Applied
+
+- #1 Game Theory Cooperative — applied
+- #2 Decision Tree — applied
+
+## Legal triggers
+
+None.
+`;
+
+describe("handleScoreSpec — input validation", () => {
+  beforeEach(() => _resetRateLimits());
+
+  it("rejects empty content", () => {
+    const r = handleScoreSpec({ content: "", type: "feat" }, "test-empty");
+    expect("error" in r && r.error === "invalid_input").toBe(true);
+  });
+
+  it("rejects non-string content", () => {
+    const r = handleScoreSpec({ content: 12345, type: "feat" }, "test-non-str");
+    expect("error" in r && r.error === "invalid_input").toBe(true);
+  });
+
+  it("rejects unknown spec type", () => {
+    const r = handleScoreSpec({ content: "x", type: "wat" }, "test-bad-type");
+    expect("error" in r && r.error === "invalid_input").toBe(true);
+  });
+
+  it("rejects content >200KB", () => {
+    const big = "a".repeat(200 * 1024 + 1);
+    const r = handleScoreSpec({ content: big, type: "feat" }, "test-big");
+    expect("error" in r && r.error === "content_too_large").toBe(true);
+  });
+
+  it("returns structured score for a minimal feat spec", () => {
+    const r = handleScoreSpec({ content: MINIMAL_FEAT, type: "feat" }, "test-feat");
+    expect("error" in r).toBe(false);
+    if ("error" in r) return;
+    expect(r.type).toBe("feat");
+    expect(r.max).toBeGreaterThan(0);
+    expect(Array.isArray(r.checks)).toBe(true);
+    expect(r.checks.length).toBe(r.max);
+    expect(typeof r.passed).toBe("boolean");
+    expect(typeof r.rubric_version).toBe("string");
+  });
+
+  it("returns rate_limited error after exceeding minute cap", () => {
+    const key = "test-rl";
+    for (let i = 0; i < 30; i++) {
+      handleScoreSpec({ content: MINIMAL_FEAT, type: "feat" }, key);
+    }
+    const blocked = handleScoreSpec({ content: MINIMAL_FEAT, type: "feat" }, key);
+    expect("error" in blocked && blocked.error === "rate_limited").toBe(true);
+  });
+});
+
+describe("SCORE_SPEC_TOOL schema", () => {
+  it("declares content + type as required", () => {
+    expect(SCORE_SPEC_TOOL.inputSchema.required).toContain("content");
+    expect(SCORE_SPEC_TOOL.inputSchema.required).toContain("type");
+  });
+
+  it("type enum includes the canonical spec types", () => {
+    const e = (SCORE_SPEC_TOOL.inputSchema.properties.type as { enum: string[] }).enum;
+    expect(e).toContain("feat");
+    expect(e).toContain("bug");
+    expect(e).toContain("hotfix");
+    expect(e).toContain("chore");
+  });
+});

--- a/packages/zai-mcp/tsconfig.json
+++ b/packages/zai-mcp/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/zai-mcp/tsup.config.ts
+++ b/packages/zai-mcp/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "tsup";
+
+// Bundle src/index.ts into dist/index.js. The score-engine module reaches
+// into the parent zai repo's src/lib/scoreSpec.ts via relative import; tsup
+// resolves and bundles it so the published package is self-contained.
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node22",
+  outDir: "dist",
+  clean: true,
+  dts: true,
+  sourcemap: true,
+  shims: false,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
+  // Treat MCP SDK as external — it is a runtime dep declared in package.json
+  // and will be installed alongside @htu/zai-mcp by npm.
+  external: ["@modelcontextprotocol/sdk"],
+});

--- a/packages/zai-mcp/vitest.config.ts
+++ b/packages/zai-mcp/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    exclude: ["node_modules/**", "dist/**"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        branches: 75,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

First MCP integration in the htu portfolio: `@htu/zai-mcp`, exposing a single tool `score_spec` over stdio. Buyers can install the server in Claude Desktop / Cursor / Cline and verify the ZAI methodology in their own environment in under 5 minutes — no auth, no state, scoring identical to `zai.htu.io/app`.

Closes #80.

## Architectural decisions (per pre-impl confirmation)

- **(a) Screencast** — pending, blocks merge; ZiLin attaches before merge. See checkbox below.
- **(b) Workspaces** — root converted to `workspaces: ["packages/*"]`. Vitest already scoped to `src/**` and `tsconfig.app.json` already scoped to `src/`, so the conversion is genuinely additive — root web app build / dev / test / wrangler deploy commands behave identically before and after.
- **(c) npm scope `@htu`** — pre-flight check confirmed available: registry org endpoint `https://registry.npmjs.org/-/org/htu` returns 404 and `scope:htu` registry search returns 0 packages. Scaffolded as `@htu/zai-mcp`. CI publish workflow is `workflow_dispatch` only — no auto-publish on merge or tag, so registration can happen manually first.
- **(d) Single PR** — all of it. ~3.6k insertions across 20 files, single coherent scope.

## What this PR adds

### Package — `packages/zai-mcp/`

| File | Purpose |
|---|---|
| `src/index.ts` | Stdio MCP server entry; exports `createServer` for tests |
| `src/tools/score-spec.ts` | Tool def + handler (validation, 200KB cap, rate-limit gate, structured errors) |
| `src/score-engine.ts` | Re-exports zai's `scoreSpec`; tsup bundles into the published artifact |
| `src/rate-limit.ts` | In-memory sliding-window limiter, 30/min · 200/hr · 1000/day per key |
| `tests/unit/rate-limit.test.ts` | 5 boundary tests |
| `tests/unit/score-spec.test.ts` | 8 input-validation + happy-path tests |
| `tests/unit/parity-with-web-ui.test.ts` | 2 fixtures, asserts MCP scoring matches `scoreSpec` direct call |
| `tests/integration/mcp-protocol.test.ts` | 3 end-to-end tests via `@modelcontextprotocol/sdk/client` + `InMemoryTransport.createLinkedPair()` |
| `examples/sample-feat.md` | Reproducible passing FEAT used by README transcript and DEMO.md |
| `README.md` · `DEMO.md` | Install in <10 lines + four sample transcripts |

### CI

- **`.github/workflows/zai-mcp-pack-check.yml`** — PR-time validation. Path-filtered to `packages/zai-mcp/**` + `src/lib/scoreSpec.ts` (the bundled engine). Runs build + test + `npm pack --dry-run`. Catches packaging gaps at PR time, not at publish time.
- **`.github/workflows/publish-mcp.yml`** — manual-trigger only (`workflow_dispatch`). Inputs: `version` (must match `package.json`), `dry_run` (skip the actual publish). Includes provenance flag.

### Root

- `package.json` — `workspaces: ["packages/*"]` added; nothing else changed.
- `package-lock.json` — refreshed for the new package's deps (`@modelcontextprotocol/sdk`, `tsup`, `@types/node`, `typescript`, `vitest`).

## Validation

- `npm install` — OK, 120 new packages in workspace
- `npm run build` (root, vite) — OK, byte-equivalent diff vs `main`
- `npm run test` (root, vitest) — OK, 90/90 unchanged
- `npm run build` (zai-mcp, tsup + dts) — OK, ESM bundle 24.7 KB
- `npm run test` (zai-mcp, vitest) — OK, **18/18 pass**
- `npm pack --dry-run` — OK, 7 files / 21.4 KB tarball

## Acceptance criteria

- [x] `npx -y @htu/zai-mcp` starts MCP server (validated via dist/index.js shebang + bin entry)
- [x] `tools/list` returns exactly `score_spec`
- [x] `tools/call score_spec` returns the documented schema
- [x] Score parity with web UI (`parity-with-web-ui.test.ts`)
- [x] Rate limits enforced; over-limit returns structured `rate_limited` error
- [x] Empty content / invalid type / >200KB → structured errors (not exceptions)
- [x] Stderr silent during normal operation (only fatal startup writes)
- [x] Vitest unit + integration tests; coverage thresholds in `vitest.config.ts`
- [x] Integration test uses `@modelcontextprotocol/sdk/client`
- [x] README documents Claude Desktop install in <10 lines
- [x] README includes example LLM transcript
- [x] All 9 ZAI FEAT rubric checks pass on the scored spec (9/9)
- [ ] **Screencast attached (manual, blocks merge)** — ZiLin
- [ ] daniel-silvers approval recorded — reviewer

## Test plan (post-merge)

- [ ] Manually publish via `gh workflow run publish-mcp.yml -f version=0.1.0 -f dry_run=true` first
- [ ] If dry-run clean, register `@htu` scope on npm, then `dry_run=false` to actually publish
- [ ] Install in Claude Desktop per README, score `examples/sample-feat.md`, confirm 9/9 pass
- [ ] Test rate-limited path: run 31 calls in a minute, confirm structured `rate_limited` response
- [ ] Test invalid input: send `type: "urgent"`, confirm structured `invalid_input` response

## Notes for reviewer

- **`scoreSpec` API** derives spec_type from filename (`YYYY-MM-DD__type__...`). The MCP tool handler synthesizes a minimal valid filename so the engine routes correctly without modifying `src/lib/scoreSpec.ts` (per spec line 201: "no edits"). See `tools/score-spec.ts`.
- **Bundling strategy:** tsup resolves `../../../src/lib/scoreSpec.ts` and inlines it into `dist/index.js`. The published package is fully self-contained — end users don't need the zai repo present.
- **Rate-limit semantics under stdio:** stdio transport has no per-IP signal. Falls back to a single `"stdio"` key, which is effectively per-process. Documented in DEMO.md and source comments.