### PR TITLE
feat: HTU Registrar CLI v1 — Cloudflare Registrar API integration (#66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test-results
 playwright-report
 .playwright
 env/
+registrar-audit.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,23 @@ To add a new pattern permanently for zai, append to the committed file
 and PR. To experiment locally, append to the local file (or accept the
 prompt). See the canonical reference doc for the full taxonomy and the
 `streettt-private` deny-heavy variant.
+
+## HTU Registrar
+
+Operator-only CLI for Cloudflare Registrar API (beta, April 2026). Wraps
+domain search / check / register / list with safety rails (`--confirm`,
+budget cap, premium flag, `--dry-run`, JSON-lines audit log). Script
+lives at `scripts/htu-registrar.mjs`; runs on Node.js 20+ with zero npm
+dependencies (built-in `fetch`).
+
+**Authority invariant:** registrar capability is operator-only in v1.
+ZiLin-Dev (the agent) does NOT have access to the API token and does
+NOT invoke the CLI. Tier-aware operation (v1.2) and bounded agent
+capability (v1.3) are deferred to separate SPECs in
+`zi007lin/htu-foundation`. Any future enablement requires a new spec
+with explicit legal review and per-run budget caps.
+
+For setup, usage, beta-API caveats, audit log schema, and forward
+roadmap, see `scripts/REGISTRAR.md` (canonical operator documentation).
+For SPEC, decision tree, game theory, and legal triggers, see
+`zi007lin/htu-foundation#66`.

--- a/scripts/REGISTRAR.md
+++ b/scripts/REGISTRAR.md
@@ -1,0 +1,369 @@
+# REGISTRAR — HTU Registrar CLI
+
+Setup, usage, and operator reference for `scripts/htu-registrar.mjs` (v1).
+
+Wraps Cloudflare's Registrar API (beta, April 2026) for domain search,
+availability check, and registration. Zero npm dependencies; runs on
+Node.js 20+ with built-in `fetch`.
+
+**Authority:** operator-driven only. ZiLin-Dev (the agent) does NOT have
+registrar capability in v1. Tier-aware operation (v1.2) and agent
+capability (v1.3) are deferred to separate SPECs. See htu-foundation#66
+for the full SPEC and authority rationale.
+
+---
+
+## Beta API caveats — operator validation required on first use
+
+Cloudflare's Registrar API launched in beta in April 2026. Field names
+and endpoint paths may shift before GA. The script's API call shapes
+are best-effort against current CF v4 API patterns; verify them on
+first use.
+
+### Three best-effort assumptions
+
+| # | Location | What it assumes | If beta differs |
+|---|----------|-----------------|-----------------|
+| 1 | `htu-registrar.mjs` L44-50 (`API_PATHS` block) | Endpoint paths follow `/accounts/:id/registrar/domains[/:domain]` | Edit the four `API_PATHS` constants to match current beta. No structural change needed. |
+| 2 | `htu-registrar.mjs` L370 (pricing extraction) | Check response exposes `price` / `cost_usd` / `registration_price` | Adjust the field-name fallback chain to whichever field name CF uses. |
+| 3 | `htu-registrar.mjs` L371 (premium flag) | Check response exposes `premium` / `is_premium` boolean | Adjust the field-name fallback chain. |
+
+### First-use validation checklist
+
+Run these in order before depending on the CLI for real registrations:
+
+1. `node scripts/htu-registrar.mjs --help` — confirm CLI loads, prints help with all four commands.
+2. `node scripts/htu-registrar.mjs --version` — confirm version string prints.
+3. `node scripts/htu-registrar.mjs check <known-domain> --use-case htu --dry-run` — replace `<known-domain>` with a domain you've already registered through the dashboard. Dry-run does not call API; confirms argument parsing.
+4. Drop `--dry-run`: `node scripts/htu-registrar.mjs check <known-domain> --use-case htu`. Compare returned fields against expected. If pricing is `null` / `undefined` or premium flag is missing, the field-name extraction (L370/L371) needs adjustment.
+5. `node scripts/htu-registrar.mjs list --use-case htu` — should return your existing CF-registered domains. If endpoint 404s, the `API_PATHS.list` constant (L49) needs adjustment.
+
+### Failure mode
+
+If endpoints differ from the constants, every command errors at first
+run with `API error 404` or similar (the script's `cfRequest` returns
+`ok: false` and the command dispatcher prints the error and exits 1).
+Edit `API_PATHS` (L44-50) and retry. The audit log records every
+failed attempt — useful for debugging mismatched paths.
+
+---
+
+## Phase 2 — Setup and onboarding
+
+One-time setup before the CLI works. Steps mirror htu-foundation#66
+§Phase-2-Setup-and-onboarding (canonical source).
+
+### 1. Create API token at Cloudflare dashboard
+
+Dashboard → My Profile → API Tokens → Create Token → Custom token.
+
+Permissions:
+- Account → Registrar → Edit
+- Account → Registrar → Read
+
+Account Resources: include the HTU account only.
+
+Save the token value — Cloudflare displays it once. Store in `.env`
+(see step 5).
+
+### 2. Configure default registrant contact in dashboard
+
+Dashboard → Domain Registration → Manage Domains → Registrant Contact
+(or per-domain contact if HTU prefers per-domain). Required because the
+API uses the dashboard-configured contact for new registrations; the
+CLI does not pass contact details per call.
+
+### 3. Verify billing profile
+
+Dashboard → Billing → Payment methods. Confirm a valid payment method
+is attached to the HTU account. Registrations bill this method
+immediately on successful registration; there is no follow-up
+authorization step.
+
+### 4. Accept Domain Registration Agreement
+
+Dashboard → Domain Registration → Domain Registration Agreement.
+One-time acceptance. The API will return `agreement_not_accepted` (or
+similar) until this is done.
+
+### 5. Set environment variables
+
+Either in a `.env` file at the repo root (gitignored) or exported in
+your shell. The script prefers `.env` if present, falls back to shell
+environment.
+
+```bash
+# .env (gitignored)
+CF_ACCOUNT_ID=<your HTU CF account ID>
+CF_REGISTRAR_API_TOKEN=<token from step 1>
+
+# optional override (default: 50)
+BUDGET_CAP_USD=50
+```
+
+Find the account ID at Dashboard → top-right account selector → URL
+contains `/accounts/<account-id>` once you click into the account.
+
+### 6. Smoke-test
+
+Run the first-use validation checklist above (Beta API caveats §First-use
+validation checklist).
+
+---
+
+## Usage
+
+CLI surface mirrors `node scripts/htu-registrar.mjs --help` output.
+
+### Commands
+
+```
+htu-registrar <command> [arguments] [flags]
+
+COMMANDS
+  search <keywords...>         Search Cloudflare's domain registry for available names.
+  check <domain>               Check availability + pricing for a specific domain.
+  register <domain> --confirm  Register a domain (requires --confirm; safety rails apply).
+  list                         List domains currently registered on HTU's CF account.
+```
+
+### Required flags (all commands)
+
+```
+  --use-case <vertical>        One of: htu, streettt-club, streettt-venue, nyqex, other
+                               If 'other', --use-case-note <text> is also required.
+```
+
+### Register-specific flags
+
+```
+  --confirm                    Required for register; registration is non-refundable.
+  --override-budget-cap        Allow registration over BUDGET_CAP_USD (audit-logged).
+  --accept-premium             Allow premium-domain registration (audit-logged).
+```
+
+### Universal flags
+
+```
+  --dry-run                    Print intended action; do not call API.
+  --help, -h                   Show this help.
+  --version, -v                Show version.
+```
+
+### Examples
+
+Search for available domains matching keywords:
+
+```bash
+node scripts/htu-registrar.mjs search ping pong club --use-case streettt-club
+```
+
+Check availability and pricing for a specific domain:
+
+```bash
+node scripts/htu-registrar.mjs check streettt-canal-essex.com --use-case streettt-venue
+```
+
+Register a domain with safety rails:
+
+```bash
+node scripts/htu-registrar.mjs register high-tech-united.com --confirm --use-case htu
+```
+
+Register with budget override (audit-logged):
+
+```bash
+node scripts/htu-registrar.mjs register premium-domain.com --confirm --override-budget-cap --accept-premium --use-case htu
+```
+
+Dry-run (prints intended action; no API call):
+
+```bash
+node scripts/htu-registrar.mjs register example-test.com --confirm --use-case htu --dry-run
+```
+
+List currently registered HTU domains:
+
+```bash
+node scripts/htu-registrar.mjs list --use-case htu
+```
+
+Use-case `other` with note:
+
+```bash
+node scripts/htu-registrar.mjs check experimental.io --use-case other --use-case-note "exploring acquisition for unrelated project"
+```
+
+### See also
+
+For environment variable setup, see §Phase 2 — Setup and onboarding.
+For audit log format, see §Audit log format. For authority model and
+operator-only invariant, see §Authority model. For Cloudflare beta-API
+caveats and operator validation checklist, see §Beta API caveats.
+
+---
+
+## Safety rails
+
+Five layered defenses (see htu-foundation#66 §Models-Applied #8 Swiss
+Cheese for the design rationale):
+
+| # | Rail | Trigger | Bypass | Audit field |
+|---|------|---------|--------|-------------|
+| 1 | `--confirm` required | `register` without flag | None — must add flag | `result_status: blocked-confirm` |
+| 2 | Budget cap | Price > BUDGET_CAP_USD (default 50) | `--override-budget-cap` | `result_status: blocked-budget`; logs `price`, `budget_cap_usd`, `override_budget_cap: true` on bypass |
+| 3 | Premium domain block | Check returns `premium: true` | `--accept-premium` | `result_status: blocked-premium`; logs `premium: true`, `accept_premium: true` on bypass |
+| 4 | `--dry-run` | Universal flag | N/A — does not call API | `result_status: dry-run` |
+| 5 | Audit log on every operation | Always, including blocks and dry-runs | Cannot disable | All rails write to `./registrar-audit.log` |
+
+The agent (ZiLin-Dev) is excluded from registrar capability entirely in
+v1 — that's the sixth defense layer (per Game Theory Cooperative
+authority gradient in spec §Game-Theory).
+
+---
+
+## Audit log format
+
+`./registrar-audit.log` — JSON-lines (one JSON object per line, newline-
+delimited). Schema is permissive; readers should ignore unknown fields.
+Aligns with the future event-log SPEC for eventual Observer integration
+(per htu-foundation#57).
+
+### Minimum fields per record
+
+| Field | Type | Always present | Notes |
+|-------|------|----------------|-------|
+| `timestamp` | string (ISO-8601 UTC) | Yes | Set by `writeAudit()` |
+| `operation` | string | Yes | `search`/`check`/`register`/`list`/`error` |
+| `use_case` | string | Yes | One of vocabulary; tagged on every audit record |
+| `use_case_note` | string \| null | Yes (null when not `other`) | Free-text when `use_case=other` |
+| `dry_run` | boolean | Yes | True if `--dry-run` was set |
+| `result_status` | string | Yes | `success`/`error`/`dry-run`/`blocked-confirm`/`blocked-budget`/`blocked-premium` |
+| `error_details` | object \| string \| null | Yes (null on success) | CF error payload or local message |
+
+### Operation-specific fields
+
+| Operation | Additional fields |
+|-----------|-------------------|
+| `search` | `keywords` (array of strings) |
+| `check` | `domain` |
+| `register` | `domain`, `price`, `premium`, `budget_cap_usd`, `override_budget_cap`, `accept_premium` |
+| `list` | (none beyond minimum) |
+| `error` (catch-all) | `subcommand` (which command threw) |
+
+### Reading the log
+
+```bash
+# pretty-print last 5 entries
+tail -n 5 registrar-audit.log | python3 -c "import sys,json; [print(json.dumps(json.loads(l), indent=2)) for l in sys.stdin]"
+
+# all blocked operations
+grep -E '"result_status":"blocked-' registrar-audit.log
+
+# all registrations (including dry-runs)
+grep '"operation":"register"' registrar-audit.log
+```
+
+### Log lifetime and rotation
+
+V1 does not implement rotation. At expected volume (< 100 operations/
+month per spec §Assumptions) the file stays small for years. If it
+grows past practicality, archive manually:
+
+```bash
+mv registrar-audit.log registrar-audit-$(date +%Y%m%d).log
+```
+
+V1.1 (Worker) is expected to ingest into D1 + Observer; local file
+becomes a fallback only.
+
+---
+
+## Legal triggers
+
+Domain registration is a financial transaction with non-refundable
+consequences. Operator responsibility before every `register --confirm`:
+
+- **Domain Registration Agreement** — accepted in dashboard (Phase 2
+  step 4); applies to every registration via the API.
+- **Trademark exposure** — registering domains that conflict with
+  existing trademarks creates legal risk. Tool does NOT check
+  trademarks. Operator does due diligence before `--confirm`.
+- **Privacy / WHOIS** — Cloudflare Registrar uses redacted WHOIS by
+  default (`privacy_mode='redaction'`). Confirm in audit that registered
+  domains have privacy enabled.
+- **Cost authorization** — registrations bill the account's payment
+  method without further authorization once API call succeeds. Budget
+  cap is the operator-side safeguard; the CLI does not insert a
+  payment-method confirmation step.
+- **Tier-2 customer billing (v1.2 — deferred)** — when registering on
+  a customer's CF account via HTU-managed admin token, the
+  registration bills the customer's account. The customer contract
+  must explicitly authorize HTU to register domains on their behalf.
+  Out of scope for v1.
+- **Agent capability (v1.3 — deferred)** — giving an agent the ability
+  to spend money creates novel liability questions. v1.3 SPEC requires
+  legal review.
+
+See htu-foundation#66 §Legal-triggers for the canonical list.
+
+---
+
+## Authority model
+
+| Actor | v1 capability | Forward |
+|-------|---------------|---------|
+| Operator (zi007lin) | Full registrar capability — runs CLI with token | Same |
+| ZiLin-Dev (agent) | NONE — does not have token, does not invoke CLI | v1.3 SPEC introduces bounded agent capability with per-run budget cap + spec-body authorization requirement |
+| Customer (downstream) | NONE — never has direct API access | v1.2 SPEC enables tier-2 onboarding flows where customer requests route through HTU-managed admin token |
+
+The agent's exclusion from financial transactions in v1 is intentional
+per spec §Game-Theory authority gradient and §Models-Applied #1 (Game
+Theory Cooperative). Each tier's capability is bounded by deliberate
+design rather than goodwill.
+
+---
+
+## Failure modes / troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `error: missing required environment variables: CF_ACCOUNT_ID, CF_REGISTRAR_API_TOKEN` | `.env` missing or vars not set | Add to `.env` per Phase 2 step 5 |
+| `error: BUDGET_CAP_USD must be a positive number` | Env var set to non-numeric or negative value | Set to a positive number, or unset to use default 50 |
+| `API error 404` on every command | Beta API endpoint paths drifted | Edit `API_PATHS` constants in `htu-registrar.mjs` L44-50 per Beta API caveats above |
+| Pricing is `null` in check output | Beta response field renamed | Adjust pricing field extraction in `htu-registrar.mjs` L370 |
+| `agreement_not_accepted` on register | Phase 2 step 4 not done | Accept Domain Registration Agreement in dashboard |
+| `unauthorized` on every command | Token lacks Registrar permissions | Recreate token per Phase 2 step 1 with both Edit and Read |
+| `extension_not_supported_via_api` | TLD not yet covered by beta | Use dashboard for that TLD; revisit when CF expands API |
+| Premium domain blocks register and operator wants to proceed | Safety rail working as designed | Add `--accept-premium` (audit-logged) |
+
+---
+
+## Forward roadmap
+
+Per spec §Final-Spec progressive disclosure (Models-Applied #11):
+
+- **v1.1 — Worker endpoint** (deferred): `registrar.htu.io` Worker exposes
+  `/search`, `/check`, `/register` with HTU-issued auth tokens; CF token
+  stored as Wrangler secret; audit log moves to D1 + Observer.
+- **v1.2 — Tier-aware operation** (deferred): per-customer CF account
+  targeting via cross-account token; `customer_id` field in audit log;
+  customer-tier-registrations table integration per three-tier customer
+  model. Will be authored as a separate FEAT spec in htu-foundation
+  post-v1-merge.
+- **v1.3 — ZiLin-Dev tool capability** (deferred, separate SPEC + legal
+  review): agent gets registrar capability via MCP; per-run budget cap
+  (lower than overall cap, e.g., $25/run); spec body must explicitly
+  authorize specific domain names; agent halts rather than improvising
+  on registration decisions.
+
+---
+
+## References
+
+- htu-foundation#66 — full FEAT SPEC (decision tree, game theory, legal
+  triggers, work estimate)
+- htu-foundation#57 — Observer SPEC v2 (future audit log destination)
+- htu-foundation#60 — three-tier customer model (v1.2 dependency)
+- Cloudflare Registrar API docs — https://developers.cloudflare.com/api/
+  (verify endpoint paths on first use; see Beta API caveats above)

--- a/scripts/htu-registrar.mjs
+++ b/scripts/htu-registrar.mjs
@@ -1,0 +1,592 @@
+#!/usr/bin/env node
+/**
+ * htu-registrar — HTU Registrar CLI v1
+ *
+ * Wraps Cloudflare's Registrar API (beta, April 2026) for domain search,
+ * availability check, and registration. Zero npm dependencies (Node.js
+ * 20+ built-in fetch).
+ *
+ * Per htu-foundation#66 (FEAT spec). Phase 1 v1 only.
+ *
+ * Authority: API token in env. Operator runs the tool; ZiLin-Dev does NOT
+ * have registrar capability in v1. v1.2 (tier-aware) and v1.3 (agent
+ * capability) are deferred to separate SPECs.
+ *
+ * Safety rails: --confirm, budget cap with override, --accept-premium,
+ * --dry-run, audit log appended to ./registrar-audit.log on every op.
+ *
+ * Audit log format: JSON-lines (one JSON object per line). Schema is
+ * permissive; readers ignore unknown fields. Aligns with future event-log
+ * SPEC for eventual migration / Observer integration (htu-foundation#57).
+ *
+ * NOTE: Cloudflare Registrar API endpoint paths below are best-effort
+ * based on CF v4 API patterns. Verify against current CF docs at
+ * https://developers.cloudflare.com/api/ (search "registrar") on first
+ * use; adjust constants in the API_PATHS block if needed.
+ */
+
+import { appendFile, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+// ─────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────
+
+const CLI_NAME = 'htu-registrar';
+const VERSION = '1.0.0';
+
+const BUDGET_CAP_USD_DEFAULT = 50;
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+const API_PATHS = {
+  // verify against current CF Registrar API docs on first use
+  search: (accountId) => `/accounts/${accountId}/registrar/domains/search`,
+  check: (accountId, domain) => `/accounts/${accountId}/registrar/domains/${domain}`,
+  register: (accountId, domain) => `/accounts/${accountId}/registrar/domains/${domain}`,
+  list: (accountId) => `/accounts/${accountId}/registrar/domains`,
+};
+
+const REQUIRED_ENV = ['CF_ACCOUNT_ID', 'CF_REGISTRAR_API_TOKEN'];
+
+const USE_CASES = ['htu', 'streettt-club', 'streettt-venue', 'nyqex', 'other'];
+
+const AUDIT_LOG_PATH = './registrar-audit.log';
+
+// ─────────────────────────────────────────────────────────────────────
+// .env loader (zero deps; falls back to shell env)
+// ─────────────────────────────────────────────────────────────────────
+
+async function loadDotEnv() {
+  const envPath = resolve(process.cwd(), '.env');
+  if (!existsSync(envPath)) return;
+  const text = await readFile(envPath, 'utf8');
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+    if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+
+function validateEnv() {
+  const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    process.stderr.write(
+      `error: missing required environment variables: ${missing.join(', ')}\n` +
+      `       set them in .env (gitignored) or export from your shell\n` +
+      `       see scripts/REGISTRAR.md for setup steps\n`
+    );
+    process.exit(2);
+  }
+}
+
+function getBudgetCap() {
+  const raw = process.env.BUDGET_CAP_USD;
+  if (!raw) return BUDGET_CAP_USD_DEFAULT;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(
+      `error: BUDGET_CAP_USD must be a positive number; got ${JSON.stringify(raw)}\n`
+    );
+    process.exit(2);
+  }
+  return n;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Argument parser (zero deps)
+// ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  // argv: [node, script, subcommand, ...rest]
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    return { subcommand: 'help' };
+  }
+  if (args[0] === '--version' || args[0] === '-v') {
+    return { subcommand: 'version' };
+  }
+  const subcommand = args[0];
+  const rest = args.slice(1);
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (token.startsWith('--')) {
+      const name = token.slice(2);
+      const next = rest[i + 1];
+      // Boolean flags vs flags-with-values: known boolean flags first
+      if (['confirm', 'override-budget-cap', 'accept-premium', 'dry-run', 'help'].includes(name)) {
+        flags[name] = true;
+      } else if (next !== undefined && !next.startsWith('--')) {
+        flags[name] = next;
+        i += 1;
+      } else {
+        flags[name] = true;
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { subcommand, positional, flags };
+}
+
+function validateUseCase(flags) {
+  const useCase = flags['use-case'];
+  if (!useCase) {
+    return { ok: false, error: 'missing required flag: --use-case <htu|streettt-club|streettt-venue|nyqex|other>' };
+  }
+  if (!USE_CASES.includes(useCase)) {
+    return {
+      ok: false,
+      error: `invalid --use-case value ${JSON.stringify(useCase)}; expected one of: ${USE_CASES.join(', ')}`,
+    };
+  }
+  if (useCase === 'other') {
+    const note = flags['use-case-note'];
+    if (!note || typeof note !== 'string' || note.trim() === '') {
+      return {
+        ok: false,
+        error: '--use-case=other requires --use-case-note <free-text> to be set',
+      };
+    }
+  }
+  return { ok: true, useCase, useCaseNote: flags['use-case-note'] || null };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Audit log (JSON-lines, one record per line)
+// ─────────────────────────────────────────────────────────────────────
+
+async function writeAudit(record) {
+  const enriched = {
+    timestamp: new Date().toISOString(),
+    ...record,
+  };
+  const line = JSON.stringify(enriched) + '\n';
+  try {
+    await appendFile(AUDIT_LOG_PATH, line, 'utf8');
+  } catch (err) {
+    process.stderr.write(`warning: could not write audit log: ${err.message}\n`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Cloudflare API client
+// ─────────────────────────────────────────────────────────────────────
+
+async function cfRequest(path, { method = 'GET', body = null, dryRun = false } = {}) {
+  const url = `${CF_API_BASE}${path}`;
+  const accountId = process.env.CF_ACCOUNT_ID;
+  const token = process.env.CF_REGISTRAR_API_TOKEN;
+
+  if (dryRun) {
+    return {
+      _dry_run: true,
+      method,
+      url,
+      account_id: accountId,
+      body: body ?? null,
+    };
+  }
+
+  const init = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+  if (body !== null) init.body = JSON.stringify(body);
+
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return { ok: false, status: response.status, error: 'non-JSON response', body: text };
+  }
+  if (!response.ok || (json && json.success === false)) {
+    return { ok: false, status: response.status, error: json.errors || json, body: json };
+  }
+  return { ok: true, status: response.status, body: json };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Command: search
+// ─────────────────────────────────────────────────────────────────────
+
+async function cmdSearch(positional, flags) {
+  const useCaseResult = validateUseCase(flags);
+  if (!useCaseResult.ok) {
+    process.stderr.write(`error: ${useCaseResult.error}\n`);
+    process.exit(2);
+  }
+  if (positional.length === 0) {
+    process.stderr.write(`error: search requires at least one keyword\n`);
+    process.exit(2);
+  }
+  const accountId = process.env.CF_ACCOUNT_ID;
+  const dryRun = flags['dry-run'] === true;
+
+  const result = await cfRequest(API_PATHS.search(accountId), {
+    method: 'POST',
+    body: { keywords: positional },
+    dryRun,
+  });
+
+  await writeAudit({
+    operation: 'search',
+    keywords: positional,
+    use_case: useCaseResult.useCase,
+    use_case_note: useCaseResult.useCaseNote,
+    dry_run: dryRun,
+    result_status: dryRun ? 'dry-run' : result.ok ? 'success' : 'error',
+    error_details: result.ok ? null : result.error,
+  });
+
+  if (dryRun) {
+    process.stdout.write(`[dry-run] would POST ${API_PATHS.search(accountId)} with keywords=${JSON.stringify(positional)}\n`);
+    return;
+  }
+  if (!result.ok) {
+    process.stderr.write(`error: search failed: ${JSON.stringify(result.error)}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(result.body, null, 2) + '\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Command: check
+// ─────────────────────────────────────────────────────────────────────
+
+async function cmdCheck(positional, flags) {
+  const useCaseResult = validateUseCase(flags);
+  if (!useCaseResult.ok) {
+    process.stderr.write(`error: ${useCaseResult.error}\n`);
+    process.exit(2);
+  }
+  if (positional.length !== 1) {
+    process.stderr.write(`error: check requires exactly one domain argument\n`);
+    process.exit(2);
+  }
+  const domain = positional[0];
+  const accountId = process.env.CF_ACCOUNT_ID;
+  const dryRun = flags['dry-run'] === true;
+
+  const result = await cfRequest(API_PATHS.check(accountId, domain), {
+    method: 'GET',
+    dryRun,
+  });
+
+  await writeAudit({
+    operation: 'check',
+    domain,
+    use_case: useCaseResult.useCase,
+    use_case_note: useCaseResult.useCaseNote,
+    dry_run: dryRun,
+    result_status: dryRun ? 'dry-run' : result.ok ? 'success' : 'error',
+    error_details: result.ok ? null : result.error,
+  });
+
+  if (dryRun) {
+    process.stdout.write(`[dry-run] would GET ${API_PATHS.check(accountId, domain)}\n`);
+    return;
+  }
+  if (!result.ok) {
+    process.stderr.write(`error: check failed: ${JSON.stringify(result.error)}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(result.body, null, 2) + '\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Command: register (with safety rails)
+// ─────────────────────────────────────────────────────────────────────
+
+async function cmdRegister(positional, flags) {
+  const useCaseResult = validateUseCase(flags);
+  if (!useCaseResult.ok) {
+    process.stderr.write(`error: ${useCaseResult.error}\n`);
+    process.exit(2);
+  }
+  if (positional.length !== 1) {
+    process.stderr.write(`error: register requires exactly one domain argument\n`);
+    process.exit(2);
+  }
+  const domain = positional[0];
+  const dryRun = flags['dry-run'] === true;
+  const accountId = process.env.CF_ACCOUNT_ID;
+
+  // Safety rail #1: --confirm required
+  if (!flags.confirm) {
+    await writeAudit({
+      operation: 'register',
+      domain,
+      use_case: useCaseResult.useCase,
+      use_case_note: useCaseResult.useCaseNote,
+      dry_run: dryRun,
+      result_status: 'blocked-confirm',
+      error_details: '--confirm flag not provided',
+    });
+    process.stderr.write(
+      `error: register requires --confirm flag (registration is non-refundable)\n` +
+      `       run with --dry-run first to verify intent\n`
+    );
+    process.exit(2);
+  }
+
+  // Pre-register: pricing check
+  const checkResult = await cfRequest(API_PATHS.check(accountId, domain), {
+    method: 'GET',
+    dryRun: false, // always make this call even if the user requested --dry-run, to log pricing
+  });
+  if (!checkResult.ok && !dryRun) {
+    await writeAudit({
+      operation: 'register',
+      domain,
+      use_case: useCaseResult.useCase,
+      use_case_note: useCaseResult.useCaseNote,
+      dry_run: dryRun,
+      result_status: 'error',
+      error_details: `pre-register check failed: ${JSON.stringify(checkResult.error)}`,
+    });
+    process.stderr.write(`error: pre-register check failed: ${JSON.stringify(checkResult.error)}\n`);
+    process.exit(1);
+  }
+
+  // Extract price + premium status from check response
+  // Adjust these field paths if CF Registrar API uses different shape
+  const checkBody = checkResult.body?.result || checkResult.body || {};
+  const price = checkBody.price ?? checkBody.cost_usd ?? checkBody.registration_price ?? null;
+  const isPremium = Boolean(checkBody.premium ?? checkBody.is_premium ?? false);
+
+  // Safety rail #2: budget cap (with override)
+  const budgetCap = getBudgetCap();
+  if (typeof price === 'number' && price > budgetCap && !flags['override-budget-cap']) {
+    await writeAudit({
+      operation: 'register',
+      domain,
+      price,
+      premium: isPremium,
+      budget_cap_usd: budgetCap,
+      use_case: useCaseResult.useCase,
+      use_case_note: useCaseResult.useCaseNote,
+      dry_run: dryRun,
+      result_status: 'blocked-budget',
+      error_details: `price ${price} exceeds budget cap ${budgetCap}; pass --override-budget-cap to proceed`,
+    });
+    process.stderr.write(
+      `error: domain ${domain} price ${price} USD exceeds budget cap ${budgetCap} USD\n` +
+      `       pass --override-budget-cap to proceed (audit-logged)\n`
+    );
+    process.exit(2);
+  }
+
+  // Safety rail #3: premium domain flag
+  if (isPremium && !flags['accept-premium']) {
+    await writeAudit({
+      operation: 'register',
+      domain,
+      price,
+      premium: isPremium,
+      use_case: useCaseResult.useCase,
+      use_case_note: useCaseResult.useCaseNote,
+      dry_run: dryRun,
+      result_status: 'blocked-premium',
+      error_details: 'premium domain detected; --accept-premium not set',
+    });
+    process.stderr.write(
+      `error: domain ${domain} is a premium registration (price ${price} USD)\n` +
+      `       pass --accept-premium to proceed (audit-logged)\n`
+    );
+    process.exit(2);
+  }
+
+  // Proceed with registration
+  const registerResult = await cfRequest(API_PATHS.register(accountId, domain), {
+    method: 'POST',
+    body: { confirm: true },
+    dryRun,
+  });
+
+  await writeAudit({
+    operation: 'register',
+    domain,
+    price,
+    premium: isPremium,
+    budget_cap_usd: budgetCap,
+    override_budget_cap: Boolean(flags['override-budget-cap']),
+    accept_premium: Boolean(flags['accept-premium']),
+    use_case: useCaseResult.useCase,
+    use_case_note: useCaseResult.useCaseNote,
+    dry_run: dryRun,
+    result_status: dryRun ? 'dry-run' : registerResult.ok ? 'success' : 'error',
+    error_details: registerResult.ok ? null : registerResult.error,
+  });
+
+  if (dryRun) {
+    process.stdout.write(
+      `[dry-run] would POST ${API_PATHS.register(accountId, domain)}\n` +
+      `[dry-run] price=${price} USD; premium=${isPremium}; budget=${budgetCap}\n`
+    );
+    return;
+  }
+  if (!registerResult.ok) {
+    process.stderr.write(`error: registration failed: ${JSON.stringify(registerResult.error)}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`✓ registered ${domain} (price ${price} USD)\n`);
+  process.stdout.write(JSON.stringify(registerResult.body, null, 2) + '\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Command: list
+// ─────────────────────────────────────────────────────────────────────
+
+async function cmdList(positional, flags) {
+  const useCaseResult = validateUseCase(flags);
+  if (!useCaseResult.ok) {
+    process.stderr.write(`error: ${useCaseResult.error}\n`);
+    process.exit(2);
+  }
+  const accountId = process.env.CF_ACCOUNT_ID;
+  const dryRun = flags['dry-run'] === true;
+
+  const result = await cfRequest(API_PATHS.list(accountId), {
+    method: 'GET',
+    dryRun,
+  });
+
+  await writeAudit({
+    operation: 'list',
+    use_case: useCaseResult.useCase,
+    use_case_note: useCaseResult.useCaseNote,
+    dry_run: dryRun,
+    result_status: dryRun ? 'dry-run' : result.ok ? 'success' : 'error',
+    error_details: result.ok ? null : result.error,
+  });
+
+  if (dryRun) {
+    process.stdout.write(`[dry-run] would GET ${API_PATHS.list(accountId)}\n`);
+    return;
+  }
+  if (!result.ok) {
+    process.stderr.write(`error: list failed: ${JSON.stringify(result.error)}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(result.body, null, 2) + '\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Help text
+// ─────────────────────────────────────────────────────────────────────
+
+function printHelp() {
+  process.stdout.write(`${CLI_NAME} v${VERSION} — HTU Registrar CLI
+
+USAGE
+  ${CLI_NAME} <command> [arguments] [flags]
+
+COMMANDS
+  search <keywords...>         Search Cloudflare's domain registry for available names.
+  check <domain>               Check availability + pricing for a specific domain.
+  register <domain> --confirm  Register a domain (requires --confirm; safety rails apply).
+  list                         List domains currently registered on HTU's CF account.
+
+REQUIRED FLAGS (all commands)
+  --use-case <vertical>        One of: ${USE_CASES.join(', ')}
+                               If 'other', --use-case-note <text> is also required.
+
+REGISTER-SPECIFIC FLAGS
+  --confirm                    Required for register; registration is non-refundable.
+  --override-budget-cap        Allow registration over BUDGET_CAP_USD (audit-logged).
+  --accept-premium             Allow premium-domain registration (audit-logged).
+
+UNIVERSAL FLAGS
+  --dry-run                    Print intended action; do not call API.
+  --help, -h                   Show this help.
+  --version, -v                Show version.
+
+ENVIRONMENT
+  CF_ACCOUNT_ID                Cloudflare account ID (required).
+  CF_REGISTRAR_API_TOKEN       CF API token with Registrar write permissions (required).
+  BUDGET_CAP_USD               Override default budget cap (default: ${BUDGET_CAP_USD_DEFAULT}).
+
+  Loaded from .env in cwd if present (gitignored); falls back to shell env.
+
+AUDIT LOG
+  ${AUDIT_LOG_PATH}             JSON-lines; appended on every operation.
+
+DOCUMENTATION
+  See scripts/REGISTRAR.md for setup steps + per-command examples.
+
+AUTHORITY
+  Operator runs the tool. ZiLin-Dev (agent) does NOT have registrar
+  capability in v1. v1.2 (tier-aware) and v1.3 (agent capability) are
+  deferred to separate SPECs.
+`);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const parsed = parseArgs(process.argv);
+
+  if (parsed.subcommand === 'help') {
+    printHelp();
+    return;
+  }
+  if (parsed.subcommand === 'version') {
+    process.stdout.write(`${CLI_NAME} v${VERSION}\n`);
+    return;
+  }
+
+  await loadDotEnv();
+  validateEnv();
+
+  const { subcommand, positional, flags } = parsed;
+
+  try {
+    switch (subcommand) {
+      case 'search':
+        await cmdSearch(positional, flags);
+        break;
+      case 'check':
+        await cmdCheck(positional, flags);
+        break;
+      case 'register':
+        await cmdRegister(positional, flags);
+        break;
+      case 'list':
+        await cmdList(positional, flags);
+        break;
+      default:
+        process.stderr.write(`error: unknown command ${JSON.stringify(subcommand)}\n`);
+        printHelp();
+        process.exit(2);
+    }
+  } catch (err) {
+    await writeAudit({
+      operation: 'error',
+      subcommand,
+      error_details: err.message || String(err),
+      result_status: 'error',
+    });
+    process.stderr.write(`error: ${err.message || String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements HTU Registrar CLI v1 per spec at zi007lin/htu-foundation#66 (cross-repo: audit artifact filed in htu-foundation, implementation lands here in zai).

Wraps Cloudflare's Registrar API (beta, April 2026) for domain search / check / register / list with safety rails — `--confirm`, budget cap, premium flag, `--dry-run`, JSON-lines audit log. Zero npm dependencies; Node.js 20+ built-in `fetch`.

## Files changed (4)

- `scripts/htu-registrar.mjs` — NEW, 592 lines, zero npm deps, four commands with five layered safety rails
- `scripts/REGISTRAR.md` — NEW, 369 lines: setup, usage, **§Beta API caveats** (operator validation required on first use), audit log schema, authority model, troubleshooting, forward roadmap
- `CLAUDE.md` — UPDATED, +20 lines: `## HTU Registrar` section stating operator-only authority invariant + pointers to canonical docs
- `.gitignore` — UPDATED, +1 line: explicit `registrar-audit.log` per spec §Files (existing `*.log` wildcard already covered the case; explicit line added for self-documentation)

## Authority invariant

**Operator-only in v1.** ZiLin-Dev (the agent) does NOT have registrar capability in v1 — does not have access to the API token and does not invoke the CLI. Tier-aware operation (v1.2) and bounded agent capability (v1.3) are deferred to separate SPECs in zi007lin/htu-foundation.

## Cross-repo coordination

- Spec + audit artifact: zi007lin/htu-foundation#66
- Implementation (this PR): scripts + governance updates in zai
- The cross-repo audit-artifact convention follows the pattern established in earlier PRs (audit spec in htu-foundation, implementation in target repo)

Closes zi007lin/htu-foundation#66

## Test plan

- [ ] CLI loads cleanly: `node scripts/htu-registrar.mjs --help`
- [ ] Version prints: `node scripts/htu-registrar.mjs --version`
- [ ] Phase 3 operator validation per `scripts/REGISTRAR.md` §Beta API caveats §First-use validation checklist (5 steps; post-merge, operator-driven with real CF token)
- [ ] Phase 4 defensive registrations (operator-driven, post-merge: high-tech-united.com + htu.com if available)

## Reviewer

daniel-silvers per dual-control authority chain.