### PR TITLE
FIX: quote implw run-name — YAML comment truncation (zzv-skills#102 follow-up)

### DIFF
--- a/.github/workflows/implw.yml
+++ b/.github/workflows/implw.yml
@@ -4,7 +4,7 @@ name: implw — autonomous spec implementation
 # run-name so the tool can match the dispatched run back to its caller.
 # Declaring the input is required: GitHub returns HTTP 422 on a
 # workflow_dispatch carrying an undeclared input (BUG htu-foundation#180).
-run-name: implw #${{ inputs.issue_number }} by @${{ github.actor }} [${{ inputs.dispatch_id }}]
+run-name: "implw #${{ inputs.issue_number }} by @${{ github.actor }} [${{ inputs.dispatch_id }}]"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Unquoted run-name truncated at '#' (YAML treats ' #' as comment start), so displayTitle rendered as bare 'implw'. Quoting restores 'implw #<issue> by @<actor> [<dispatch_id>]'.