### PR TITLE
feat: add EPIC spec type to ZAI rubric, bump v1.4.0 → v1.5.0 (PR 1 of 2)

### DIFF
--- a/src/lib/scoreSpec.test.ts
+++ b/src/lib/scoreSpec.test.ts
@@ -744,8 +744,8 @@ describe("scoreSpec — gates and meta", () => {
     expect(r.gates[0]).toMatch(/chain/i);
   });
 
-  it("rubric version is 1.4.0", () => {
-    expect(scoreSpec(featSpec140, "2026-04-13__feat__x.md").rubric_version).toBe("1.4.0");
+  it("rubric version is 1.5.0", () => {
+    expect(scoreSpec(featSpec140, "2026-04-13__feat__x.md").rubric_version).toBe("1.5.0");
   });
 
   it("non-matching filename throws SpecTypeError (previously silently fell back to feat)", () => {
@@ -1328,5 +1328,260 @@ just a paragraph with no bullets at all.
     expect(r.section_reasons.work_estimate).toMatch(/Actuals.*missing required column headers/);
     expect(r.section_reasons.work_estimate).toMatch(/Actual/);
     expect(r.section_reasons.work_estimate).toMatch(/Delta/);
+  });
+});
+
+// ─── EPIC rubric (v1.5.0) ─────────────────────────────────────────────────
+//
+// 10-check coverage for the EPIC spec type added in FEAT zzv-skills#27.
+// Includes the two edge cases the spec calls out explicitly: anti-bypass
+// (a 1-phase document fails check #3) and explicit-none reversibility
+// (`Reversibility: none — see Risks #N` passes check #6).
+
+const epicSpec = `# EPIC: example tracking issue
+
+## Intent
+A tight strategic framing well under two hundred words: why this multi-
+phase initiative exists and what cross-team work it coordinates.
+
+## Architectural decision
+| Option | Chosen/Rejected | Rationale |
+|---|---|---|
+| A | Chosen | best fit, lowest blast radius |
+| B | Rejected | too costly to maintain |
+
+## Phases
+
+### Phase 1 — foundation
+- Type: feat
+- Status: in progress
+- Depends on: nothing
+- Acceptance: foundation tests green
+- [ ] foundation shipped
+
+### Phase 2 — rollout
+- Type: chore
+- Status: planned
+- Blocks: no downstream work yet
+- Acceptance: rollout verified in prod
+- [ ] rollout complete
+
+## Cross-model validation
+| Model | Verdict |
+|---|---|
+| #1 Game Theory Cooperative | incentive-compatible |
+| #2 Decision Tree | options mapped, choice recorded |
+| #15 Inversion / Premortem | failure modes enumerated |
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| version drift between engines | bounded re-port window |
+| scope creep across phases | per-phase acceptance gates |
+
+## Reversibility
+Reversibility: none — see Risks #1.
+
+## Cost projection
+- At launch: two PRs, ~5h wall-clock
+- At scale: linear with phase count
+
+## Dependencies
+- None
+
+## Tracking checklist
+- [ ] Phase 1 merged
+- [ ] Phase 2 merged
+
+## Legal triggers
+None.
+`;
+
+describe("scoreSpec — epic (v1.5.0)", () => {
+  it("scores a compliant EPIC spec 10/10 passed", () => {
+    const r = scoreSpec(epicSpec, "2026-05-11__epic__example.md");
+    expect(r.spec_type).toBe("epic");
+    expect(r.required_count).toBe(10);
+    expect(r.score).toBe("10/10");
+    expect(r.passed).toBe(true);
+    expect(r.rubric_version).toBe("1.5.0");
+    for (const key of r.section_order) {
+      if (r.sections[key] !== "FAIL") expect(r.section_reasons[key]).toBeNull();
+    }
+  });
+
+  it("section order matches the 10-check EPIC rubric", () => {
+    const r = scoreSpec(epicSpec, "2026-05-11__epic__example.md");
+    expect(r.section_order).toEqual([
+      "intent",
+      "architectural_decision",
+      "phases",
+      "cross_model_validation",
+      "risks_mitigations",
+      "escape_hatch",
+      "cost_projection",
+      "dependencies",
+      "tracking_checklist",
+      "legal_triggers",
+    ]);
+  });
+
+  it("[anti-bypass] a 1-phase document fails check #3 (phases)", () => {
+    const md = epicSpec.replace(
+      /### Phase 2 — rollout[\s\S]*?(?=\n## Cross-model)/,
+      "",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.phases).toBe("FAIL");
+    expect(r.section_reasons.phases).toMatch(/at least 2/i);
+    expect(r.section_reasons.phases).toMatch(/non-EPIC type/i);
+  });
+
+  it("[explicit-none] `Reversibility: none — see Risks #N` passes check #6", () => {
+    // The base fixture already uses this phrasing; assert it directly.
+    const r = scoreSpec(epicSpec, "2026-05-11__epic__example.md");
+    expect(r.sections.escape_hatch).toBe("PASS");
+  });
+
+  it("accepts `## Escape hatch` as an alternative to `## Reversibility`", () => {
+    const md = epicSpec.replace(
+      /## Reversibility\nReversibility: none — see Risks #1\.\n/,
+      "## Escape hatch\nIf Phase 2 stalls past the bound, roll back Phase 1's version bump.\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.escape_hatch).toBe("PASS");
+  });
+
+  it("empty Reversibility section fails check #6", () => {
+    const md = epicSpec.replace(
+      /## Reversibility\nReversibility: none — see Risks #1\.\n/,
+      "## Reversibility\n\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.escape_hatch).toBe("FAIL");
+    expect(r.section_reasons.escape_hatch).toMatch(/empty/i);
+  });
+
+  it("missing `## Cross-model validation` fails check #4", () => {
+    const md = epicSpec.replace(/## Cross-model validation\n[\s\S]*?(?=\n## Risks)/, "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.cross_model_validation).toBe("FAIL");
+    expect(r.section_reasons.cross_model_validation).toMatch(/Cross-model validation/i);
+  });
+
+  it("cross-model with fewer than 3 distinct model refs fails check #4", () => {
+    const md = epicSpec.replace(
+      /\| #2 Decision Tree \| options mapped, choice recorded \|\n\| #15 Inversion \/ Premortem \| failure modes enumerated \|\n/,
+      "",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.cross_model_validation).toBe("FAIL");
+    expect(r.section_reasons.cross_model_validation).toMatch(/at least 3 distinct/i);
+  });
+
+  it("phase missing a type label fails check #3", () => {
+    const md = epicSpec.replace("- Type: feat\n", "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.phases).toBe("FAIL");
+    expect(r.section_reasons.phases).toMatch(/type label/i);
+  });
+
+  it("phase missing a status line fails check #3", () => {
+    const md = epicSpec.replace("- Status: in progress\n", "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.phases).toBe("FAIL");
+    expect(r.section_reasons.phases).toMatch(/status/i);
+  });
+
+  it("phase missing a Depends-on/Blocks line fails check #3", () => {
+    const md = epicSpec.replace("- Depends on: nothing\n", "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.phases).toBe("FAIL");
+    expect(r.section_reasons.phases).toMatch(/Depends on.*Blocks/i);
+  });
+
+  it("phase missing acceptance criteria fails check #3", () => {
+    // Remove both the checkbox and the "Acceptance:" line from Phase 1.
+    const md = epicSpec
+      .replace("- Acceptance: foundation tests green\n", "")
+      .replace("- [ ] foundation shipped\n", "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.phases).toBe("FAIL");
+    expect(r.section_reasons.phases).toMatch(/acceptance/i);
+  });
+
+  it("tracking checklist with fewer checkboxes than phases fails check #9", () => {
+    const md = epicSpec.replace("- [ ] Phase 2 merged\n", "");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.tracking_checklist).toBe("FAIL");
+    expect(r.section_reasons.tracking_checklist).toMatch(/checkbox per Phase/i);
+  });
+
+  it("architectural decision without a table fails check #2", () => {
+    const md = epicSpec.replace(
+      /\| Option \| Chosen\/Rejected \| Rationale \|\n\|---\|---\|---\|\n\| A \| Chosen \| best fit, lowest blast radius \|\n\| B \| Rejected \| too costly to maintain \|\n/,
+      "We picked A over B.\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.architectural_decision).toBe("FAIL");
+    expect(r.section_reasons.architectural_decision).toMatch(/markdown table/i);
+  });
+
+  it("risks & mitigations without a table fails check #5", () => {
+    const md = epicSpec.replace(
+      /\| Risk \| Mitigation \|\n\|---\|---\|\n\| version drift between engines \| bounded re-port window \|\n\| scope creep across phases \| per-phase acceptance gates \|\n/,
+      "Risks are managed via phase gates.\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.risks_mitigations).toBe("FAIL");
+    expect(r.section_reasons.risks_mitigations).toMatch(/markdown table/i);
+  });
+
+  it("cost projection with only one line fails check #7", () => {
+    const md = epicSpec.replace(
+      "- At launch: two PRs, ~5h wall-clock\n- At scale: linear with phase count\n",
+      "- At launch: two PRs\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.cost_projection).toBe("FAIL");
+    expect(r.section_reasons.cost_projection).toMatch(/table or ≥2/i);
+  });
+
+  it("cost projection as a table with ≥2 rows passes check #7", () => {
+    const md = epicSpec.replace(
+      "## Cost projection\n- At launch: two PRs, ~5h wall-clock\n- At scale: linear with phase count\n",
+      "## Cost projection\n| Horizon | Cost |\n|---|---|\n| At launch | 2 PRs / ~5h |\n| At scale | linear with phases |\n",
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.cost_projection).toBe("PASS");
+  });
+
+  it("accepts `## Dependencies on other tracked work` as the dependencies heading", () => {
+    const md = epicSpec.replace("## Dependencies\n- None\n", "## Dependencies on other tracked work\n- htu-foundation#67\n");
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.dependencies).toBe("PASS");
+  });
+
+  it("intent over 200 words fails check #1 for epic", () => {
+    const long = Array.from({ length: 210 }, (_, i) => `word${i}`).join(" ");
+    const md = epicSpec.replace(
+      /## Intent\nA tight strategic framing[^\n]*\n[^\n]*\n/,
+      `## Intent\n${long}\n`,
+    );
+    const r = scoreSpec(md, "2026-05-11__epic__x.md");
+    expect(r.sections.intent).toBe("FAIL");
+    expect(r.section_reasons.intent).toMatch(/200-word cap/i);
+    expect(r.section_reasons.intent).toMatch(/EPIC/);
+  });
+
+  it("`epic` is in KNOWN_TYPES and has a RUBRIC_SECTION_KEYS entry with 10 checks", () => {
+    expect((KNOWN_TYPES as readonly string[]).includes("epic")).toBe(true);
+    expect(RUBRIC_SECTION_KEYS.epic).toBeDefined();
+    expect(RUBRIC_SECTION_KEYS.epic.length).toBe(10);
+    expect(INTENT_CAPS.epic).toBe(200);
+  });
+
+  it("detectSpecType recognizes the epic filename prefix", () => {
+    expect(detectSpecType("2026-05-11__epic__example.md")).toBe("epic");
   });
 });

--- a/src/lib/scoreSpec.ts
+++ b/src/lib/scoreSpec.ts
@@ -9,7 +9,8 @@ export type SpecType =
   | "refactor"
   | "research"
   | "ux"
-  | "brand";
+  | "brand"
+  | "epic";
 
 export interface ScoreResult {
   rubric_version: string;
@@ -34,12 +35,16 @@ export class SpecTypeError extends Error {
   }
 }
 
-const RUBRIC_VERSION = "1.4.0";
+// v1.5.0 (FEAT zzv-skills#27): adds EPIC as a first-class spec type —
+// 10 EPIC-specific checks for tracking issues that coordinate multi-
+// phase strategic work. Additive only; no existing spec type changes.
+const RUBRIC_VERSION = "1.5.0";
 
 // Per-type Intent word caps. FEAT/BUG/UX/BRAND stay at 150 where compression
 // is a virtue; CHORE stays at 100; SPEC and REFACTOR rise to 250 because they
 // must frame actors, scope, deferrals, reversibility; RESEARCH rises to 200
-// to set up context for the research questions that follow.
+// to set up context for the research questions that follow; EPIC rises to 200
+// to frame the strategic problem space ahead of the Phases breakdown.
 export const INTENT_CAPS: Record<SpecType, number> = {
   feat: 150,
   bug: 150,
@@ -50,6 +55,7 @@ export const INTENT_CAPS: Record<SpecType, number> = {
   research: 200,
   ux: 150,
   brand: 150,
+  epic: 200,
 };
 
 // ─── helpers ──────────────────────────────────────────────────────────────
@@ -202,6 +208,17 @@ const ACTIVE_OPERATOR_HEADING = /^###\s+Active\s+operator\s+time\b/mi;
 const WALL_CLOCK_HEADING = /^###\s+Wall[-\s]?clock\s+time\b/mi;
 const ASSUMPTIONS_HEADING = /^###\s+Assumptions\b/mi;
 const ACTUALS_HEADING = /^###\s+Actuals\b/mi;
+
+// ─── EPIC headings (v1.5.0) ───────────────────────────────────────────────
+const EPIC_ARCH_DECISION_HEADING = /^##\s+Architectural\s+decision\b/mi;
+const EPIC_PHASES_HEADING = /^##\s+Phases\b/mi;
+const EPIC_PHASE_SUBHEADING_RE = /^###\s+Phase\b/i; // per-line test in splitPhases
+const EPIC_CROSS_MODEL_HEADING = /^##\s+Cross[-\s]?model\s+validation\b/mi;
+const EPIC_RISKS_HEADING = /^##\s+Risks\s*(&|and)\s*mitigations\b/mi;
+const EPIC_ESCAPE_OR_REVERSIBILITY_HEADING = /^##\s+(Escape\s+hatch|Reversibility)\b/mi;
+const EPIC_COST_HEADING = /^##\s+Cost\s+projection\b/mi;
+const EPIC_DEPENDENCIES_HEADING = /^##\s+Dependencies(\s+on\s+other\s+tracked\s+work)?\b/mi;
+const EPIC_TRACKING_HEADING = /^##\s+Tracking\s+checklist\b/mi;
 
 // ─── section checks ───────────────────────────────────────────────────────
 
@@ -477,6 +494,164 @@ function checkWorkEstimate(md: string): CheckResult {
   return pass();
 }
 
+// ─── EPIC section checks (v1.5.0) ─────────────────────────────────────────
+
+const PHASE_TYPE_TOKEN_RE = /\b(feat|bug|spec|chore|refactor|ux|brand)\b/i;
+const DEPENDS_OR_BLOCKS_RE = /\b(depends\s+on|blocks)\b/i;
+
+// Split a `## Phases` section body into per-`### Phase` chunks. Lines
+// before the first `### Phase` are discarded (intro prose). Each chunk
+// retains its own `### Phase …` heading line plus everything up to the
+// next `### Phase` heading.
+function splitPhases(phasesBody: string): string[] {
+  const out: string[] = [];
+  let current: string[] | null = null;
+  for (const line of phasesBody.split(/\r?\n/)) {
+    if (EPIC_PHASE_SUBHEADING_RE.test(line)) {
+      if (current) out.push(current.join("\n"));
+      current = [line];
+    } else if (current) {
+      current.push(line);
+    }
+  }
+  if (current) out.push(current.join("\n"));
+  return out;
+}
+
+function checkEpicArchDecision(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_ARCH_DECISION_HEADING))
+    return fail('"## Architectural decision" heading not found');
+  const body = sectionBody(md, EPIC_ARCH_DECISION_HEADING);
+  if (!tablePresent(body))
+    return fail(
+      '"## Architectural decision" requires a markdown table (Option | Chosen/Rejected | Rationale)',
+    );
+  const rows = tableDataRowCount(body);
+  if (rows < 2)
+    return fail(
+      `"## Architectural decision" table needs ≥2 option rows — found ${rows}`,
+    );
+  return pass();
+}
+
+function checkEpicPhases(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_PHASES_HEADING))
+    return fail('"## Phases" heading not found');
+  const phases = splitPhases(sectionBody(md, EPIC_PHASES_HEADING));
+  if (phases.length < 2)
+    return fail(
+      `at least 2 "### Phase" subheadings required — found ${phases.length} ` +
+        `(single-phase strategic work should be filed as the appropriate non-EPIC type)`,
+    );
+  for (let i = 0; i < phases.length; i++) {
+    const p = phases[i];
+    const tag = `phase #${i + 1}`;
+    if (!PHASE_TYPE_TOKEN_RE.test(p))
+      return fail(
+        `${tag} missing a type label (one of feat|bug|spec|chore|refactor|ux|brand)`,
+      );
+    if (!/\bstatus\b/i.test(p)) return fail(`${tag} missing a "status" line`);
+    if (!DEPENDS_OR_BLOCKS_RE.test(p))
+      return fail(`${tag} missing a "Depends on" or "Blocks" line`);
+    if (checkboxCount(p) < 1 && !/\bacceptance\b/i.test(p))
+      return fail(
+        `${tag} missing acceptance criteria (a checkbox or an "acceptance" line)`,
+      );
+  }
+  return pass();
+}
+
+function checkEpicCrossModel(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_CROSS_MODEL_HEADING))
+    return fail('"## Cross-model validation" heading not found');
+  const body = sectionBody(md, EPIC_CROSS_MODEL_HEADING);
+  const refs = new Set<string>();
+  for (const m of body.matchAll(/#(\d{1,2})\b/g)) {
+    const n = Number(m[1]);
+    if (n >= 1 && n <= 16) refs.add(String(n));
+  }
+  if (refs.size < 3)
+    return fail(
+      `at least 3 distinct model references (#1–#16) required — found ${refs.size}`,
+    );
+  const structuredLines = bulletListCount(body) + numberedListCount(body);
+  if (!tablePresent(body) && structuredLines < refs.size)
+    return fail(
+      "expected a verdict per referenced model (a markdown table or one list line per model)",
+    );
+  return pass();
+}
+
+function checkEpicRisks(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_RISKS_HEADING))
+    return fail('"## Risks & mitigations" heading not found');
+  const body = sectionBody(md, EPIC_RISKS_HEADING);
+  if (!tablePresent(body))
+    return fail(
+      '"## Risks & mitigations" requires a markdown table (Risk | Mitigation)',
+    );
+  const rows = tableDataRowCount(body);
+  if (rows < 2)
+    return fail(`"## Risks & mitigations" table needs ≥2 rows — found ${rows}`);
+  return pass();
+}
+
+function checkEpicEscapeOrReversibility(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_ESCAPE_OR_REVERSIBILITY_HEADING))
+    return fail('one of "## Escape hatch" or "## Reversibility" required');
+  const body = sectionBody(md, EPIC_ESCAPE_OR_REVERSIBILITY_HEADING);
+  if (wordCount(body) === 0)
+    return fail(
+      'Escape hatch / Reversibility section is empty (use "Reversibility: none — see Risks #N" for genuinely irreversible EPICs)',
+    );
+  return pass();
+}
+
+function checkEpicCost(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_COST_HEADING))
+    return fail('"## Cost projection" heading not found');
+  const body = sectionBody(md, EPIC_COST_HEADING);
+  if (tablePresent(body)) {
+    if (tableDataRowCount(body) < 2)
+      return fail(
+        '"## Cost projection" table needs ≥2 rows (at-launch + at-scale minimum)',
+      );
+    return pass();
+  }
+  const items = bulletListCount(body) + numberedListCount(body);
+  if (items < 2)
+    return fail(
+      '"## Cost projection" needs a table or ≥2 itemized lines (at-launch + at-scale minimum)',
+    );
+  return pass();
+}
+
+function checkEpicDependencies(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_DEPENDENCIES_HEADING))
+    return fail(
+      '"## Dependencies" heading not found (also accepts "## Dependencies on other tracked work")',
+    );
+  const body = sectionBody(md, EPIC_DEPENDENCIES_HEADING);
+  if (wordCount(body) === 0)
+    return fail('"## Dependencies" section is empty (list ≥1 item or write "None")');
+  return pass();
+}
+
+function checkEpicTracking(md: string): CheckResult {
+  if (!headingPresent(md, EPIC_TRACKING_HEADING))
+    return fail('"## Tracking checklist" heading not found');
+  const boxes = checkboxCount(sectionBody(md, EPIC_TRACKING_HEADING));
+  if (boxes < 1) return fail('"## Tracking checklist" needs ≥1 checkbox');
+  let phaseCount = 0;
+  if (headingPresent(md, EPIC_PHASES_HEADING))
+    phaseCount = splitPhases(sectionBody(md, EPIC_PHASES_HEADING)).length;
+  if (phaseCount >= 2 && boxes < phaseCount)
+    return fail(
+      `"## Tracking checklist" needs ≥1 checkbox per Phase — ${phaseCount} phases declared, ${boxes} checkbox(es) found`,
+    );
+  return pass();
+}
+
 // ─── section definitions per spec type ────────────────────────────────────
 
 interface SectionDef {
@@ -588,6 +763,23 @@ const BRAND_SECTIONS: SectionDef[] = [
   WORK_ESTIMATE_SECTION,
 ];
 
+// EPIC — 10 checks (v1.5.0). Tracking issues that coordinate multi-phase
+// strategic work. Distinct from FEAT: Phases (≥2, anti-bypass), cross-model
+// validation, an escape hatch / reversibility statement, and a per-phase
+// tracking checklist have no FEAT-rubric equivalent.
+const EPIC_SECTIONS: SectionDef[] = [
+  { key: "intent", label: "Intent", check: makeIntentCheck("epic") },
+  { key: "architectural_decision", label: "Architectural decision", check: checkEpicArchDecision },
+  { key: "phases", label: "Phases", check: checkEpicPhases },
+  { key: "cross_model_validation", label: "Cross-model validation", check: checkEpicCrossModel },
+  { key: "risks_mitigations", label: "Risks & mitigations", check: checkEpicRisks },
+  { key: "escape_hatch", label: "Escape hatch / Reversibility", check: checkEpicEscapeOrReversibility },
+  { key: "cost_projection", label: "Cost projection", check: checkEpicCost },
+  { key: "dependencies", label: "Dependencies", check: checkEpicDependencies },
+  { key: "tracking_checklist", label: "Tracking checklist", check: checkEpicTracking },
+  { key: "legal_triggers", label: "Legal triggers", check: checkLegalTriggers },
+];
+
 export const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {
   feat: FEAT_SECTIONS,
   bug: BUG_SECTIONS,
@@ -598,10 +790,16 @@ export const SECTIONS_BY_TYPE: Record<SpecType, SectionDef[]> = {
   research: RESEARCH_SECTIONS,
   ux: UX_SECTIONS,
   brand: BRAND_SECTIONS,
+  epic: EPIC_SECTIONS,
 };
 
 // Ordered canonical section keys per type. Exported for the drift-detection
 // test so it can compare against ZAI_SYSTEM_INSTRUCTIONS.md §Appendix.
+// NOTE (v1.5.0): `epic` is intentionally NOT yet in the §Appendix table —
+// the ZAI_SYSTEM_INSTRUCTIONS.md update is a deferred downstream FEAT. The
+// drift test iterates appendix→code (documented types must have impls), so
+// adding `epic` to the code without the doc entry does not break it; the
+// reverse direction (code→doc) is unchecked by design until that FEAT lands.
 export const RUBRIC_SECTION_KEYS: Record<SpecType, string[]> = {
   feat: FEAT_SECTIONS.map((s) => s.key),
   bug: BUG_SECTIONS.map((s) => s.key),
@@ -612,6 +810,7 @@ export const RUBRIC_SECTION_KEYS: Record<SpecType, string[]> = {
   research: RESEARCH_SECTIONS.map((s) => s.key),
   ux: UX_SECTIONS.map((s) => s.key),
   brand: BRAND_SECTIONS.map((s) => s.key),
+  epic: EPIC_SECTIONS.map((s) => s.key),
 };
 
 // ─── type detection ───────────────────────────────────────────────────────
@@ -626,6 +825,7 @@ export const KNOWN_TYPES: readonly SpecType[] = [
   "research",
   "ux",
   "brand",
+  "epic",
 ];
 
 export function detectSpecType(filename: string): SpecType {


### PR DESCRIPTION
## Summary

**PR 1 of 2** for FEAT [zi007lin/zzv-skills#27](https://github.com/zi007lin/zzv-skills/issues/27) — the two-PR upstream-first sequence to add EPIC as a first-class spec type.

This PR lands the rubric change in the **source-of-truth engine** (`zi007lin/zai/src/lib/scoreSpec.ts`). PR #2 in `zi007lin/zzv-skills` re-ports `zai-rubric.ts` from this commit's SHA + adds the `draft_epic` MCP tool + wires dispatch through `score_spec`/`score_and_file`. **PR #2 cannot start until this PR merges and deploys** (the verbatim-port discipline from BUG #93 requires a stable upstream commit to port from).

Per the spec's D9 / abuse-vector-#4 mitigation: PR #2 must open within 24h of this merge, or an emergency CHORE rolls back the `RUBRIC_VERSION` bump (the `scoreEpic` function can stay dormant at 1.4.0 since no consumer calls it yet — the zai SPA UI doesn't expose "epic" as a selectable type, and zzv-skills hasn't re-ported).

## Changes — `src/lib/scoreSpec.ts`

- `SpecType` union, `KNOWN_TYPES`, `SECTIONS_BY_TYPE`, `RUBRIC_SECTION_KEYS`, `INTENT_CAPS` all gain `epic` (Intent cap 200, matching RESEARCH's strategic-framing allowance)
- `RUBRIC_VERSION`: `"1.4.0"` → `"1.5.0"` — additive; no existing spec type's checks change
- `scoreEpic` via 10 EPIC-specific checks:

| # | Check | Rule |
|---|---|---|
| 1 | `## Intent` | ≤200 words |
| 2 | `## Architectural decision` | markdown table ≥2 option rows |
| 3 | `## Phases` | ≥2 `### Phase` H3s; each phase needs a type label (feat\|bug\|spec\|chore\|refactor\|ux\|brand), a status line, a Depends-on/Blocks line, and acceptance criteria — **this is the anti-bypass check** |
| 4 | `## Cross-model validation` | ≥3 distinct `#1`–`#16` model refs + a verdict per model (table or one list line each) |
| 5 | `## Risks & mitigations` | markdown table ≥2 rows |
| 6 | `## Escape hatch` OR `## Reversibility` | one present, non-empty; `Reversibility: none — see Risks #N` is the explicit-none path |
| 7 | `## Cost projection` | table ≥2 rows OR ≥2 itemized lines |
| 8 | `## Dependencies` | also accepts "Dependencies on other tracked work"; non-empty, "None" allowed |
| 9 | `## Tracking checklist` | ≥1 checkbox per declared Phase |
| 10 | `## Legal triggers` | reuses the shared `checkLegalTriggers` |

## Changes — `src/lib/scoreSpec.test.ts`

+21 tests: full 10/10 EPIC fixture, section-order pin, **anti-bypass** (1-phase fail), **explicit-none reversibility** (`Reversibility: none — see Risks #N` passes #6), `## Escape hatch` alias, empty-reversibility fail, missing/under-3 cross-model fail, per-phase missing-field fails (type / status / depends-blocks / acceptance), tracking-vs-phase-count fail, arch-table fail, risks-table fail, cost-<2-lines fail, cost-as-table pass, `## Dependencies on other tracked work` alias pass, intent-over-200 fail, surface checks (`KNOWN_TYPES` / `RUBRIC_SECTION_KEYS` / `INTENT_CAPS`), `detectSpecType` prefix.

The one pre-existing assertion referencing the version string (`it("rubric version is 1.4.0")`) is updated to `1.5.0` — part of the change surface, not unanticipated drift.

## Regression (gate-blocking per the spec)

All existing FEAT/BUG/SPEC/CHORE/REFACTOR/UX/BRAND fixture tests pass under v1.5.0. The appendix-driven drift-detection tests pass — they iterate appendix→code (documented types must have impls), so adding `epic` to the code without a `docs/ZAI_SYSTEM_INSTRUCTIONS.md` §Appendix entry doesn't break them; the reverse direction (code→doc) is unchecked by design until the deferred doc FEAT lands.

```
Test Files  3 passed (3)
     Tests  148 passed (148)         (was 127; +21)
lint        tsc --noEmit clean
build       tsc -b && vite build clean
```

## Explicitly deferred (NOT in this PR)

- `docs/ZAI_SYSTEM_INSTRUCTIONS.md` §Appendix update for the `epic` type — separate downstream FEAT
- zai SPA UI accepting "epic" as a selectable `spec_type` — same separate downstream FEAT

`renderScoredSpec.ts` needs no change: it interpolates `spec_type` into the score block without a per-type switch; `epic` renders identically to every other type.

## Test plan

- [ ] daniel-silvers approves
- [ ] Merge + deploy to `zai.htu.io/app` (Cloudflare Pages)
- [ ] Verify `RUBRIC_VERSION` reads `"1.5.0"` in zai's `score_spec` output post-deploy
- [ ] **Within 24h of merge:** open PR #2 in `zi007lin/zzv-skills` (re-port `zai-rubric.ts` from this commit's SHA + `draft_epic` + MCP wiring) — OR file the rollback CHORE