### PR TITLE
chore: port implw.yml from htu-foundation — per-step GH_TOKEN scoping (#108)

### DIFF
--- a/.github/workflows/implw.yml
+++ b/.github/workflows/implw.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Fetch issue body
         id: fetch_issue
         env:
-          GH_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Same-repo `gh issue view` — GITHUB_TOKEN is auto-issued per run and
+          # always valid. Scoping per REFACTOR htu-foundation#192 eliminates the
+          # stale-ZZV_DISPATCH_TOKEN silent-failure class for same-repo reads.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           SPEC_PATH="$(mktemp -t implw-spec-${{ inputs.issue_number }}-XXXX.md)"
@@ -58,13 +61,13 @@ jobs:
       - name: Run implw via claude (subscription mode)
         id: claude_run
         timeout-minutes: 12
-        env:
-          # zi007lin PAT fallback: the implw command runs `gh pr create`, and a PR
-          # opened with the default GITHUB_TOKEN does not trigger downstream
-          # workflow_dispatch (GitHub anti-recursion). ZZV_DISPATCH_TOKEN is the
-          # canonical cross-repo dispatch PAT; falls back to GITHUB_TOKEN where the
-          # secret is not yet provisioned. See CHORE htu-foundation#175.
-          GH_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+        # No GH_TOKEN env: claude inherits the self-hosted runner's persistent
+        # `gh auth` (operator PAT), which is what enables `gh pr create` to
+        # trigger downstream workflow_dispatch (GitHub anti-recursion bypasses
+        # the run-scoped GITHUB_TOKEN, not a user PAT). Scoping per REFACTOR
+        # htu-foundation#192 — handing claude a workflow-scoped GH_TOKEN was
+        # redundant with gh-CLI inheritance and exposed the stale-token failure
+        # class. See CHORE htu-foundation#175 for original PR-dispatch rationale.
         run: |
           set -euo pipefail
           # Enforce subscription auth: Claude Code precedence is
@@ -87,12 +90,13 @@ jobs:
           # loud if `claude` is still unresolvable. See CHORE htu-foundation#186.
           export PATH="$HOME/.npm-global/bin:$PATH"
           command -v claude >/dev/null || { echo "::error::claude not found on PATH"; exit 127; }
+          # --dangerously-skip-permissions is required in CI: headless `claude -p`
+          # does not honor repo-committed `defaultMode: bypassPermissions` (a repo
+          # cannot self-grant bypass), so without the flag the agent falls back to
+          # ask-mode, blocks on the first gated tool, and times out against
+          # `< /dev/null`. See BUG htu-foundation#189; verified remedy in
+          # streettt.com#970.
           set +e
-          # --dangerously-skip-permissions is required for headless `claude -p` in CI:
-          # project-committed `defaultMode: bypassPermissions` is not honored for
-          # `claude -p` (a repo cannot self-grant bypass), so without the flag the
-          # agent runs in ask-mode, blocks on the first gated tool, and times out
-          # (stdin is /dev/null). Spec: issues/2026-05-27__bug__ci-implw-skip-permissions-flag.scored.md.
           timeout 10m claude --dangerously-skip-permissions -p "/implw ${{ steps.fetch_issue.outputs.spec_path }}" < /dev/null
           CLAUDE_EXIT=$?
           set -e
@@ -106,7 +110,10 @@ jobs:
       - name: Comment failure on issue
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.ZZV_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Same-repo `gh issue comment` — GITHUB_TOKEN is auto-issued and
+          # always valid. Scoping per REFACTOR htu-foundation#192 keeps the
+          # failure-reporting path from itself failing on a stale PAT.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_EXIT: ${{ steps.claude_run.outputs.claude_exit }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

Ports `.github/workflows/implw.yml` to the canonical htu-foundation template (post-REFACTOR htu-foundation#192, PR #193, merge `92508a9`, merged 2026-05-27). The ported file is **byte-identical** to `htu-foundation/main`.

Per-step `GH_TOKEN` scoping replaces the `ZZV_DISPATCH_TOKEN || GITHUB_TOKEN` fallback:

- **Fetch issue body** step -> `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (same-repo read)
- **Run implw via claude** step -> **no `GH_TOKEN` env** (inherits the self-hosted runner's persistent `gh auth` operator PAT, which is what lets `gh pr create` trigger downstream `workflow_dispatch`)
- **Comment failure on issue** step -> `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (same-repo write)

Eliminates the stale-PAT silent-401 class for same-repo implw operations. `--dangerously-skip-permissions` is preserved — it is already part of the canonical template (BUG htu-foundation#189).

Diff: `1 file changed, 21 insertions(+), 14 deletions(-)` — only `.github/workflows/implw.yml`.

### Divergence note (reviewer disposition)

The skip-permissions comment block now references **BUG htu-foundation#189 / streettt.com#970** instead of the prior local spec path (`issues/2026-05-27__bug__ci-implw-skip-permissions-flag.scored.md`), and `set +e` moved to immediately precede the `timeout … claude` call. Both are comment-only / ordering-only, taken straight from canonical; no behavioral change to the flag itself.

## IMPORTANT — ZZV_DISPATCH_TOKEN: RETAIN, do not delete (spec assumption #3 falsified)

The spec's Action #4 / AC #4 anticipated flagging `ZZV_DISPATCH_TOKEN` for issuer-side deletion *if no other workflow references it*. The implementation-time audit found that **assumption is false for this repo**:

- `gh secret list --repo zi007lin/zai` -> `ZZV_DISPATCH_TOKEN` **exists** (created 2026-04-16).
- `.github/workflows/zilin-queue.yml` **still references it in 3 places**:
  - L51 — "Resolve target repo and mode"
  - L229 — "Dispatch to target repo (dispatch mode)": runs `gh api repos/$TARGET/dispatches`, a **cross-repo** dispatch that the run-scoped `GITHUB_TOKEN` **cannot** perform (requires a PAT)
  - L266 — "Legacy in-place execute (legacy mode)"

The htu-foundation#192 audit found "zero cross-repo dispatch" **in htu-foundation** — but ZAI's `zilin-queue.yml` is precisely a cross-repo dispatch router that needs the PAT. **Deleting the secret would break zilin-queue.yml's dispatch mode.**

**Recommendation: retain `ZZV_DISPATCH_TOKEN`.** Do **not** run `gh secret delete`. Per protocol Rule 6 the agent surfaces and does not execute secret operations; here the audit affirmatively recommends *against* deletion. Decoupling implw/zilin-queue from the dispatch PAT (if desired) is a separate spec.

## Acceptance criteria

- [x] implw.yml matches the canonical htu-foundation template (byte-identical)
- [x] No `secrets.ZZV_DISPATCH_TOKEN` reference remains in implw.yml
- [x] Same-repo gh ops use `secrets.GITHUB_TOKEN` directly, no `||` fallback
- [ ] ZZV_DISPATCH_TOKEN exists -> flagged, but **recommended for RETENTION, not deletion** (zilin-queue.yml dependency; see above)
- [ ] Action-dispatched implw completes exit 0 post-merge (post-merge verification, not part of this PR)

## CI note

CI-config-only change. Repo `lint`/`build`/`test` (`tsc`, `vitest`) cover the TypeScript/Vite app and neither exercise nor are affected by workflow YAML. The file was validated as well-formed YAML and is byte-identical to the live canonical template.

## ZAI Spec Score

- **Rubric version:** 1.5.0
- **Spec type:** chore
- **Score:** 6/6
- **Passed:** YES

| Section | Status |
|---|---|
| intent | PASS |
| action | PASS |
| acceptance_criteria | PASS |
| files | PASS |
| legal_triggers | PASS |
| work_estimate | PASS |

Integrity re-score at impl time: **6/6 PASS** (rubric 1.5.0) — matches the stored block.

Closes #108
