### PR TITLE
feat: rubric v1.4.0 — mandatory Work Estimate section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ Versioning follows [SemVer](https://semver.org/) — but note that the `RUBRIC_V
 
 _(No unreleased changes.)_
 
+## [1.4.0] — 2026-05-01
+
+Implements zi007lin/zzv.io PR #35 (merged at 1c9a9eb). Mandatory `## Work Estimate` section added to every building rubric. Captures active operator time, wall-clock time with wait dependencies, assumptions, and a placeholder Actuals table to be filled post-execution. Specs scored at v1.4.0 or later require the section; pre-v1.4.0 scored specs retain their stored scores (grandfathered).
+
+### Added
+
+- `checkWorkEstimate(md)` detector in `src/lib/scoreSpec.ts`. Validates the `## Work Estimate` H2, the `### Active operator time` table (Phase + Estimate columns, ≥ 1 phase row + Total row), the `### Wall-clock time` table (Wait dependency + Estimate columns, ≥ 1 row + Total row), the `### Assumptions` subsection (≥ 1 bullet), and the `### Actuals (filled post-execution)` table (Phase, Estimate, Actual, Delta column headers).
+- New helpers in `scoreSpec.ts`: `subsectionBody`, `tableHeaderLine`, `tableHasTotalRow`, `tableDataRowCount`. Used by `checkWorkEstimate` only; reusable for any future subsection-aware detectors.
+- `WORK_ESTIMATE_SECTION` shared `SectionDef` constant — appended as the last item in every per-type `*_SECTIONS` array so the rubric order matches the documented `Appendix: rubric-count summary` table.
+- 11 new tests in `scoreSpec.test.ts`: 9 backward-compat tests (one per type, asserting that pre-v1.4.0 fixtures FAIL only the new `work_estimate` check while every other check still PASSes), 1 positive test, and 9 negative tests covering each failure mode (missing H2, missing each of the four subsections, both Total-row variants, no-bullet Assumptions, missing Actuals column headers).
+- New `WORK_ESTIMATE_OK` fixture block + `<type>Spec140` fixtures (per-type v1.4.0-compliant variants) inline in the test file, matching the existing template-string fixture pattern.
+
+### Changed
+
+- `RUBRIC_VERSION` bumped `1.3.1` → `1.4.0` (minor; new check added across all rubrics — backwards-compatible at the API layer, behavior-changing at the scoring-rule layer).
+- Per-type rubric counts incremented by 1: **FEAT 9→10, BUG 7→8, HOTFIX 7→8, SPEC 6→7, CHORE 5→6, REFACTOR 9→10, RESEARCH 6→7, UX 6→7, BRAND 6→7**.
+- `docs/ZAI_SYSTEM_INSTRUCTIONS.md` Appendix table updated for every documented type; new section IDs include `work_estimate` as the last entry. Doc footer bumped to `v1.4.0`.
+- Existing "scores a compliant `<type>` spec X/X passed" tests now use the new `<type>Spec140` fixtures and assert the new `(X+1)/(X+1)` count. The legacy `<type>Spec` fixtures are preserved unchanged and exercised by the new backward-compat tests.
+
+### Added (CI)
+
+- `.github/workflows/ci.yml` — minimal lint + test workflow on `pull_request` and pushes to `main`. Two jobs (`lint`, `test`) on `ubuntu-latest`. Replaces the previous "no PR-time CI" gap surfaced during Phase A discovery.
+
+### Backward compatibility
+
+- Pre-v1.4.0 scored specs are grandfathered; their stored `.scored.md` outputs are not re-validated and their scores stand.
+- Specs scored at v1.4.0 or later require the `## Work Estimate` section.
+- The committed legacy fixtures (`featSpec`, `bugSpec`, etc.) are not modified; the new backward-compat test suite asserts they now FAIL only the `work_estimate` check, with every other section still PASSing — proving the new check is the only behavioral delta.
+
+### Implementation notes
+
+- Parent SPEC (zzv.io PR #35) listed 7 spec types (FEAT, BUG, SPEC, CHORE, REFACTOR, UX, BRAND); the implementation covers **9** because the codebase has HOTFIX and RESEARCH rubrics in addition to the 7 documented. Per operator decision during Phase A, all 9 types receive the new check.
+- Parent SPEC also stated REFACTOR's pre-change count as 7. The actual rubric had **9** sections; the implementation moves it to 10. This is informational — no separate ticket; the SPEC table was illustrative, not authoritative.
+- No new dependencies. The detector uses the existing string/regex helpers; the test fixtures use the existing template-string pattern.
+- `package.json` `lint` script changed from `eslint .` to `tsc --noEmit`. ESLint was named in the script but never actually installed in the repo's `node_modules` (pre-existing gap surfaced during Phase A). The replacement uses the already-installed TypeScript compiler in typecheck-only mode, so the CI lint job has something real to run without adding new dependencies. Adding ESLint properly is a separate cleanup CHORE.
+- Branch protection is **not** configured on `zi007lin/zai` `main`. Surfaced in the implementation PR body as a follow-up CHORE candidate; out of scope for this PR.
+
+### Reference
+
+- Spec: zi007lin/zzv.io PR #35, merged at `1c9a9eb`
+- Implementation handoff CHORE: zi007lin/zzv.io PR #36, merged at `bc041e2`
+
 ## [1.3.1] — 2026-04-20
 
 Closes #51. Per-type Intent word caps replace the previous uniform 150-word cap (with CHORE as a 100-word exception). SPEC, REFACTOR, and RESEARCH need more framing than FEAT/BUG — the uniform cap forced authors to compress substantive context or split content into sections where it didn't belong. Additive liberalization; no previously passing spec regresses.

--- a/docs/ZAI_SYSTEM_INSTRUCTIONS.md
+++ b/docs/ZAI_SYSTEM_INSTRUCTIONS.md
@@ -425,6 +425,7 @@ OpenAPI at `zai.htu.io/openapi.json`.
 | 1.2 | 2026-04-19 | Added `legal_trigger_declaration` check to every building-type rubric (RESEARCH exempt; reports are non-building). Added `contract_law_signals` bundle (structural only, mandatory disclaimer banner, jurisdiction-agnostic, explicitly not legal advice). Added future `legal_services` bundle slot for 2027+ partner firm use. Rubric counts: FEAT 8→9, BUG 6→7, SPEC 5→6, CHORE 4→5, REFACTOR introduced as first-class type at 9 checks (was previously silently folded into CHORE in implementation — see BUG 2026-04-19), RESEARCH unchanged at 6 (non-building), UX/BRAND 5→6. |
 | 1.3 | 2026-04-20 | Enterprise disclosure footer rendered on `.scored.md` output for specs carrying any trigger bundle (`healthcare`, `fintech`, `financial_advisory`, `legal_services`, `government`). Canonical text sourced from `docs/brand/enterprise-disclosure.md`; drift-detection test asserts verbatim equality. Rendering lives in the output layer (`src/lib/renderScoredSpec.ts`), not the scoring engine — `ScoreResult` shape unchanged. No rubric count changes. Part of the ZiLin Brand Migration REFACTOR Phase 1 (2026-04-19). |
 | 1.3.1 | 2026-04-20 | Per-type Intent word caps (was uniform 150 with CHORE exception at 100). SPEC 250, REFACTOR 250, RESEARCH 200 — these types must frame actors/scope/deferrals, carry trigger + reversibility caveat, or set up context for research questions. FEAT/BUG/UX/BRAND unchanged at 150; CHORE unchanged at 100. `INTENT_CAPS` lookup in `scoreSpec.ts` replaces the previous flat constant. Drift-detection test extended with an Intent-cap column in the Appendix table. Error message on cap violation now names the cap, spec type, and suggests relocation or decomposition. Additive liberalization — no previously passing spec regresses. Also tightens the BUG/HOTFIX Intent check, which was previously loose (no cap enforced); per docs the cap has always been 150, so this aligns code to doc. Closes #51. |
+| 1.4.0 | 2026-05-01 | Mandatory `## Work Estimate` section added to **all 9** building rubrics (FEAT, BUG, HOTFIX, SPEC, CHORE, REFACTOR, RESEARCH, UX, BRAND). Detector validates: H2 present, `### Active operator time` table with Phase + Estimate columns and Total row, `### Wall-clock time` table with Wait dependency + Estimate columns and Total row, `### Assumptions` subsection with ≥1 bullet, `### Actuals (filled post-execution)` table with Phase, Estimate, Actual, Delta column headers. Rubric check counts: FEAT 9→10, BUG 7→8, HOTFIX 7→8, SPEC 6→7, CHORE 5→6, REFACTOR 9→10, RESEARCH 6→7, UX 6→7, BRAND 6→7. Backward compat: pre-v1.4.0 scored specs grandfathered (their stored scores stand); specs scored at v1.4.0 or later require the section. The parent SPEC PR (zzv.io #35) lists 7 spec types; the implementation covers 9 because the codebase has HOTFIX and RESEARCH rubrics in addition to the 7 documented. The SPEC also stated REFACTOR's pre-change count as 7, but the actual rubric had 9 — informational mismatch documented in the implementation PR. |
 ```
 
 ---
@@ -435,14 +436,14 @@ The Layer 3 drift-detection test asserts that rubric arrays in `scoreSpec.ts` ma
 
 | Type | Count | Intent cap | Ordered section IDs (canonical) |
 |---|---|---|---|
-| `feat` | 9 | 150 | `intent, decision_tree, final_spec, acceptance_criteria, game_theory, migration_summary, files_list, models_applied, legal_triggers` |
-| `bug` | 7 | 150 | `intent, repro, fix, acceptance_criteria, migration_summary, files, legal_triggers` |
-| `spec` | 6 | 250 | `intent, decision_tree, rules_or_content, migration_summary, files_schema, legal_triggers` |
-| `chore` | 5 | 100 | `intent, action, acceptance_criteria, files, legal_triggers` |
-| `refactor` | 9 | 250 | `intent, decision_tree, final_spec, acceptance_criteria, migration_summary, files_list, models_applied, migration_plan, legal_triggers` |
-| `research` | 6 | 200 | `intent, research_questions, acceptance_criteria, report_format, migration_summary, files` |
-| `ux` | 6 | 150 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers` |
-| `brand` | 6 | 150 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers` |
+| `feat` | 10 | 150 | `intent, decision_tree, final_spec, acceptance_criteria, game_theory, migration_summary, files_list, models_applied, legal_triggers, work_estimate` |
+| `bug` | 8 | 150 | `intent, repro, fix, acceptance_criteria, migration_summary, files, legal_triggers, work_estimate` |
+| `spec` | 7 | 250 | `intent, decision_tree, rules_or_content, migration_summary, files_schema, legal_triggers, work_estimate` |
+| `chore` | 6 | 100 | `intent, action, acceptance_criteria, files, legal_triggers, work_estimate` |
+| `refactor` | 10 | 250 | `intent, decision_tree, final_spec, acceptance_criteria, migration_summary, files_list, models_applied, migration_plan, legal_triggers, work_estimate` |
+| `research` | 7 | 200 | `intent, research_questions, acceptance_criteria, report_format, migration_summary, files, work_estimate` |
+| `ux` | 7 | 150 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers, work_estimate` |
+| `brand` | 7 | 150 | `intent, jobs_to_be_done, design_rationale, acceptance_criteria, assets_files, legal_triggers, work_estimate` |
 
 Drift test implementation notes:
 - Parse each `### X rubric (N checks)` heading in this doc
@@ -453,4 +454,4 @@ Drift test implementation notes:
 
 ---
 
-*End of ZAI_SYSTEM_INSTRUCTIONS.md v1.3.1*
+*End of ZAI_SYSTEM_INSTRUCTIONS.md v1.4.0*

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint .",
+    "lint": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -292,6 +292,53 @@ None.
 
 const brandSpec = uxSpec;
 
+// ─── Work Estimate fixture block (v1.4.0) ─────────────────────────────────
+//
+// Canonical Work Estimate section that satisfies the v1.4.0 detector.
+// Append it to a v1.2 fixture to produce a v1.4.0-compliant fixture.
+
+const WORK_ESTIMATE_OK = `
+## Work Estimate
+
+### Active operator time
+
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | discovery |
+| Phase B | 30 min | implementation |
+| **Total active** | **35 min** | |
+
+### Wall-clock time
+
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 30 min - 12 hr | reviewer pace |
+| **Total wall-clock** | **30 min - 12 hr** | |
+
+### Assumptions
+
+- repo accessible
+- reviewer available
+
+### Actuals (filled post-execution)
+
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| Phase B | 30 min | TBD | TBD | |
+| **Total** | **35 min** | **TBD** | **TBD** | |
+`;
+
+const featSpec140 = featSpec + WORK_ESTIMATE_OK;
+const researchSpec140 = researchSpec + WORK_ESTIMATE_OK;
+const bugSpec140 = bugSpec + WORK_ESTIMATE_OK;
+const hotfixSpec140 = hotfixSpec + WORK_ESTIMATE_OK;
+const choreSpec140 = choreSpec + WORK_ESTIMATE_OK;
+const specSpec140 = specSpec + WORK_ESTIMATE_OK;
+const refactorSpec140 = refactorSpec + WORK_ESTIMATE_OK;
+const uxSpec140 = uxSpec + WORK_ESTIMATE_OK;
+const brandSpec140 = brandSpec + WORK_ESTIMATE_OK;
+
 // ─── detectSpecType ───────────────────────────────────────────────────────
 
 describe("detectSpecType", () => {
@@ -335,11 +382,11 @@ describe("detectSpecType", () => {
 // ─── scoreSpec — feat (9 checks) ──────────────────────────────────────────
 
 describe("scoreSpec — feat", () => {
-  it("scores a compliant feat spec 9/9 passed", () => {
-    const r = scoreSpec(featSpec, "2026-04-12__feat__example.md");
+  it("scores a compliant feat spec 10/10 passed (v1.4.0)", () => {
+    const r = scoreSpec(featSpec140, "2026-04-12__feat__example.md");
     expect(r.spec_type).toBe("feat");
-    expect(r.required_count).toBe(9);
-    expect(r.score).toBe("9/9");
+    expect(r.required_count).toBe(10);
+    expect(r.score).toBe("10/10");
     expect(r.passed).toBe(true);
     for (const key of r.section_order) {
       if (r.sections[key] !== "FAIL") {
@@ -418,11 +465,11 @@ describe("scoreSpec — feat", () => {
 // ─── scoreSpec — research (6 checks, v1.2 unchanged) ──────────────────────
 
 describe("scoreSpec — research", () => {
-  it("scores a compliant research spec 6/6 passed", () => {
-    const r = scoreSpec(researchSpec, "2026-04-13__research__example.md");
+  it("scores a compliant research spec 7/7 passed (v1.4.0)", () => {
+    const r = scoreSpec(researchSpec140, "2026-04-13__research__example.md");
     expect(r.spec_type).toBe("research");
-    expect(r.required_count).toBe(6);
-    expect(r.score).toBe("6/6");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
     expect(r.passed).toBe(true);
   });
 
@@ -456,11 +503,11 @@ describe("scoreSpec — research", () => {
 // ─── scoreSpec — bug (7 checks, v1.2) ─────────────────────────────────────
 
 describe("scoreSpec — bug", () => {
-  it("scores a compliant bug spec 7/7 passed", () => {
-    const r = scoreSpec(bugSpec, "2026-04-13__bug__example.md");
+  it("scores a compliant bug spec 8/8 passed (v1.4.0)", () => {
+    const r = scoreSpec(bugSpec140, "2026-04-13__bug__example.md");
     expect(r.spec_type).toBe("bug");
-    expect(r.required_count).toBe(7);
-    expect(r.score).toBe("7/7");
+    expect(r.required_count).toBe(8);
+    expect(r.score).toBe("8/8");
     expect(r.passed).toBe(true);
   });
 
@@ -487,16 +534,16 @@ describe("scoreSpec — bug", () => {
 // ─── scoreSpec — hotfix (7 checks — aliased to bug) ───────────────────────
 
 describe("scoreSpec — hotfix", () => {
-  it("scores a compliant hotfix spec 7/7 passed", () => {
-    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
+  it("scores a compliant hotfix spec 8/8 passed (v1.4.0)", () => {
+    const r = scoreSpec(hotfixSpec140, "2026-04-13__hotfix__example.md");
     expect(r.spec_type).toBe("hotfix");
-    expect(r.required_count).toBe(7);
-    expect(r.score).toBe("7/7");
+    expect(r.required_count).toBe(8);
+    expect(r.score).toBe("8/8");
     expect(r.passed).toBe(true);
   });
 
-  it("hotfix uses same section set as bug", () => {
-    const r = scoreSpec(hotfixSpec, "2026-04-13__hotfix__example.md");
+  it("hotfix uses same section set as bug (v1.4.0)", () => {
+    const r = scoreSpec(hotfixSpec140, "2026-04-13__hotfix__example.md");
     expect(r.section_order).toEqual([
       "intent",
       "repro",
@@ -505,6 +552,7 @@ describe("scoreSpec — hotfix", () => {
       "migration_summary",
       "files",
       "legal_triggers",
+      "work_estimate",
     ]);
   });
 });
@@ -512,11 +560,11 @@ describe("scoreSpec — hotfix", () => {
 // ─── scoreSpec — chore (5 checks, v1.2) ───────────────────────────────────
 
 describe("scoreSpec — chore", () => {
-  it("scores a compliant chore spec 5/5 passed", () => {
-    const r = scoreSpec(choreSpec, "2026-04-13__chore__example.md");
+  it("scores a compliant chore spec 6/6 passed (v1.4.0)", () => {
+    const r = scoreSpec(choreSpec140, "2026-04-13__chore__example.md");
     expect(r.spec_type).toBe("chore");
-    expect(r.required_count).toBe(5);
-    expect(r.score).toBe("5/5");
+    expect(r.required_count).toBe(6);
+    expect(r.score).toBe("6/6");
     expect(r.passed).toBe(true);
   });
 
@@ -542,11 +590,11 @@ describe("scoreSpec — chore", () => {
 // ─── scoreSpec — spec (6 checks, v1.2) ────────────────────────────────────
 
 describe("scoreSpec — spec", () => {
-  it("scores a compliant spec 6/6 passed", () => {
-    const r = scoreSpec(specSpec, "2026-04-13__spec__example.md");
+  it("scores a compliant spec 7/7 passed (v1.4.0)", () => {
+    const r = scoreSpec(specSpec140, "2026-04-13__spec__example.md");
     expect(r.spec_type).toBe("spec");
-    expect(r.required_count).toBe(6);
-    expect(r.score).toBe("6/6");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
     expect(r.passed).toBe(true);
   });
 
@@ -566,18 +614,18 @@ describe("scoreSpec — spec", () => {
 // ─── scoreSpec — refactor (9 checks, v1.2) ────────────────────────────────
 
 describe("scoreSpec — refactor", () => {
-  it("scores a compliant refactor spec 9/9 passed", () => {
-    const r = scoreSpec(refactorSpec, "2026-04-13__refactor__example.md");
+  it("scores a compliant refactor spec 10/10 passed (v1.4.0)", () => {
+    const r = scoreSpec(refactorSpec140, "2026-04-13__refactor__example.md");
     expect(r.spec_type).toBe("refactor");
-    expect(r.required_count).toBe(9);
-    expect(r.score).toBe("9/9");
+    expect(r.required_count).toBe(10);
+    expect(r.score).toBe("10/10");
     expect(r.passed).toBe(true);
   });
 
-  it("refactor is NOT downgraded to chore (the bug this PR fixes)", () => {
-    const r = scoreSpec(refactorSpec, "2026-04-13__refactor__example.md");
+  it("refactor is NOT downgraded to chore (Apr 2026 bug fix); v1.4.0 has 10 checks", () => {
+    const r = scoreSpec(refactorSpec140, "2026-04-13__refactor__example.md");
     expect(r.spec_type).toBe("refactor");
-    expect(r.required_count).toBe(9);
+    expect(r.required_count).toBe(10);
   });
 
   it("migration_plan FAILs without ### Rollback subsection", () => {
@@ -602,11 +650,11 @@ describe("scoreSpec — refactor", () => {
 // ─── scoreSpec — ux / brand (6 checks each, v1.2) ─────────────────────────
 
 describe("scoreSpec — ux", () => {
-  it("scores a compliant ux spec 6/6 passed", () => {
-    const r = scoreSpec(uxSpec, "2026-04-13__ux__example.md");
+  it("scores a compliant ux spec 7/7 passed (v1.4.0)", () => {
+    const r = scoreSpec(uxSpec140, "2026-04-13__ux__example.md");
     expect(r.spec_type).toBe("ux");
-    expect(r.required_count).toBe(6);
-    expect(r.score).toBe("6/6");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
     expect(r.passed).toBe(true);
   });
 
@@ -639,11 +687,11 @@ describe("scoreSpec — ux", () => {
 });
 
 describe("scoreSpec — brand", () => {
-  it("scores a compliant brand spec 6/6 passed (same rubric as ux)", () => {
-    const r = scoreSpec(brandSpec, "2026-04-13__brand__example.md");
+  it("scores a compliant brand spec 7/7 passed (v1.4.0; same rubric as ux)", () => {
+    const r = scoreSpec(brandSpec140, "2026-04-13__brand__example.md");
     expect(r.spec_type).toBe("brand");
-    expect(r.required_count).toBe(6);
-    expect(r.score).toBe("6/6");
+    expect(r.required_count).toBe(7);
+    expect(r.score).toBe("7/7");
     expect(r.passed).toBe(true);
   });
 });
@@ -652,7 +700,7 @@ describe("scoreSpec — brand", () => {
 
 describe("scoreSpec — section_reasons", () => {
   it("all passing sections return null reasons", () => {
-    const r = scoreSpec(featSpec, "2026-04-12__feat__example.md");
+    const r = scoreSpec(featSpec140, "2026-04-12__feat__example.md");
     for (const key of r.section_order) {
       expect(r.section_reasons[key]).toBeNull();
     }
@@ -696,8 +744,8 @@ describe("scoreSpec — gates and meta", () => {
     expect(r.gates[0]).toMatch(/chain/i);
   });
 
-  it("rubric version is 1.3.1", () => {
-    expect(scoreSpec(featSpec, "2026-04-13__feat__x.md").rubric_version).toBe("1.3.1");
+  it("rubric version is 1.4.0", () => {
+    expect(scoreSpec(featSpec140, "2026-04-13__feat__x.md").rubric_version).toBe("1.4.0");
   });
 
   it("non-matching filename throws SpecTypeError (previously silently fell back to feat)", () => {
@@ -784,9 +832,9 @@ describe("drift-detection — scoreSpec vs ZAI_SYSTEM_INSTRUCTIONS.md §Appendix
     }
   });
 
-  it("REFACTOR specifically has a registered rubric with 9 checks", () => {
+  it("REFACTOR specifically has a registered rubric with 10 checks (v1.4.0)", () => {
     expect(RUBRIC_SECTION_KEYS.refactor).toBeDefined();
-    expect(RUBRIC_SECTION_KEYS.refactor.length).toBe(9);
+    expect(RUBRIC_SECTION_KEYS.refactor.length).toBe(10);
   });
 
   it("hotfix is not in the appendix (aliased to bug at runtime)", () => {
@@ -858,7 +906,7 @@ docs/widget-rules.md
 
 ## Legal triggers
 None.
-`;
+${WORK_ESTIMATE_OK}`;
 
 const refactorBase = (intentBody: string) => `# refactor title
 
@@ -904,7 +952,7 @@ Trigger: TM opposition. Reverse DNS, revert docs.
 
 ## Legal triggers
 None.
-`;
+${WORK_ESTIMATE_OK}`;
 
 const researchBase = (intentBody: string) => `# research title
 
@@ -933,7 +981,7 @@ The report structure is documented here.
 \`\`\`
 issues/reports/example.md
 \`\`\`
-`;
+${WORK_ESTIMATE_OK}`;
 
 describe("scoreSpec — per-type Intent caps", () => {
   it("spec-intent-240-pass: SPEC at 240 words passes under 250-word cap", () => {
@@ -1005,5 +1053,280 @@ describe("scoreSpec — per-type Intent caps", () => {
       "2026-04-13__chore__x.md",
     );
     expect(r.sections.intent).toBe("PASS");
+  });
+});
+
+// ─── v1.4.0 Work Estimate ─────────────────────────────────────────────────
+//
+// 1 backward-compat test per type + 1 positive + 9 negative failure-mode
+// tests covering every branch in checkWorkEstimate.
+
+describe("v1.4.0 — backward compatibility (pre-v1.4.0 fixtures lack Work Estimate)", () => {
+  const cases: { type: SpecType; spec: string; filename: string; preCount: number }[] = [
+    { type: "feat", spec: featSpec, filename: "2026-04-12__feat__legacy.md", preCount: 9 },
+    { type: "bug", spec: bugSpec, filename: "2026-04-12__bug__legacy.md", preCount: 7 },
+    { type: "hotfix", spec: hotfixSpec, filename: "2026-04-12__hotfix__legacy.md", preCount: 7 },
+    { type: "spec", spec: specSpec, filename: "2026-04-12__spec__legacy.md", preCount: 6 },
+    { type: "chore", spec: choreSpec, filename: "2026-04-12__chore__legacy.md", preCount: 5 },
+    { type: "refactor", spec: refactorSpec, filename: "2026-04-12__refactor__legacy.md", preCount: 9 },
+    { type: "research", spec: researchSpec, filename: "2026-04-12__research__legacy.md", preCount: 6 },
+    { type: "ux", spec: uxSpec, filename: "2026-04-12__ux__legacy.md", preCount: 6 },
+    { type: "brand", spec: brandSpec, filename: "2026-04-12__brand__legacy.md", preCount: 6 },
+  ];
+  for (const { type, spec, filename, preCount } of cases) {
+    it(`${type}: pre-v1.4.0 fixture (no Work Estimate) fails ONLY work_estimate; other sections still pass`, () => {
+      const r = scoreSpec(spec, filename);
+      expect(r.required_count).toBe(preCount + 1);
+      expect(r.sections.work_estimate).toBe("FAIL");
+      expect(r.section_reasons.work_estimate).toMatch(/Work Estimate/i);
+      expect(r.passed).toBe(false);
+      // Every other check still PASSes (proves the new check is the only
+      // failing one — the rest of the rubric is unchanged).
+      for (const key of r.section_order) {
+        if (key !== "work_estimate") {
+          expect(r.sections[key]).toBe("PASS");
+        }
+      }
+    });
+  }
+});
+
+describe("v1.4.0 — Work Estimate positive case", () => {
+  it("a fully-compliant Work Estimate section passes the work_estimate check", () => {
+    const r = scoreSpec(featSpec140, "2026-05-01__feat__we-positive.md");
+    expect(r.sections.work_estimate).toBe("PASS");
+    expect(r.section_reasons.work_estimate).toBeNull();
+  });
+});
+
+describe("v1.4.0 — Work Estimate failure modes", () => {
+  // Reusable mutator helper: replace the entire Work Estimate block.
+  function withMutatedWorkEstimate(replacement: string): string {
+    return featSpec + replacement;
+  }
+
+  it("missing ## Work Estimate H2", () => {
+    const r = scoreSpec(featSpec, "2026-05-01__feat__we-1.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/"## Work Estimate" heading not found/);
+  });
+
+  it("missing ### Active operator time subsection", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Assumptions
+- repo accessible
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-2.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Active operator time/);
+  });
+
+  it("missing ### Wall-clock time subsection", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Assumptions
+- repo accessible
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-3.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Wall-clock time/);
+  });
+
+  it("missing ### Assumptions subsection", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-4.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Assumptions/);
+  });
+
+  it("missing ### Actuals (filled post-execution) subsection", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Assumptions
+- repo accessible
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-5.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Actuals/);
+  });
+
+  it("Active operator time table without Total row", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Assumptions
+- ok
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-6.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Active operator time.*Total row/);
+  });
+
+  it("Wall-clock time table without Total row", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+
+### Assumptions
+- ok
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-7.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Wall-clock time.*Total row/);
+  });
+
+  it("Assumptions section with no bullets", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Assumptions
+just a paragraph with no bullets at all.
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Actual | Delta | Note |
+|---|---|---|---|---|
+| Phase A | 5 min | TBD | TBD | |
+| **Total** | **5 min** | **TBD** | **TBD** | |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-8.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Assumptions.*no bullets/);
+  });
+
+  it("Actuals table missing required column headers", () => {
+    const md = withMutatedWorkEstimate(`
+## Work Estimate
+
+### Active operator time
+| Phase | Estimate | Notes |
+|---|---|---|
+| Phase A | 5 min | |
+| **Total active** | **5 min** | |
+
+### Wall-clock time
+| Wait dependency | Estimate | Notes |
+|---|---|---|
+| Review | 1 hr | |
+| **Total wall-clock** | **1 hr** | |
+
+### Assumptions
+- ok
+
+### Actuals (filled post-execution)
+| Phase | Estimate | Note |
+|---|---|---|
+| Phase A | 5 min | TBD |
+| **Total** | **5 min** | **TBD** |
+`);
+    const r = scoreSpec(md, "2026-05-01__feat__we-9.md");
+    expect(r.sections.work_estimate).toBe("FAIL");
+    expect(r.section_reasons.work_estimate).toMatch(/Actuals.*missing required column headers/);
+    expect(r.section_reasons.work_estimate).toMatch(/Actual/);
+    expect(r.section_reasons.work_estimate).toMatch(/Delta/);
   });
 });

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -34,7 +34,7 @@ export class SpecTypeError extends Error {
   }
 }
 
-const RUBRIC_VERSION = "1.3.1";
+const RUBRIC_VERSION = "1.4.0";
 
 // Per-type Intent word caps. FEAT/BUG/UX/BRAND stay at 150 where compression
 // is a virtue; CHORE stays at 100; SPEC and REFACTOR rise to 250 because they
@@ -94,6 +94,56 @@ function bulletListCount(body: string): number {
   return (body.match(/^[-*]\s+/gm) || []).length;
 }
 
+// ─── Work Estimate helpers (v1.4.0) ───────────────────────────────────────
+
+// Body of a `### subheading` inside a `## section` body. Cuts off at the
+// next `## ` (sibling section) or `### ` (sibling subsection), whichever
+// comes first.
+function subsectionBody(parentBody: string, headingPattern: RegExp): string {
+  const start = parentBody.search(headingPattern);
+  if (start === -1) return "";
+  const after = parentBody.slice(start).replace(headingPattern, "");
+  const next = after.search(/^###?\s+/m);
+  return next === -1 ? after : after.slice(0, next);
+}
+
+// First markdown-table header line in a body (the row before `|---|---|`).
+function tableHeaderLine(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const next = lines[i + 1] ?? "";
+    if (/\|.*\|/.test(lines[i]) && /^\s*\|[\s\-:|]+\|\s*$/.test(next)) {
+      return lines[i];
+    }
+  }
+  return null;
+}
+
+// True when the body contains a row whose first cell starts with `Total`
+// (with or without bold markers). Used to detect "Total" rows in the
+// Active-operator-time and Wall-clock tables.
+function tableHasTotalRow(body: string): boolean {
+  return /\|\s*\*{0,2}\s*Total\b[^|]*\|/i.test(body);
+}
+
+// Number of data rows (rows after the `|---|...|` separator that look
+// like `| ... |`). Used to enforce ">= 1 phase row + 1 Total row".
+function tableDataRowCount(body: string): number {
+  const lines = body.split(/\r?\n/);
+  let count = 0;
+  let pastSeparator = false;
+  for (const line of lines) {
+    if (/^\s*\|[\s\-:|]+\|\s*$/.test(line)) {
+      pastSeparator = true;
+      continue;
+    }
+    if (pastSeparator && /\|.*\|/.test(line) && line.trim().startsWith("|")) {
+      count++;
+    }
+  }
+  return count;
+}
+
 function openQuestionsNotEmpty(body: string): boolean {
   const row = body.match(/\|\s*Open\s+questions\s*\|([^|\n]*)\|/i);
   if (!row) return false;
@@ -147,6 +197,11 @@ const ACTION_HEADING = /^##\s+Action\b/mi;
 const JOBS_HEADING = /^##\s+Jobs\s+To\s+Be\s+Done\b/mi;
 const DESIGN_RATIONALE_HEADING = /^##\s+Design\s+Rationale\b/mi;
 const RULES_OR_CONTENT_HEADING = /^##\s+(Rules|Content)\b/mi;
+const WORK_ESTIMATE_HEADING = /^##\s+Work\s+Estimate\b/mi;
+const ACTIVE_OPERATOR_HEADING = /^###\s+Active\s+operator\s+time\b/mi;
+const WALL_CLOCK_HEADING = /^###\s+Wall[-\s]?clock\s+time\b/mi;
+const ASSUMPTIONS_HEADING = /^###\s+Assumptions\b/mi;
+const ACTUALS_HEADING = /^###\s+Actuals\b/mi;
 
 // ─── section checks ───────────────────────────────────────────────────────
 
@@ -346,6 +401,82 @@ function checkRulesOrContent(md: string): CheckResult {
   return pass();
 }
 
+// `## Work Estimate` (v1.4.0). Validates:
+//   - H2 exists
+//   - `### Active operator time` subsection: markdown table with
+//     `Phase` + `Estimate` headers, ≥1 phase row, a `Total` row
+//   - `### Wall-clock time` subsection: markdown table with
+//     `Wait dependency` + `Estimate` headers, ≥1 row, a `Total` row
+//   - `### Assumptions` subsection: ≥1 bullet (- or *)
+//   - `### Actuals (filled post-execution)` subsection: markdown table
+//     with required column headers `Phase`, `Estimate`, `Actual`, `Delta`
+function checkWorkEstimate(md: string): CheckResult {
+  if (!headingPresent(md, WORK_ESTIMATE_HEADING))
+    return fail('"## Work Estimate" heading not found');
+  const body = sectionBody(md, WORK_ESTIMATE_HEADING);
+
+  // Active operator time
+  if (!headingPresent(body, ACTIVE_OPERATOR_HEADING))
+    return fail('missing "### Active operator time" subsection');
+  const activeBody = subsectionBody(body, ACTIVE_OPERATOR_HEADING);
+  if (!tablePresent(activeBody))
+    return fail('"### Active operator time" missing markdown table');
+  const activeHeader = tableHeaderLine(activeBody);
+  if (!activeHeader || !/Phase/i.test(activeHeader) || !/Estimate/i.test(activeHeader))
+    return fail(
+      '"### Active operator time" table missing required column headers (Phase, Estimate)',
+    );
+  if (!tableHasTotalRow(activeBody))
+    return fail('"### Active operator time" table missing Total row');
+  if (tableDataRowCount(activeBody) < 2)
+    return fail(
+      '"### Active operator time" table needs at least 1 phase row plus a Total row',
+    );
+
+  // Wall-clock time
+  if (!headingPresent(body, WALL_CLOCK_HEADING))
+    return fail('missing "### Wall-clock time" subsection');
+  const wallBody = subsectionBody(body, WALL_CLOCK_HEADING);
+  if (!tablePresent(wallBody))
+    return fail('"### Wall-clock time" missing markdown table');
+  const wallHeader = tableHeaderLine(wallBody);
+  if (!wallHeader || !/Wait\s+dependency/i.test(wallHeader) || !/Estimate/i.test(wallHeader))
+    return fail(
+      '"### Wall-clock time" table missing required column headers (Wait dependency, Estimate)',
+    );
+  if (!tableHasTotalRow(wallBody))
+    return fail('"### Wall-clock time" table missing Total row');
+  if (tableDataRowCount(wallBody) < 2)
+    return fail(
+      '"### Wall-clock time" table needs at least 1 wait-dependency row plus a Total row',
+    );
+
+  // Assumptions
+  if (!headingPresent(body, ASSUMPTIONS_HEADING))
+    return fail('missing "### Assumptions" subsection');
+  const assumptionsBody = subsectionBody(body, ASSUMPTIONS_HEADING);
+  if (bulletListCount(assumptionsBody) < 1)
+    return fail('"### Assumptions" subsection has no bullets (- or *)');
+
+  // Actuals (filled post-execution)
+  if (!headingPresent(body, ACTUALS_HEADING))
+    return fail('missing "### Actuals (filled post-execution)" subsection');
+  const actualsBody = subsectionBody(body, ACTUALS_HEADING);
+  if (!tablePresent(actualsBody))
+    return fail('"### Actuals (filled post-execution)" missing markdown table');
+  const actualsHeader = tableHeaderLine(actualsBody);
+  if (!actualsHeader)
+    return fail('"### Actuals (filled post-execution)" table missing header row');
+  const required = ["Phase", "Estimate", "Actual", "Delta"];
+  const missing = required.filter((c) => !new RegExp(`\\b${c}\\b`, "i").test(actualsHeader));
+  if (missing.length > 0)
+    return fail(
+      `"### Actuals (filled post-execution)" table missing required column headers: ${missing.join(", ")}`,
+    );
+
+  return pass();
+}
+
 // ─── section definitions per spec type ────────────────────────────────────
 
 interface SectionDef {
@@ -353,6 +484,12 @@ interface SectionDef {
   label: string;
   check: (md: string) => CheckResult;
 }
+
+const WORK_ESTIMATE_SECTION: SectionDef = {
+  key: "work_estimate",
+  label: "Work Estimate",
+  check: checkWorkEstimate,
+};
 
 const FEAT_SECTIONS: SectionDef[] = [
   { key: "intent", label: "Intent", check: makeIntentCheck("feat") },
@@ -364,6 +501,7 @@ const FEAT_SECTIONS: SectionDef[] = [
   { key: "files_list", label: "Files created / updated", check: checkFilesList },
   { key: "models_applied", label: "Models Applied", check: checkModelsApplied },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const BUG_SECTIONS: SectionDef[] = [
@@ -374,6 +512,7 @@ const BUG_SECTIONS: SectionDef[] = [
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
   { key: "files", label: "Files", check: checkFiles },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const HOTFIX_SECTIONS: SectionDef[] = [
@@ -384,6 +523,7 @@ const HOTFIX_SECTIONS: SectionDef[] = [
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
   { key: "files", label: "Files", check: checkFiles },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const SPEC_SECTIONS: SectionDef[] = [
@@ -393,6 +533,7 @@ const SPEC_SECTIONS: SectionDef[] = [
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
   { key: "files_schema", label: "Files / Schema", check: checkFilesOrSchema },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const CHORE_SECTIONS: SectionDef[] = [
@@ -401,6 +542,7 @@ const CHORE_SECTIONS: SectionDef[] = [
   { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 1) },
   { key: "files", label: "Files", check: checkFiles },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const REFACTOR_SECTIONS: SectionDef[] = [
@@ -413,6 +555,7 @@ const REFACTOR_SECTIONS: SectionDef[] = [
   { key: "models_applied", label: "Models Applied", check: checkModelsApplied },
   { key: "migration_plan", label: "Migration Plan", check: checkMigrationPlan },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const RESEARCH_SECTIONS: SectionDef[] = [
@@ -422,6 +565,7 @@ const RESEARCH_SECTIONS: SectionDef[] = [
   { key: "report_format", label: "Report Format", check: checkReportFormat },
   { key: "migration_summary", label: "Subject Migration Summary", check: checkMigrationSummary },
   { key: "files", label: "Files", check: checkFiles },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const UX_SECTIONS: SectionDef[] = [
@@ -431,6 +575,7 @@ const UX_SECTIONS: SectionDef[] = [
   { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 2) },
   { key: "assets_files", label: "Assets / Files", check: checkFilesOrSchema },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 const BRAND_SECTIONS: SectionDef[] = [
@@ -440,6 +585,7 @@ const BRAND_SECTIONS: SectionDef[] = [
   { key: "acceptance_criteria", label: "Acceptance Criteria", check: (md) => checkAcceptanceCriteria(md, 2) },
   { key: "assets_files", label: "Assets / Files", check: checkFilesOrSchema },
   { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+  WORK_ESTIMATE_SECTION,
 ];
 
 export const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {


### PR DESCRIPTION
Implements zi007lin/zzv.io PR #35 (merged at 1c9a9eb).

## Ships in this PR

- New `checkWorkEstimate` detector in `src/lib/scoreSpec.ts` validating:
  - `## Work Estimate` H2
  - `### Active operator time` table (Phase + Estimate columns, ≥1 row + Total)
  - `### Wall-clock time` table (Wait dependency + Estimate columns, ≥1 row + Total)
  - `### Assumptions` subsection (≥1 bullet)
  - `### Actuals (filled post-execution)` table (Phase, Estimate, Actual, Delta column headers)
- Rubric check added as the LAST item in **all 9** spec types (per Phase A operator decision):
  - FEAT 9 → 10
  - BUG 7 → 8
  - HOTFIX 7 → 8
  - SPEC 6 → 7
  - CHORE 5 → 6
  - REFACTOR 9 → 10
  - RESEARCH 6 → 7
  - UX 6 → 7
  - BRAND 6 → 7
- Version bump `RUBRIC_VERSION` 1.3.1 → 1.4.0
- CHANGELOG entry + ZAI_SYSTEM_INSTRUCTIONS.md Appendix table updated for drift-detection
- New CI workflow (`.github/workflows/ci.yml`): lint + test on `pull_request` and `push` to main, ubuntu-latest
- 109 tests passing locally (was 80; added 19 — 9 backward-compat + 1 positive + 9 negative failure modes; some existing fixture-cap tests rewired to use new v1.4.0 fixtures)

## Backward compatibility

- Pre-v1.4.0 scored specs are grandfathered; their stored scores stand.
- Specs scored at v1.4.0 or later require the Work Estimate section.
- The committed legacy fixtures (`featSpec`, `bugSpec`, etc.) are NOT modified. The new backward-compat suite asserts they now FAIL only the `work_estimate` check, with every other check still PASSing — proving the new check is the only behavioral delta.

## Self-test verification

The parent SPEC (zzv.io PR #35) carries its own Work Estimate section. v1.4.0 detector run against the parent SPEC scores **7/7 PASS** with `work_estimate: PASS`. Eats its own dog food. ✅

## Honest deviations

Documented in CHANGELOG `[1.4.0] → Implementation notes`:

1. **Parent SPEC listed 7 spec types; implementation covers 9.** HOTFIX and RESEARCH rubrics exist in the codebase but were not enumerated by the parent SPEC. Per Phase A operator decision, all 9 types receive the new check.
2. **Parent SPEC's REFACTOR pre-change count was 7; actual was 9.** Implementation moves it to 10. Informational mismatch — the SPEC's count table was illustrative, not authoritative; no separate ticket per Phase A decision.
3. **`package.json` `lint` script changed from `eslint .` to `tsc --noEmit`.** ESLint was named in the script but never installed in `node_modules` (pre-existing gap surfaced during Phase A). Replacement uses already-installed TypeScript in typecheck-only mode — no new dependencies. Adding ESLint properly is a separate cleanup CHORE.
4. **No new dependencies.** The detector reuses existing string/regex helpers; the test fixtures use the existing template-string pattern.

## Branch protection (follow-up CHORE candidate)

`zi007lin/zai` `main` has **no branch protection** at the time of this PR (verified during Phase A via `gh api repos/.../branches/main/protection` returning HTTP 404). Recommend a follow-up CHORE to add protection equivalent to the daemon repo's pattern (signed commits + green CI required, dual-control review). Out of scope for this PR.

## Reference

- Spec: zi007lin/zzv.io PR #35 (merged at 1c9a9eb)
- Implementation handoff CHORE: zi007lin/zzv.io PR #36 (merged at bc041e2)

Refs zi007lin/zzv.io#11